### PR TITLE
make_beam_dependency_flags now checks extra_packages instead of extra_package

### DIFF
--- a/tfx/utils/dependency_utils.py
+++ b/tfx/utils/dependency_utils.py
@@ -58,7 +58,7 @@ def make_beam_dependency_flags(beam_pipeline_args: List[Text]) -> List[Text]:
   pipeline_options = beam.options.pipeline_options.PipelineOptions(
       flags=beam_pipeline_args)
   all_options = pipeline_options.get_all_options()
-  for flag_name in ['extra_package', 'setup_file', 'requirements_file']:
+  for flag_name in ['extra_packages', 'setup_file', 'requirements_file']:
     if all_options.get(flag_name):
       absl.logging.info('Nonempty beam arg %s already includes dependency',
                         flag_name)


### PR DESCRIPTION
pipeline_options.get_all_options() can never have an option which is called 'extra_package'. Instead even if one specifies an 'extra_package' arg in beam_pipeline_args, it will resolve to extra_packages in pipeline_options.get_all_options().