### PR TITLE
Fix #990, correctly implement ComponentSpec equality check

### DIFF
--- a/tfx/types/component_spec.py
+++ b/tfx/types/component_spec.py
@@ -88,7 +88,7 @@ class ComponentSpec(with_metaclass(abc.ABCMeta, json_utils.Jsonable)):
     self._parse_parameters()
 
   def __eq__(self, other):
-    return (isinstance(other.__class__, self.__class__) and
+    return (other.__class__ == self.__class__ and
             self.to_json_dict() == other.to_json_dict())
 
   def _validate_spec(self):

--- a/tfx/types/component_spec_test.py
+++ b/tfx/types/component_spec_test.py
@@ -87,6 +87,7 @@ class ComponentSpecTest(tf.test.TestCase):
     self.assertEqual(10, spec.exec_properties['folds'])
     self.assertIs(spec.inputs['input'], input_channel)
     self.assertIs(spec.outputs['output'], output_channel)
+    self.assertEqual(spec, spec)
 
     # Verify compatibility aliasing behavior.
     self.assertIs(spec.inputs['future_input_name'], spec.inputs['input'])


### PR DESCRIPTION
This PR also adds an extra assert in `component_spec_test.py`.