### PR TITLE
Updates link to info about Chicago taxi dataset

### DIFF
--- a/tfx/examples/chicago_taxi_pipeline/README.md
+++ b/tfx/examples/chicago_taxi_pipeline/README.md
@@ -41,7 +41,7 @@ accuracy, timeliness, or completeness of any of the data provided at this site.
 The data provided at this site is subject to change at any time. It is
 understood that the data provided at this site is being used at one’s own risk.
 
-You can [read more](https://cloud.google.com/bigquery/public-data/chicago-taxi) about
+You can [read more](https://console.cloud.google.com/marketplace/details/city-of-chicago-public-data/chicago-taxi-trips) about
 the dataset in [Google BigQuery](https://cloud.google.com/bigquery/). Explore
 the full dataset in the
 [BigQuery UI](https://bigquery.cloud.google.com/dataset/bigquery-public-data:chicago_taxi_trips).


### PR DESCRIPTION
The current link (https://cloud.google.com/bigquery/public-data/chicago-taxi) redirects to https://cloud.google.com/bigquery/public-data/, which is generic - so there's nothing there about the Chicago taxi dataset. All the dataset-specific info is on Marketplace pages.