### PR TITLE
Pass exec_properties to BaseDriver's _prepare_output_artifacts

### DIFF
--- a/tfx/components/base/base_driver.py
+++ b/tfx/components/base/base_driver.py
@@ -165,13 +165,13 @@ class BaseDriver(object):
     """
     return exec_properties
 
-  def _prepare_output_artifacts(
+  def prepare_output_artifacts(
       self,
       output_dict: Dict[Text, types.Channel],
       execution_id: int,
       pipeline_info: data_types.PipelineInfo,
       component_info: data_types.ComponentInfo,
-      exec_properties: Dict[Text, Any],
+      exec_properties: Dict[Text, Any],  # pylint: disable=unused-argument
   ) -> Dict[Text, List[types.Artifact]]:
     """Prepare output artifacts by assigning uris to each artifact.
 
@@ -275,7 +275,7 @@ class BaseDriver(object):
                       exec_properties)
 
       # Step 4a. New execution is needed. Prepare output artifacts.
-      output_artifacts = self._prepare_output_artifacts(
+      output_artifacts = self.prepare_output_artifacts(
           output_dict=output_dict,
           execution_id=execution_id,
           pipeline_info=pipeline_info,


### PR DESCRIPTION
It's currently very difficult to override the `_prepare_output_artifacts` function in the `BaseDriver`.
This function currently receive only basic pipeline and component information as well as the `output_dict`. 
That means you cannot have external parameters in your custom logic.

This PR passes the `exec_properties` dictionary as a parameter, in a similar way to what is done in `resolve_input_artifacts`.
It also rename `_prepare_output_artifacts`  to `prepare_output_artifacts` to make it "public" according to Python standard