### PR TITLE
Lock in version of `kfp`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def _make_required_test_packages():
   return [
       'apache-airflow>=1.10,<2',
       'docker>=3.7,<4',
-      'kfp>=0.1,<1',
+      'kfp>=0.1,<=0.1.11',
       'tensorflow>=1.13,<2',
   ]
 


### PR DESCRIPTION
My team and I hit a snag this week when trying to compile Kubeflow Pipelines:

```
File "/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_kubeflow.py", line 187, in <module>
    pipeline = KubeflowRunner().run(_create_pipeline())

File "/tfx/orchestration/kubeflow/runner.py", line 122, in run
    _construct_pipeline)

TypeError: add_pipeline() takes 2 positional arguments but 3 were given
```

Thanks to commit [`eb63dae`](https://github.com/tensorflow/tfx/commit/eb63daed199afee8a88fca44c2e8e0f738adf44b) this week which added a test for this, we were able to debug easier.

It turns out the issue was that we had version `0.1.14` of the Kubeflow Pipelines SDK installed. The [docs](https://www.kubeflow.org/docs/pipelines/sdk/install-sdk/) recommended this, and the docs and the [Release Page](https://github.com/kubeflow/pipelines/releases) do not install from PyPi. 

This feels like it was intentional, but only version published to PyPi is `0.1.11`, the last compatible version with tfx. I've tried `0.1.12` all the way to the most recent `0.1.15` and continue to get the same error as above. 

Additionally, the check submitted by this PR doesn't even catch this. 

When running `pip show kfp` from the non-PyPi install, I get:
```
Name: kfp
Version: 0.1
Summary: KubeFlow Pipelines SDK
Home-page: UNKNOWN
Author: google
Author-email: None
License: UNKNOWN
Location: /usr/local/lib/python3.7/site-packages
Requires: PyYAML, kubernetes, requests-toolbelt, certifi, google-cloud-storage, google-auth, cryptography, python-dateutil, six, PyJWT, urllib3
Required-by:
```

And when running after installing from `setup.py`:
```
Name: kfp
Version: 0.1.11
Summary: KubeFlow Pipelines SDK
Home-page: UNKNOWN
Author: google
Author-email: None
License: UNKNOWN
Location:  /usr/local/lib/python3.7/site-packages
Requires: PyJWT, google-cloud-storage, PyYAML, certifi, six, python-dateutil, kubernetes, requests-toolbelt, cryptography, urllib3, google-auth
```

I'm not sure if I should follow an issue in [Kubeflow/pipelines](https://github.com/kubeflow/pipelines) and ask if they can tag with the patch, or if these will never be published to PyPi and this is a non-issue. 

I'm unsure what the proper fix should be, but wanted to submit to start the conversation and document for anyone else who may run into this. 


