### PR TITLE
Orchestration/Kubeflow - Removed the use of undocumented KFP compiler API

### DIFF
--- a/tfx/orchestration/kubeflow/runner.py
+++ b/tfx/orchestration/kubeflow/runner.py
@@ -95,8 +95,8 @@ class KubeflowRunner(tfx_runner.TfxRunner):
     """
 
     @dsl.pipeline(
-      pipeline.pipeline_args['pipeline_name'],
-      pipeline.pipeline_args.get('description', '')
+      name=pipeline.pipeline_args['pipeline_name'],
+      description=pipeline.pipeline_args.get('description', '')
     )
     def _construct_pipeline():
       """Constructs a Kubeflow pipeline.

--- a/tfx/orchestration/kubeflow/runner.py
+++ b/tfx/orchestration/kubeflow/runner.py
@@ -94,6 +94,10 @@ class KubeflowRunner(tfx_runner.TfxRunner):
         pipeline.
     """
 
+    @dsl.pipeline(
+      pipeline.pipeline_args['pipeline_name'],
+      pipeline.pipeline_args.get('description', '')
+    )
     def _construct_pipeline():
       """Constructs a Kubeflow pipeline.
 
@@ -115,11 +119,6 @@ class KubeflowRunner(tfx_runner.TfxRunner):
       )
 
       self._construct_pipeline_graph(pipeline)
-
-    pipeline_name = pipeline.pipeline_args['pipeline_name']
-    dsl.Pipeline.add_pipeline(pipeline_name,
-                              pipeline.pipeline_args.get('description', ''),
-                              _construct_pipeline)
 
     pipeline_file = os.path.join(self._output_dir, pipeline_name + '.tar.gz')
     compiler.Compiler().compile(_construct_pipeline, pipeline_file)


### PR DESCRIPTION
See https://github.com/tensorflow/tfx/pull/30#issuecomment-482289948

The KFP documentation clearly says that the pipeline function must be decorated with `@pipeline` decorator. It's even mentioned in the `compile` function documentation: https://github.com/kubeflow/pipelines/blob/086d4763d9f163acdeb423bc2bc49ab470442a92/sdk/python/kfp/compiler/compiler.py#L636

Running `Compiler().compile(...)` without having the function decorated will raise error: https://github.com/kubeflow/pipelines/blob/086d4763d9f163acdeb423bc2bc49ab470442a92/sdk/python/kfp/compiler/compiler.py#L578 `'Please use a function with @dsl.pipeline decorator.'`.

For some reason this documented behavior was circumvented by a hack that used an undocumented function that should be a part of internal compiler API.

This has triggered the https://github.com/tensorflow/tfx/pull/30 issue when the internal compiler API was changed by the KFP team.

This PR fixes this issue.