### PR TITLE
Update command to install with test dependencies in CONTRIBUTING.md

### DIFF
--- a/tfx/CONTRIBUTING.md
+++ b/tfx/CONTRIBUTING.md
@@ -33,7 +33,7 @@ After installing 'test' extra dependency, you can invoke all python unit tests:
 
 ```
 # From root directory after git checkout
-pip install -e .[tfx]
+pip install -e .[test]
 python -m unittest discover -s tfx -p '*test.py'
 ```
 


### PR DESCRIPTION
Updates the command to install TFX with test dependencies from `pip install -e .[tfx]` to `pip install -e .[test]`, since "test" is what's defined for this purpose in `setup.py` 