### PR TITLE
Typo in the documentation

### DIFF
--- a/docs/guide/examplegen.md
+++ b/docs/guide/examplegen.md
@@ -23,9 +23,9 @@ queries) the ExampleGen pipeline component is typically very easy to deploy and
 requires little customization. Typical code looks like this:
 
 ```python
-from tfx.utils.dsl_utils import csv_inputs
+from tfx.utils.dsl_utils import csv_input
 from tfx.components import ExamplesGen
 
-examples = csv_inputs(os.path.join(base_dir, 'no_split/span_1'))
+examples = csv_input(os.path.join(base_dir, 'no_split/span_1'))
 examples_gen = ExamplesGen(input_data=examples)
 ```


### PR DESCRIPTION
I think there is a typo here as `csv_input` exists in `dsl_utils` but not `csv_inputs`.