### PR TITLE
Fix for KeyError when calling 'base_component.BaseComponent.__str__ method

### DIFF
--- a/tfx/components/base/base_component.py
+++ b/tfx/components/base/base_component.py
@@ -72,7 +72,7 @@ class BaseComponent(with_metaclass(abc.ABCMeta, object)):
 
   def __str__(self):
     return """
-{
+{{
   component_name: {component_name},
   unique_name: {unique_name},
   driver: {driver},
@@ -80,7 +80,7 @@ class BaseComponent(with_metaclass(abc.ABCMeta, object)):
   input_dict: {input_dict},
   outputs: {outputs},
   exec_properties: {exec_properties}
-}
+}}
     """.format(  # pylint: disable=missing-format-argument-key
         component_name=self.component_name,
         unique_name=self.unique_name,


### PR DESCRIPTION
Fixes #23 

I thought it'd be better to do a quick PR for this small fix.

I wanted to write a unit test, but couldn't run the tests by calling down to python file name. I opened #24 to ask how to run the tests.

Happy to write a unit test for this. I just didn't have time this morning to figure out the test suite.