### PR TITLE
Fix requirements error with scikit-learn version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# latest version 0.21.0 of scikit-learn only supports python>=3.5
+scikit-learn==0.20.3
+
 --index-url https://pypi.python.org/simple/
 
 -e .


### PR DESCRIPTION
As the latest released version of scikit-learn, version 0.21.0, only supports python>=3.5, the previous version 0.20.3 has to be explicitly installed, so that tfx can be installed on python==2.7