### PR TITLE
custom_executor_spec instead of executor_class

### DIFF
--- a/docs/guide/examplegen.md
+++ b/docs/guide/examplegen.md
@@ -119,7 +119,7 @@ from tfx.utils.dsl_utils import external_input
 
 examples = external_input(os.path.join(base_dir, 'data/simple'))
 example_gen = FileBasedExampleGen(input_base=examples,
-                                  executor_class=executor.Executor)
+                                  custom_executor_spec=executor_spec.ExecutorClassSpec(executor.Executor)
 ```
 
 Now, we also support reading Avro and Parquet files using this

--- a/docs/guide/examplegen.md
+++ b/docs/guide/examplegen.md
@@ -120,7 +120,7 @@ from tfx.utils.dsl_utils import external_input
 
 examples = external_input(os.path.join(base_dir, 'data/simple'))
 example_gen = FileBasedExampleGen(input_base=examples,
-                                  custom_executor_spec=executor_spec.ExecutorClassSpec(executor.Executor)
+                                  custom_executor_spec=executor_spec.ExecutorClassSpec(executor.Executor))
 ```
 
 Now, we also support reading Avro and Parquet files using this

--- a/docs/guide/examplegen.md
+++ b/docs/guide/examplegen.md
@@ -113,6 +113,7 @@ Alternatively, pass a custom executor into the standard
 ExampleGen component as shown below.
 
 ```python
+from tfx.components.base import executor_spec
 from tfx.components.example_gen.component import FileBasedExampleGen
 from tfx.components.example_gen.csv_example_gen import executor
 from tfx.utils.dsl_utils import external_input


### PR DESCRIPTION
After discussion https://github.com/tensorflow/tfx/issues/583 , updating docs regarding custom Executor use according to https://github.com/tensorflow/tfx/commit/3069981910a5011ddac86a01ad90a11d637ede5b
I don't know if this is enough to update also official website, but at least this will update docs inside repo.