### PR TITLE
BaseDriver: make input artifact verification a method on BaseDriver class

### DIFF
--- a/tfx/components/base/base_driver.py
+++ b/tfx/components/base/base_driver.py
@@ -29,24 +29,6 @@ from tfx.orchestration import metadata
 from tfx.types import channel_utils
 
 
-def _verify_input_artifacts(
-    artifacts_dict: Dict[Text, List[types.Artifact]]) -> None:
-  """Verify that all artifacts have existing uri.
-
-  Args:
-    artifacts_dict: key -> types.Artifact for inputs.
-
-  Raises:
-    RuntimeError: if any input as an empty or non-existing uri.
-  """
-  for single_artifacts_list in artifacts_dict.values():
-    for artifact in single_artifacts_list:
-      if not artifact.uri:
-        raise RuntimeError('Artifact %s does not have uri' % artifact)
-      if not tf.io.gfile.exists(artifact.uri):
-        raise RuntimeError('Artifact uri %s is missing' % artifact.uri)
-
-
 def _generate_output_uri(artifact: types.Artifact, base_output_dir: Text,
                          name: Text, execution_id: int) -> Text:
   """Generate uri for output artifact."""
@@ -80,6 +62,25 @@ class BaseDriver(object):
 
   def __init__(self, metadata_handler: metadata.Metadata):
     self._metadata_handler = metadata_handler
+
+  def verify_input_artifacts(
+    self,
+    artifacts_dict: Dict[Text, List[types.Artifact]]) -> None:
+    """Verify that all artifacts have existing uri.
+
+    Args:
+      artifacts_dict: key -> types.Artifact for inputs.
+
+    Raises:
+      RuntimeError: if any input as an empty or non-existing uri.
+    """
+    for single_artifacts_list in artifacts_dict.values():
+      for artifact in single_artifacts_list:
+        if not artifact.uri:
+          raise RuntimeError('Artifact %s does not have uri' % artifact)
+        if not tf.io.gfile.exists(artifact.uri):
+          raise RuntimeError('Artifact uri %s is missing' % artifact.uri)
+
 
   def _log_properties(self, input_dict: Dict[Text, List[types.Artifact]],
                       output_dict: Dict[Text, List[types.Artifact]],
@@ -257,7 +258,7 @@ class BaseDriver(object):
     # Step 1. Fetch inputs from metadata.
     input_artifacts = self.resolve_input_artifacts(input_dict, exec_properties,
                                                    driver_args, pipeline_info)
-    _verify_input_artifacts(artifacts_dict=input_artifacts)
+    self.verify_input_artifacts(artifacts_dict=input_artifacts)
     absl.logging.debug('Resolved input artifacts are: %s', input_artifacts)
     # Step 2. Register execution in metadata.
     execution_id = self._register_execution(

--- a/tfx/components/base/base_driver_test.py
+++ b/tfx/components/base/base_driver_test.py
@@ -66,7 +66,7 @@ class BaseDriverTest(tf.test.TestCase):
     self._execution_id = 100
 
   @mock.patch(
-      'tfx.components.base.base_driver._verify_input_artifacts'
+      'tfx.components.base.base_driver.BaseDriver.verify_input_artifacts'
   )
   def testPreExecutionNewExecution(self, mock_verify_input_artifacts_fn):
     input_dict = {
@@ -116,7 +116,7 @@ class BaseDriverTest(tf.test.TestCase):
                      'output_a', str(execution_id), 'split', ''))
 
   @mock.patch(
-      'tfx.components.base.base_driver._verify_input_artifacts'
+      'tfx.components.base.base_driver.BaseDriver.verify_input_artifacts'
   )
   def testPreExecutionCached(self, mock_verify_input_artifacts_fn):
     input_dict = {
@@ -170,8 +170,9 @@ class BaseDriverTest(tf.test.TestCase):
     base_driver._verify_input_artifacts(self._input_artifacts)
 
   def testVerifyInputArtifactsNotExists(self):
+    driver = base_driver.BaseDriver(metadata_handler=self._mock_metadata)
     with self.assertRaises(RuntimeError):
-      base_driver._verify_input_artifacts(
+      driver.verify_input_artifacts(
           {'artifact': [types.Artifact(type_name='input_data')]})
 
 


### PR DESCRIPTION
Currently, `_verify_input_artifacts` being implemented as a module function makes it difficult for custom Driver implementations to reuse, extend, or swap out that logic, while keeping all other parts of the base Driver implementation constant.

Here we propose bringing that verification logic into the class definition itself, to enable such use cases.