### PR TITLE
ImporterNode: Propagate imported result to output dict

### DIFF
--- a/tfx/components/common_nodes/importer_node.py
+++ b/tfx/components/common_nodes/importer_node.py
@@ -82,8 +82,8 @@ class ImporterDriver(base_driver.BaseDriver):
                 reimport=exec_properties[REIMPORT_OPTION_KEY])
     }
 
-    # output_dict[IMPORT_RESULT_KEY] = channel_utils.as_channel(
-    #   output_artifacts[IMPORT_RESULT_KEY])
+    output_dict[IMPORT_RESULT_KEY] = channel_utils.as_channel(
+      output_artifacts[IMPORT_RESULT_KEY])
 
     return data_types.ExecutionDecision(
         input_dict={},

--- a/tfx/components/common_nodes/importer_node.py
+++ b/tfx/components/common_nodes/importer_node.py
@@ -82,8 +82,8 @@ class ImporterDriver(base_driver.BaseDriver):
                 reimport=exec_properties[REIMPORT_OPTION_KEY])
     }
 
-    output_dict[IMPORT_RESULT_KEY] = channel_utils.as_channel(
-      output_artifacts[IMPORT_RESULT_KEY])
+    # output_dict[IMPORT_RESULT_KEY] = channel_utils.as_channel(
+    #   output_artifacts[IMPORT_RESULT_KEY])
 
     return data_types.ExecutionDecision(
         input_dict={},

--- a/tfx/components/common_nodes/importer_node.py
+++ b/tfx/components/common_nodes/importer_node.py
@@ -24,6 +24,7 @@ from tfx.components.base import base_driver
 from tfx.components.base import base_node
 from tfx.orchestration import data_types
 from tfx.types import artifact
+from tfx.types import channel_utils
 from tfx.types import node_common
 
 # Constant to access importer importing result from importer output dict.
@@ -80,6 +81,10 @@ class ImporterDriver(base_driver.BaseDriver):
                 destination_channel=output_dict[IMPORT_RESULT_KEY],
                 reimport=exec_properties[REIMPORT_OPTION_KEY])
     }
+
+    output_dict[IMPORT_RESULT_KEY] = channel_utils.as_channel(
+      output_artifacts[IMPORT_RESULT_KEY])
+
     return data_types.ExecutionDecision(
         input_dict={},
         output_dict=output_artifacts,

--- a/tfx/components/common_nodes/importer_node_test.py
+++ b/tfx/components/common_nodes/importer_node_test.py
@@ -42,6 +42,10 @@ class ImporterNodeTest(tf.test.TestCase):
     self.assertEqual(
         impt.outputs.get_all()[importer_node.IMPORT_RESULT_KEY].type_name,
         standard_artifacts.Examples.TYPE_NAME)
+    self.assertEqual(
+        impt.outputs[importer_node.IMPORT_RESULT_KEY].uri,
+        'm/y/u/r/i',
+    )
 
 
 class ImporterDriverTest(tf.test.TestCase):

--- a/tfx/components/common_nodes/importer_node_test.py
+++ b/tfx/components/common_nodes/importer_node_test.py
@@ -42,10 +42,6 @@ class ImporterNodeTest(tf.test.TestCase):
     self.assertEqual(
         impt.outputs.get_all()[importer_node.IMPORT_RESULT_KEY].type_name,
         standard_artifacts.Examples.TYPE_NAME)
-    self.assertEqual(
-        impt.outputs[importer_node.IMPORT_RESULT_KEY].uri,
-        'm/y/u/r/i',
-    )
 
 
 class ImporterDriverTest(tf.test.TestCase):
@@ -90,6 +86,13 @@ class ImporterDriverTest(tf.test.TestCase):
       self.assertEqual(
           execution_result.output_dict[importer_node.IMPORT_RESULT_KEY][0].id,
           2 if reimport else 1)
+
+      self.assertNotEmpty(self.output_dict[importer_node.IMPORT_RESULT_KEY].get())
+
+      self.assertEqual(
+        self.output_dict[importer_node.IMPORT_RESULT_KEY].get()[0].uri,
+        self.source_uri,
+      )
 
   def testImportArtifact(self):
     self._callImporterDriver(reimport=True)


### PR DESCRIPTION
Current implementation of ImporterNode propagates the specified URI to ML Metadata, but does not expose said URI as part of `.output`.

This PR patches `ImporterDriver` to propagate the imported URI accordingly. This logic could certainly live in some newly-created `ImporterExecutor` that we use in lieu of `EmptyExecutor`, which would possibly be more in line with the separation-of-responsibilities between Driver and Executor. Reviewers, let me know if you'd rather go down that route and I can update accordingly.