### PR TITLE
Update .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pb2.py files
+*_pb2.py


### PR DESCRIPTION
Adds `_pb2.py` files to `.gitignore`

I believe this closes #33 