### PR TITLE
Replace tf.sparse_to_dense with tf.SparseTensor and tf.sparse.to_dense

### DIFF
--- a/docs/tutorials/transform/census.ipynb
+++ b/docs/tutorials/transform/census.ipynb
@@ -396,9 +396,10 @@
         "  for key in OPTIONAL_NUMERIC_FEATURE_KEYS:\n",
         "    # This is a SparseTensor because it is optional. Here we fill in a default\n",
         "    # value when it is missing.\n",
-        "    dense = tf.sparse_to_dense(outputs[key].indices,\n",
-        "                               [outputs[key].dense_shape[0], 1],\n",
-        "                               outputs[key].values, default_value=0.)\n",
+        "    dense = tf.sparse.to_dense(tf.SparseTensor(outputs[key].indices,\n",
+        "                                               outputs[key].values,\n"
+        "                                               [outputs[key].dense_shape[0], 1]),\n",
+        "                               default_value=0.)\n",
         "    # Reshaping from a batch of vectors of size 1 to a batch to scalars.\n",
         "    dense = tf.squeeze(dense, axis=1)\n",
         "    outputs[key] = tft.scale_to_0_1(dense)\n",

--- a/tfx/components/testdata/module_file/transform_module.py
+++ b/tfx/components/testdata/module_file/transform_module.py
@@ -75,8 +75,9 @@ def _fill_in_missing(x):
   """
   default_value = '' if x.dtype == tf.string else 0
   return tf.squeeze(
-      tf.sparse_to_dense(x.indices, [x.dense_shape[0], 1], x.values,
-                         default_value),
+      tf.sparse.to_dense(
+        tf.SparseTensor(x.indices, x.values, [x.dense_shape[0], 1]), 
+        default_value),
       axis=1)
 
 

--- a/tfx/examples/chicago_taxi/preprocess.py
+++ b/tfx/examples/chicago_taxi/preprocess.py
@@ -45,8 +45,9 @@ def _fill_in_missing(x):
   """
   default_value = '' if x.dtype == tf.string else 0
   return tf.squeeze(
-      tf.sparse_to_dense(x.indices, [x.dense_shape[0], 1], x.values,
-                         default_value),
+    tf.sparse.to_dense(
+      tf.SparseTensor(x.indices, x.values, [x.dense_shape[0], 1]), 
+        default_value),
       axis=1)
 
 

--- a/tfx/examples/chicago_taxi_pipeline/taxi_utils.py
+++ b/tfx/examples/chicago_taxi_pipeline/taxi_utils.py
@@ -103,8 +103,9 @@ def _fill_in_missing(x):
   """
   default_value = '' if x.dtype == tf.string else 0
   return tf.squeeze(
-      tf.sparse_to_dense(x.indices, [x.dense_shape[0], 1], x.values,
-                         default_value),
+      tf.sparse.to_dense(
+        tf.SparseTensor(x.indices, x.values, [x.dense_shape[0], 1]), 
+        default_value),
       axis=1)
 
 


### PR DESCRIPTION
The function [`tf.sparse_to_dense`](https://www.tensorflow.org/api_docs/python/tf/sparse_to_dense?hl=en) is deprecated and instead `tf.sparse.to_dense(tf.SparseTensor(...))` is recommended. This PR fixes all references to this deprecated function. 