### PR TITLE
Fix required lib version constraint in slack custom component

### DIFF
--- a/tfx/examples/custom_components/slack/setup.py
+++ b/tfx/examples/custom_components/slack/setup.py
@@ -24,8 +24,8 @@ def _make_required_install_packages():
   # six, and protobuf) with TF.
   return [
       'slackclient>=2.0.0,<2.0.1',
-      'tfx>=0.14.0,<0.15.0',
-      'websocket-client>=0.56,<0.6',
+      'tfx==0.14.0dev',
+      'websocket-client>=0.56.0,<0.60.0',
   ]
 
 


### PR DESCRIPTION
I followed [README.md](https://github.com/tensorflow/tfx/blob/master/tfx/examples/custom_components/slack/README.md#step-2-install-custom-slackcomponent) to install slack custom component, but the version constraint for required libs are not correct:
- tfx 0.14.0 has not been released yet (`>0.13.2` allow people to install `0.14.0-dev` locally)
- for websocket, upper bound should be `0.60`