### PR TITLE
Added Pipeline Property to mount a PV into all components

### DIFF
--- a/tfx/orchestration/kubeflow/base_component.py
+++ b/tfx/orchestration/kubeflow/base_component.py
@@ -55,7 +55,7 @@ class PipelineProperties(object):
                  tfx_image: Text = None,
                  pipeline_pv_mount=None):
         """pipeline_pv_mount must be a dict with the following keys: pvc_name, volume_name, volume_mount_path.
-        volume_name defaults to 'pipeline_shared_volume' and volume_mount_path to '/pipeline_shared_volume'.
+        volume_name defaults to 'pipeline-shared-volume' and volume_mount_path to '/pipeline_shared_volume'.
         It is encouraged to use a PV of type ReadWriteMany."""
 
         self.exec_properties = collections.OrderedDict([
@@ -67,7 +67,7 @@ class PipelineProperties(object):
         self.tfx_image = tfx_image or _KUBEFLOW_TFX_IMAGE
 
         # pipeline_pv_mount must be a dict with the following keys: pvc_name, volume_name, volume_mount_path.
-        # volume_name defaults to 'pipeline_shared_volume' and volume_mount_path to '/pipeline_shared_volume'.
+        # volume_name defaults to 'pipeline-shared-volume' and volume_mount_path to '/pipeline_shared_volume'.
         # It is encouraged to use a PV of type ReadWriteMany.
         self.pipeline_pv_mount = pipeline_pv_mount
 
@@ -144,7 +144,7 @@ class BaseComponent(object):
                 raise ValueError("pipeline_pv_mount must contain the key pvc_name containing the name of a valid PVC")
 
             if "volume_name" not in mount:
-                mount["volume_name"] = "pipeline_shared_volume"
+                mount["volume_name"] = "pipeline-shared-volume"
 
             if "volume_mount_path" not in mount:
                 mount["volume_mount_path"] = "/pipeline_shared_volume"

--- a/tfx/orchestration/kubeflow/runner.py
+++ b/tfx/orchestration/kubeflow/runner.py
@@ -59,7 +59,7 @@ class KubeflowRunner(tfx_runner.TfxRunner):
         tfx_image = None
 
         # pipeline_pv_mount must be a dict with the following keys: pvc_name, volume_name, volume_mount_path.
-        # volume_name defaults to 'pipeline_shared_volume' and volume_mount_path to '/pipeline_shared_volume'.
+        # volume_name defaults to 'pipeline-shared-volume' and volume_mount_path to '/pipeline_shared_volume'.
         # It is encouraged to use a PV of type ReadWriteMany.
         pipeline_pv_mount = None
         if 'additional_pipeline_args' in pipeline.pipeline_args:


### PR DESCRIPTION
# What
I have added a new pipeline property called _pipeline_pv_mount_ to allow mounting of a PV into all components of the Pipeline. 

pipeline_pv_mount must be a dict with the following keys: pvc_name, volume_name, volume_mount_path.
 volume_name defaults to 'pipeline-shared-volume' and volume_mount_path to '/pipeline_shared_volume'. 'pvc_name' will raise an ValueException if not provided. 

# Why
When running KubeFlow outside of GCP sharing data between components via buckets is not possible. Therefore one can now mount a PV to share data between the components. It is encouraged to use a PV of type ReadWriteMany.

# Additional Help
I am not familiar with the documentation and test process of TFX, so please advice me on additional changes.

# Example PV 
The following PV is an example which can be used to share data. Adapt the storageClassName to your plattform and needs.

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: pipeline-shared-data
  labels:
    app: kubeflow-pipelines
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 2Gi
  storageClassName: azurefile

```
