### PR TITLE
Fix missing link of TensorFlow Metadata

### DIFF
--- a/docs/guide/evaluator.md
+++ b/docs/guide/evaluator.md
@@ -5,7 +5,7 @@ for your models, to help you understand how your model performs on subsets of
 your data. 
 
 * Consumes: EvalSavedModel from [Trainer](trainer.md)
-* Emits: Analysis results to [TensorFlow Metadata](tfmd.md)
+* Emits: Analysis results to [TensorFlow Metadata](https://github.com/tensorflow/metadata)
 
 ## Evaluator and TensorFlow Model Analysis
 

--- a/docs/guide/modelval.md
+++ b/docs/guide/modelval.md
@@ -13,7 +13,7 @@ to production.
 
 * Consumes: A schema from a SchemaGen component, and statistics from a
 StatisticsGen component.
-* Emits: Validation results to [TensorFlow Metadata](tfmd.md)
+* Emits: Validation results to [TensorFlow Metadata](https://github.com/tensorflow/metadata)
 
 ## Using the ModelValidator Component
 


### PR DESCRIPTION
Since `tfmd.md` file have been removed, hyper link of TensorFlow Metadata was broken. This fix adds new hyper link for TensorFlow Metadata to URL https://github.com/tensorflow/metadata .