### PR TITLE
update LOCAL_MODEL_DIR location for chicago_taxi_pipeline example

### DIFF
--- a/examples/chicago_taxi_pipeline/README.md
+++ b/examples/chicago_taxi_pipeline/README.md
@@ -191,7 +191,7 @@ Once the pipeline completes, the model will be copied by the [Pusher](https://gi
 to the directory configured in the example code:
 
 <pre class="devsite-terminal devsite-click-to-copy">
-ls $TAXI_DIR/pipelines/serving_model/taxi_simple
+ls $TAXI_DIR/serving_model/taxi_simple
 </pre>
 
 
@@ -201,7 +201,7 @@ please follow the instructions [here](https://github.com/tensorflow/tfx/blob/mas
 In start_model_server_local.sh, change:
 
 <pre class="devsite-terminal devsite-click-to-copy">
-LOCAL_MODEL_DIR=$(pwd)/taxi/serving_model/taxi_simple
+LOCAL_MODEL_DIR=$TAXI_DIR/serving_model/taxi_simple
 </pre>
 
 This will pick up the latest model under above path.


### PR DESCRIPTION
Here is the PR for #9 

The code currently has the Pusher save the model at `$TAXI_DIR/serving_model/taxi_simple`, so this PR updates the saved model path documentation in the `chicago_taxi_pipeline/README.md`. 

It also adds a `chicago_taxi_pipeline/start_model_server_local.sh` file that can be called to serve the model instead of changing the `LOCAL_MODEL_DIR` value in `chicago_taxi/start_model_server_local.sh`.
