### PR TITLE
Fix references to examples after moving these to tfx/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please see the
 
 ## Examples
 
-*   [Chicago Taxi Example](https://github.com/tensorflow/tfx/tree/master/examples/chicago_taxi_pipeline)
+*   [Chicago Taxi Example](https://github.com/tensorflow/tfx/tree/master/tfx/examples/chicago_taxi_pipeline)
 
 ## Compatible versions
 

--- a/docs/tutorials/_toc.yaml
+++ b/docs/tutorials/_toc.yaml
@@ -2,7 +2,7 @@ toc:
 - title: "Get started with TFX"
   path: /tfx/tutorials/
 - title: "End-to-end pipeline example"
-  path: https://github.com/tensorflow/tfx/tree/master/examples/chicago_taxi_pipeline
+  path: https://github.com/tensorflow/tfx/tree/master/tfx/examples/chicago_taxi_pipeline
   status: external
 
 - heading: "Data Validation"
@@ -17,10 +17,10 @@ toc:
 
 - heading: "Model Analysis"
 - title: "Chicago Taxi"
-  path: https://github.com/tensorflow/tfx/blob/master/examples/chicago_taxi/chicago_taxi_tfma.ipynb
+  path: https://github.com/tensorflow/tfx/blob/master/tfx/examples/chicago_taxi/chicago_taxi_tfma.ipynb
   status: external
 - title: "Chicago Taxi local playground"
-  path: https://github.com/tensorflow/tfx/blob/master/examples/chicago_taxi/chicago_taxi_tfma_local_playground.ipynb
+  path: https://github.com/tensorflow/tfx/blob/master/tfx/examples/chicago_taxi/chicago_taxi_tfma_local_playground.ipynb
   status: external
 
 - heading: "Serving"

--- a/tfx/examples/chicago_taxi/README.md
+++ b/tfx/examples/chicago_taxi/README.md
@@ -1,7 +1,7 @@
 # Chicago Taxi Example
 
 
-Note: an updated end-to-end pipeline version of this example is available [here](https://github.com/tensorflow/tfx/tree/master/examples/chicago_taxi_pipeline).
+Note: an updated end-to-end pipeline version of this example is available [here](https://github.com/tensorflow/tfx/tree/master/tfx/examples/chicago_taxi_pipeline).
 
 The Chicago Taxi example demonstrates the end-to-end workflow and steps of how
 to analyze, validate and transform data, train a model, analyze and serve it. It


### PR DESCRIPTION
After the recent [change](https://github.com/tensorflow/tfx/commit/7f5df9f2cfb2a41a41dc2f9bc0058f23b82794e4) in the path of the examples, several references needed to be updated.