### PR TITLE
Some small edits. Grammar check only. Will be reviewed soon. Please don't merge yet.

### DIFF
--- a/docs/guide/examplegen.md
+++ b/docs/guide/examplegen.md
@@ -99,9 +99,9 @@ examples = csv_input(input_dir)
 example_gen = CsvExampleGen(input_base=examples, input_config=input)
 ```
 
-For file based example gen (e.g. CsvExampleGen and ImportExampleGen), `pattern`
+For file-based ExampleGen (e.g. CsvExampleGen and ImportExampleGen), `pattern`
 is a glob relative file pattern that maps to input files with root directory
-given by input base path. For query-based example gen (e.g. BigQueryExampleGen,
+given by input base path. For query-based ExampleGen (e.g. BigQueryExampleGen,
 PrestoExampleGen), `pattern` is a SQL query.
 
 By default, the entire input base dir is treated as a single input split, and


### PR DESCRIPTION
Changed "file based example gen" to "file-based ExampleGen" and "query-based example gen" to "query-based ExampleGen". Not a very important change but done to keep things uniform throughout the documentation. [See line 77 and line 115 in https://github.com/tensorflow/tfx/blob/1ba6956f2d0fbea2e6f3d1c0b0734c2a59ca371c/tfx/types/standard_component_specs.py where the components have been referenced as "X-based ExampleGen" instead of "X-based example gen"]