### PR TITLE
Fix Chicago Taxi Example not working on Dataflow

### DIFF
--- a/tfx/examples/chicago_taxi/preprocess.py
+++ b/tfx/examples/chicago_taxi/preprocess.py
@@ -28,7 +28,7 @@ import tensorflow_transform.beam as tft_beam
 from tensorflow_transform.coders import example_proto_coder
 from tensorflow_transform.tf_metadata import dataset_metadata
 from tensorflow_transform.tf_metadata import dataset_schema
-from tfx.examples.chicago_taxi.trainer import taxi
+from trainer import taxi
 
 
 def _fill_in_missing(x):

--- a/tfx/examples/chicago_taxi/process_tfma.py
+++ b/tfx/examples/chicago_taxi/process_tfma.py
@@ -24,7 +24,7 @@ import apache_beam as beam
 import tensorflow as tf
 
 import tensorflow_model_analysis as tfma
-from tfx.examples.chicago_taxi.trainer import taxi
+from trainer import taxi
 
 
 def process_tfma(eval_result_dir,

--- a/tfx/examples/chicago_taxi/tfdv_analyze_and_validate.py
+++ b/tfx/examples/chicago_taxi/tfdv_analyze_and_validate.py
@@ -24,7 +24,7 @@ import tensorflow as tf
 import tensorflow_data_validation as tfdv
 
 from tensorflow_data_validation.coders import csv_decoder
-from tfx.examples.chicago_taxi.trainer import taxi
+from trainer import taxi
 
 from google.protobuf import text_format
 from tensorflow.python.lib.io import file_io


### PR DESCRIPTION
I ran into an [issue](https://github.com/tensorflow/tfx/issues/47) when trying to run Chicago Taxi Example on Dataflow. From my investigation it seems that the code package uploaded to GS didn't reflect directory structure of the repository - importing from `tfx.examples.chicago_taxi.trainer` made no sense, since the `tar.gz` archive looks like this: 

```
├── PKG-INFO
├── README.md
├── setup.cfg
├── setup.py
├── tfx_chicago_taxi.egg-info
│   ├── PKG-INFO
│   ├── SOURCES.txt
│   ├── dependency_links.txt
│   ├── requires.txt
│   └── top_level.txt
└── trainer
    ├── __init__.py
    ├── model.py
    ├── task.py
    └── taxi.py
```

After changing the import to relative, my Dataflow jobs started working.
WDYT?