### PR TITLE
Enable equality comparison for Parameter types

### DIFF
--- a/tfx/orchestration/data_types.py
+++ b/tfx/orchestration/data_types.py
@@ -135,3 +135,9 @@ class RuntimeParameter(json_utils.Jsonable):
     return ('RuntimeParam:\n  name: %s,\n  default: %s,\n  ptype: %s,\n  '
             'description: %s') % (self.name, self.default, self.ptype,
                                   self.description)
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) \
+      and self.name == other.name \
+      and self.ptype == other.ptype \
+      and self.description == other.description

--- a/tfx/types/component_spec.py
+++ b/tfx/types/component_spec.py
@@ -231,6 +231,11 @@ class ExecutionParameter(_ComponentParameter):
     return 'ExecutionParameter(type: %s, optional: %s)' % (self.type,
                                                            self.optional)
 
+  def __eq__(self, other):
+    return isinstance(other, self.__class__)\
+      and other.type == self.type\
+      and other.optional == self.optional
+
   def type_check(self, arg_name: Text, value: Any):
     # Can't type check generics. Note that we need to do this strange check form
     # since typing.GenericMeta is not exposed.
@@ -280,6 +285,11 @@ class ChannelParameter(_ComponentParameter):
 
   def __repr__(self):
     return 'ChannelParameter(type_name: %s)' % (self.type_name,)
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__)\
+      and other.type_name == self.type_name\
+      and other.optional == self.optional
 
   def type_check(self, arg_name: Text, value: Channel):
     if not isinstance(value, Channel) or value.type_name != self.type_name:

--- a/tfx/types/component_spec.py
+++ b/tfx/types/component_spec.py
@@ -87,6 +87,12 @@ class ComponentSpec(with_metaclass(abc.ABCMeta, json_utils.Jsonable)):
     self._verify_parameter_types()
     self._parse_parameters()
 
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) \
+      and self.PARAMETERS == other.PARAMETERS \
+      and self.INPUTS == other.INPUTS \
+      and self.OUTPUTS == other.OUTPUTS
+
   def _validate_spec(self):
     """Check the parameters and types passed to this ComponentSpec."""
     for param_name, param in [('PARAMETERS', self.PARAMETERS),
@@ -232,8 +238,8 @@ class ExecutionParameter(_ComponentParameter):
                                                            self.optional)
 
   def __eq__(self, other):
-    return isinstance(other, self.__class__)\
-      and other.type == self.type\
+    return isinstance(other, self.__class__) \
+      and other.type == self.type \
       and other.optional == self.optional
 
   def type_check(self, arg_name: Text, value: Any):
@@ -287,8 +293,8 @@ class ChannelParameter(_ComponentParameter):
     return 'ChannelParameter(type_name: %s)' % (self.type_name,)
 
   def __eq__(self, other):
-    return isinstance(other, self.__class__)\
-      and other.type_name == self.type_name\
+    return isinstance(other, self.__class__) \
+      and other.type_name == self.type_name \
       and other.optional == self.optional
 
   def type_check(self, arg_name: Text, value: Channel):


### PR DESCRIPTION
This PR lays the groundwork for Spec-to-Spec equality comparisons, which is useful for asserting behavior of Spec-generation logic.

Maintainers: Let me know if you'd like to bundle in `ComponentSpec.__eq__` as well.