### PR TITLE
Fix in rest_simple tutorial notebook

### DIFF
--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -1,870 +1,874 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "MhoQ0WE77laV"
-      },
-      "source": [
-        "##### Copyright 2019 The TensorFlow Authors."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "cellView": "form",
-        "colab": {},
-        "colab_type": "code",
-        "id": "_ckMIh7O7s6D"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "jYysdyb-CaWM"
-      },
-      "source": [
-        "# Train and serve a TensorFlow model with TensorFlow Serving"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "E6FwTNtl3S4v"
-      },
-      "source": [
-        "**Warning: This notebook is designed to be run in a Google Colab only**.  It installs packages on the system and requires root access.  If you want to run it in a local Jupyter notebook, please proceed with caution.\n",
-        "\n",
-        "Note: You can run this example right now in a Jupyter-style notebook, no setup required!  Just click \"Run in Google Colab\"\n",
-        "\n",
-        "\u003cdiv class=\"devsite-table-wrapper\"\u003e\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/serving/rest_simple\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/serving/rest_simple.ipynb\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\"\u003eRun in Google Colab\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://github.com/tensorflow/tfx/blob/master/docs/tutorials/serving/rest_simple.ipynb\"\u003e\n",
-        "\u003cimg width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\"\u003eView source on GitHub\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003c/tr\u003e\u003c/table\u003e\u003c/div\u003e"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "FbVhjPpzn6BM"
-      },
-      "source": [
-        "This guide trains a neural network model to classify [images of clothing, like sneakers and shirts](https://github.com/zalandoresearch/fashion-mnist), saves the trained model, and then serves it with [TensorFlow Serving](https://www.tensorflow.org/serving/).  The focus is on TensorFlow Serving, rather than the modeling and training in TensorFlow, so for a complete example which focuses on the modeling and training see the [Basic Classification example](https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/keras/basic_classification.ipynb).\n",
-        "\n",
-        "This guide uses [tf.keras](https://github.com/tensorflow/docs/blob/master/site/en/r1/guide/keras.ipynb), a high-level API to build and train models in TensorFlow."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "dzLKpmZICaWN",
-        "outputId": "da36b678-5ff6-4e2c-dd9e-2dc3170bba8c"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "1.13.1\n"
-          ]
-        }
-      ],
-      "source": [
-        "# TensorFlow and tf.keras\n",
-        "import tensorflow as tf\n",
-        "from tensorflow import keras\n",
-        "\n",
-        "# Helper libraries\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "import os\n",
-        "import subprocess\n",
-        "\n",
-        "tf.logging.set_verbosity(tf.logging.ERROR)\n",
-        "print(tf.__version__)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "5jAk1ZXqTJqN"
-      },
-      "source": [
-        "## Create your model"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "yR0EdgrLCaWR"
-      },
-      "source": [
-        "### Import the Fashion MNIST dataset\n",
-        "\n",
-        "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
-        "\n",
-        "\u003ctable\u003e\n",
-        "  \u003ctr\u003e\u003ctd\u003e\n",
-        "    \u003cimg src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
-        "         alt=\"Fashion MNIST sprite\"  width=\"600\"\u003e\n",
-        "  \u003c/td\u003e\u003c/tr\u003e\n",
-        "  \u003ctr\u003e\u003ctd align=\"center\"\u003e\n",
-        "    \u003cb\u003eFigure 1.\u003c/b\u003e \u003ca href=\"https://github.com/zalandoresearch/fashion-mnist\"\u003eFashion-MNIST samples\u003c/a\u003e (by Zalando, MIT License).\u003cbr/\u003e\u0026nbsp;\n",
-        "  \u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003c/table\u003e\n",
-        "\n",
-        "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. You can access the Fashion MNIST directly from TensorFlow, just import and load the data.\n",
-        "\n",
-        "Note: Although these are really images, they are loaded as NumPy arrays and not binary image objects."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 255
-        },
-        "colab_type": "code",
-        "id": "7MqDQO0KCaWS",
-        "outputId": "18ee19db-cc5e-4141-9e27-ba8f52b2c148"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-labels-idx1-ubyte.gz\n",
-            "32768/29515 [=================================] - 0s 0us/step\n",
-            "40960/29515 [=========================================] - 0s 0us/step\n",
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-images-idx3-ubyte.gz\n",
-            "26427392/26421880 [==============================] - 0s 0us/step\n",
-            "26435584/26421880 [==============================] - 0s 0us/step\n",
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-labels-idx1-ubyte.gz\n",
-            "16384/5148 [===============================================================================================] - 0s 0us/step\n",
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-images-idx3-ubyte.gz\n",
-            "4423680/4422102 [==============================] - 0s 0us/step\n",
-            "4431872/4422102 [==============================] - 0s 0us/step\n",
-            "\n",
-            "train_images.shape: (60000, 28, 28, 1), of float64\n",
-            "test_images.shape: (10000, 28, 28, 1), of float64\n"
-          ]
-        }
-      ],
-      "source": [
-        "fashion_mnist = keras.datasets.fashion_mnist\n",
-        "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()\n",
-        "\n",
-        "# scale the values to 0.0 to 1.0\n",
-        "train_images = train_images / 255.0\n",
-        "test_images = test_images / 255.0\n",
-        "\n",
-        "# reshape for feeding into the model\n",
-        "train_images = train_images.reshape(train_images.shape[0], 28, 28, 1)\n",
-        "test_images = test_images.reshape(test_images.shape[0], 28, 28, 1)\n",
-        "\n",
-        "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
-        "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']\n",
-        "\n",
-        "print('\\ntrain_images.shape: {}, of {}'.format(train_images.shape, train_images.dtype))\n",
-        "print('test_images.shape: {}, of {}'.format(test_images.shape, test_images.dtype))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "PDu7OX8Nf5PY"
-      },
-      "source": [
-        "### Train and evaluate your model\n",
-        "\n",
-        "Let's use the simplest possible CNN, since we're not focused on the modeling part."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 459
-        },
-        "colab_type": "code",
-        "id": "LTNN0ANGgA36",
-        "outputId": "9733b5ce-820f-43e6-de52-7bef7bcb759d"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "_________________________________________________________________\n",
-            "Layer (type)                 Output Shape              Param #   \n",
-            "=================================================================\n",
-            "Conv1 (Conv2D)               (None, 13, 13, 8)         80        \n",
-            "_________________________________________________________________\n",
-            "flatten (Flatten)            (None, 1352)              0         \n",
-            "_________________________________________________________________\n",
-            "Softmax (Dense)              (None, 10)                13530     \n",
-            "=================================================================\n",
-            "Total params: 13,610\n",
-            "Trainable params: 13,610\n",
-            "Non-trainable params: 0\n",
-            "_________________________________________________________________\n",
-            "Epoch 1/5\n",
-            "60000/60000 [==============================] - 8s 130us/sample - loss: 0.5308 - acc: 0.8174\n",
-            "Epoch 2/5\n",
-            "60000/60000 [==============================] - 5s 86us/sample - loss: 0.3737 - acc: 0.8682\n",
-            "Epoch 3/5\n",
-            "60000/60000 [==============================] - 5s 91us/sample - loss: 0.3388 - acc: 0.8798\n",
-            "Epoch 4/5\n",
-            "60000/60000 [==============================] - 5s 78us/sample - loss: 0.3195 - acc: 0.8860\n",
-            "Epoch 5/5\n",
-            "60000/60000 [==============================] - 5s 82us/sample - loss: 0.3074 - acc: 0.8902\n",
-            "10000/10000 [==============================] - 1s 62us/sample - loss: 0.3414 - acc: 0.8777\n",
-            "\n",
-            "Test accuracy: 0.877699971199\n"
-          ]
-        }
-      ],
-      "source": [
-        "model = keras.Sequential([\n",
-        "  keras.layers.Conv2D(input_shape=(28,28,1), filters=8, kernel_size=3, \n",
-        "                      strides=2, activation='relu', name='Conv1'),\n",
-        "  keras.layers.Flatten(),\n",
-        "  keras.layers.Dense(10, activation=tf.nn.softmax, name='Softmax')\n",
-        "])\n",
-        "model.summary()\n",
-        "\n",
-        "testing = False\n",
-        "epochs = 5\n",
-        "\n",
-        "model.compile(optimizer=tf.train.AdamOptimizer(), \n",
-        "              loss='sparse_categorical_crossentropy',\n",
-        "              metrics=['accuracy'])\n",
-        "model.fit(train_images, train_labels, epochs=epochs)\n",
-        "\n",
-        "test_loss, test_acc = model.evaluate(test_images, test_labels)\n",
-        "print('\\nTest accuracy: {}'.format(test_acc))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "AwGPItyphqXT"
-      },
-      "source": [
-        "## Save your model\n",
-        "\n",
-        "To load our trained model into TensorFlow Serving we first need to save it in [SavedModel](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/saved_model) format.  This will create a protobuf file in a well-defined directory hierarchy, and will include a version number.  [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving) allows us to select which version of a model, or \"servable\" we want to use when we make inference requests.  Each version will be exported to a different sub-directory under the given path."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 136
-        },
-        "colab_type": "code",
-        "id": "0w5Rq8SsgWE6",
-        "outputId": "0c318fa8-4368-4b9d-d7c6-d9d35b8f6aad"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "export_path = /tmp/1\n",
-            "\n",
-            "\n",
-            "Saved model:\n",
-            "total 120\n",
-            "-rw-r--r-- 1 root root 118459 Apr 16 23:56 saved_model.pb\n",
-            "drwxr-xr-x 2 root root   4096 Apr 16 23:56 variables\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Fetch the Keras session and save the model\n",
-        "# The signature definition is defined by the input and output tensors,\n",
-        "# and stored with the default serving key\n",
-        "import tempfile\n",
-        "\n",
-        "MODEL_DIR = tempfile.gettempdir()\n",
-        "version = 1\n",
-        "export_path = os.path.join(MODEL_DIR, str(version))\n",
-        "print('export_path = {}\\n'.format(export_path))\n",
-        "if os.path.isdir(export_path):\n",
-        "  print('\\nAlready saved a model, cleaning up\\n')\n",
-        "  !rm -r {export_path}\n",
-        "\n",
-        "tf.saved_model.simple_save(\n",
-        "    keras.backend.get_session(),\n",
-        "    export_path,\n",
-        "    inputs={'input_image': model.input},\n",
-        "    outputs={t.name:t for t in model.outputs})\n",
-        "\n",
-        "print('\\nSaved model:')\n",
-        "!ls -l {export_path}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "FM7B_RuDYoIj"
-      },
-      "source": [
-        "## Examine your saved model\n",
-        "\n",
-        "We'll use the command line utility `saved_model_cli` to look at the [MetaGraphDefs](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/MetaGraphDef) (the models) and [SignatureDefs](../signature_defs) (the methods you can call) in our SavedModel.  See [this discussion of the SavedModel CLI](https://github.com/tensorflow/docs/blob/master/site/en/r1/guide/saved_model.md#cli-to-inspect-and-execute-savedmodel) in the TensorFlow Guide."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 272
-        },
-        "colab_type": "code",
-        "id": "LU4GDF_aYtfQ",
-        "outputId": "51a3405c-4bd0-4c0d-833e-168ef7b669ac"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "MetaGraphDef with tag-set: 'serve' contains the following SignatureDefs:\n",
-            "\n",
-            "signature_def['serving_default']:\n",
-            "  The given SavedModel SignatureDef contains the following input(s):\n",
-            "    inputs['input_image'] tensor_info:\n",
-            "        dtype: DT_FLOAT\n",
-            "        shape: (-1, 28, 28, 1)\n",
-            "        name: Conv1_input:0\n",
-            "  The given SavedModel SignatureDef contains the following output(s):\n",
-            "    outputs['Softmax/Softmax:0'] tensor_info:\n",
-            "        dtype: DT_FLOAT\n",
-            "        shape: (-1, 10)\n",
-            "        name: Softmax/Softmax:0\n",
-            "  Method name is: tensorflow/serving/predict\n"
-          ]
-        }
-      ],
-      "source": [
-        "!saved_model_cli show --dir {export_path} --all"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "lSPWuegUb7Eo"
-      },
-      "source": [
-        "That tells us a lot about our model!  In this case we just trained our model, so we already know the inputs and outputs, but if we didn't this would be important information.  It doesn't tell us everything, like the fact that this is grayscale image data for example, but it's a great start."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "DBgsyhytS6KD"
-      },
-      "source": [
-        "## Serve your model with TensorFlow Serving\n",
-        "\n",
-        "### Add TensorFlow Serving distribution URI as a package source:\n",
-        "\n",
-        "We're preparing to install TensorFlow Serving using [Aptitude](https://wiki.debian.org/Aptitude) since this Colab runs in a Debian environment.  We'll add the `tensorflow-model-server` package to the list of packages that Aptitude knows about.  Note that we're running as root.\n",
-        "\n",
-        "Note: This example is running TensorFlow Serving natively, but [you can also run it in a Docker container](https://www.tensorflow.org/tfx/serving/docker), which is one of the easiest ways to get started using TensorFlow Serving."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 578
-        },
-        "colab_type": "code",
-        "id": "EWg9X2QHlbGS",
-        "outputId": "d3d8416d-dee5-48d3-cbcc-288acc210a46"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "deb http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal\n",
-            "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
-            "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-            "\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100  2343  100  2343    0     0  14029      0 --:--:-- --:--:-- --:--:-- 13946\r100  2343  100  2343    0     0  14029      0 --:--:-- --:--:-- --:--:-- 13946\n",
-            "OK\n",
-            "Get:1 http://storage.googleapis.com/tensorflow-serving-apt stable InRelease [3,012 B]\n",
-            "Hit:2 http://archive.ubuntu.com/ubuntu bionic InRelease\n",
-            "Hit:3 http://ppa.launchpad.net/graphics-drivers/ppa/ubuntu bionic InRelease\n",
-            "Get:4 https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/ InRelease [3,609 B]\n",
-            "Get:5 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]\n",
-            "Get:6 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]\n",
-            "Ign:7 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease\n",
-            "Get:8 http://ppa.launchpad.net/marutter/c2d4u3.5/ubuntu bionic InRelease [15.4 kB]\n",
-            "Ign:9 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  InRelease\n",
-            "Hit:10 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  Release\n",
-            "Hit:11 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release\n",
-            "Get:12 http://storage.googleapis.com/tensorflow-serving-apt stable/tensorflow-model-server-universal amd64 Packages [360 B]\n",
-            "Get:13 http://storage.googleapis.com/tensorflow-serving-apt stable/tensorflow-model-server amd64 Packages [355 B]\n",
-            "Get:14 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]\n",
-            "Get:15 https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/ Packages [60.4 kB]\n",
-            "Get:16 http://ppa.launchpad.net/marutter/c2d4u3.5/ubuntu bionic/main Sources [1,636 kB]\n",
-            "Get:19 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [410 kB]\n",
-            "Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1,103 kB]\n",
-            "Get:21 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [4,171 B]\n",
-            "Get:22 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [301 kB]\n",
-            "Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [752 kB]\n",
-            "Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [7,238 B]\n",
-            "Get:25 http://ppa.launchpad.net/marutter/c2d4u3.5/ubuntu bionic/main amd64 Packages [786 kB]\n",
-            "Fetched 5,335 kB in 3s (1,671 kB/s)\n",
-            "Reading package lists... Done\n",
-            "Building dependency tree       \n",
-            "Reading state information... Done\n",
-            "37 packages can be upgraded. Run 'apt list --upgradable' to see them.\n"
-          ]
-        }
-      ],
-      "source": [
-        "# This is the same as you would do from your command line, but without the [arch=amd64], and no sudo\n",
-        "# You would instead do:\n",
-        "# echo \"deb [arch=amd64] http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal\" | sudo tee /etc/apt/sources.list.d/tensorflow-serving.list \u0026\u0026 \\\n",
-        "# curl https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | sudo apt-key add -\n",
-        "\n",
-        "!echo \"deb http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal\" | tee /etc/apt/sources.list.d/tensorflow-serving.list \u0026\u0026 \\\n",
-        "curl https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | apt-key add -\n",
-        "!apt update"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "W1ZVp_VOU7Wu"
-      },
-      "source": [
-        "### Install TensorFlow Serving\n",
-        "\n",
-        "This is all you need - one command line!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 323
-        },
-        "colab_type": "code",
-        "id": "ygwa9AgRloYy",
-        "outputId": "485b7d6c-68a4-4ff6-9690-830fc1cd2ba6"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Reading package lists... Done\n",
-            "Building dependency tree       \n",
-            "Reading state information... Done\n",
-            "The following package was automatically installed and is no longer required:\n",
-            "  libnvidia-common-410\n",
-            "Use 'apt autoremove' to remove it.\n",
-            "The following NEW packages will be installed:\n",
-            "  tensorflow-model-server\n",
-            "0 upgraded, 1 newly installed, 0 to remove and 37 not upgraded.\n",
-            "Need to get 136 MB of archives.\n",
-            "After this operation, 0 B of additional disk space will be used.\n",
-            "Get:1 http://storage.googleapis.com/tensorflow-serving-apt stable/tensorflow-model-server amd64 tensorflow-model-server all 1.13.0 [136 MB]\n",
-            "Fetched 136 MB in 2s (58.6 MB/s)\n",
-            "Selecting previously unselected package tensorflow-model-server.\n",
-            "(Reading database ... 131304 files and directories currently installed.)\n",
-            "Preparing to unpack .../tensorflow-model-server_1.13.0_all.deb ...\n",
-            "Unpacking tensorflow-model-server (1.13.0) ...\n",
-            "Setting up tensorflow-model-server (1.13.0) ...\n"
-          ]
-        }
-      ],
-      "source": [
-        "!apt-get install tensorflow-model-server"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "k5NrYdQeVm52"
-      },
-      "source": [
-        "### Start running TensorFlow Serving\n",
-        "\n",
-        "This is where we start running TensorFlow Serving and load our model.  After it loads we can start making inference requests using REST.  There are some important parameters:\n",
-        "\n",
-        "* `rest_api_port`: The port that you'll use for REST requests.\n",
-        "* `model_name`: You'll use this in the URL of REST requests.  It can be anything.\n",
-        "* `model_base_path`: This is the path to the directory where you've saved your model.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "aUgp3vUdU5GS"
-      },
-      "outputs": [],
-      "source": [
-        "os.environ[\"MODEL_DIR\"] = MODEL_DIR"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "kJDhHNJVnaLN",
-        "outputId": "3dc18177-7c73-4943-e177-5b65400ec453"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Starting job # 0 in a separate thread.\n"
-          ]
-        }
-      ],
-      "source": [
-        "%%bash --bg \n",
-        "nohup tensorflow_model_server \\\n",
-        "  --rest_api_port=8501 \\\n",
-        "  --model_name=fashion_model \\\n",
-        "  --model_base_path=\"${MODEL_DIR}\" \u003eserver.log 2\u003e\u00261\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 187
-        },
-        "colab_type": "code",
-        "id": "IxbeiOCUUs2z",
-        "outputId": "648d5262-e5c5-4b78-cbcf-b31c06b33581"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "2019-04-16 23:57:13.903708: I external/org_tensorflow/tensorflow/cc/saved_model/reader.cc:31] Reading SavedModel from: /tmp/1\n",
-            "2019-04-16 23:57:13.905313: I external/org_tensorflow/tensorflow/cc/saved_model/reader.cc:54] Reading meta graph with tags { serve }\n",
-            "2019-04-16 23:57:13.906761: I external/org_tensorflow/tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA\n",
-            "2019-04-16 23:57:13.918934: I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:182] Restoring SavedModel bundle.\n",
-            "2019-04-16 23:57:13.931921: I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:285] SavedModel load for tags { serve }; Status: success. Took 28202 microseconds.\n",
-            "2019-04-16 23:57:13.931975: I tensorflow_serving/servables/tensorflow/saved_model_warmup.cc:101] No warmup data file found at /tmp/1/assets.extra/tf_serving_warmup_requests\n",
-            "2019-04-16 23:57:13.932059: I tensorflow_serving/core/loader_harness.cc:86] Successfully loaded servable version {name: fashion_model version: 1}\n",
-            "2019-04-16 23:57:13.933039: I tensorflow_serving/model_servers/server.cc:313] Running gRPC ModelServer at 0.0.0.0:8500 ...\n",
-            "2019-04-16 23:57:13.933658: I tensorflow_serving/model_servers/server.cc:333] Exporting HTTP/REST API at:localhost:8501 ...\n",
-            "[evhttp_server.cc : 237] RAW: Entering the event loop ...\n"
-          ]
-        }
-      ],
-      "source": [
-        "!tail server.log"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "vwg1JKaGXWAg"
-      },
-      "source": [
-        "## Make a request to your model in TensorFlow Serving\n",
-        "\n",
-        "First, let's take a look at a random example from our test data."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 318
-        },
-        "colab_type": "code",
-        "id": "Luqm_Jyff9iR",
-        "outputId": "85e6d60f-3755-4d36-f87d-ad9aaba4ab52"
-      },
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEtCAYAAADnQL6OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAFtZJREFUeJzt3Xl0XNV9B/DvT6N9l+XdDthgs6QQ\nEic+xQSIKSlQoEkgkLokwaalKSmBcNqTZmNxoDTh0MSnLRQISwyEUGKSkAZSzGpWO3Eo+2LA2MYY\nWza2ZWuxNNLM7R/3Ccavur8rSx5J7u/7OUdHR+++5c6b0XfuzL3vPnHOgYhsKhnpChDRyGEAEBnG\nACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESG\nMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCR\nYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDBu2ABCRG0XEicii\nIu3fKT+fK8Yxh4uILBORZXtpX9OSc3Lu3tjfvkBE5qZeD7tE5BURuVREqgaxv4Ui4lLLnIgs3GuV\nHialw3GQ5CR/IfnzLBH5hnOutwiHWgzghn6WryrCsWjfcyGAlQCqAZwI4DIAMwCcPZKVGknDEgAA\nPgegHsBvAZwM4CQA9xbhOBuccyuKsF/6/+HVgtfHIyIyHsACEbnIObdtJCtWLCJS4ZzrDpUP10eA\n+QC2A1gAYFfy9276mlUiMlNE7hORdhFZlzTT9ko9ReSv0x8JRCQjIo+JyGoRqU+WzRCR20VkTdJc\nfEtErhORptT+FovIOyLyCRF5Oll3lYickpT/vYisFZGdIvJrERmX2t6JyJUi8t1kP7tE5HER+egA\nHss4EbleRDaISLeIvCYiXxnkeek794eIyFIR6RCRt0XknKT8y8n+20XkURE5MLX9PBF5RES2JOs8\nKyL9PcfjROTO5HxsF5GfiMhnkmPPTa17uoisEJFOEWkVkSUist9gHp9iZfJ7RnLMtSKyuJ96D6p5\nLyInicjy5HndISL3iMjBBeXXikiLiJSmtqtIzs+/FiyLPt8isiCp67HJ+WoF8DutjkUPABGZDODT\nAO5yzm0BcA+AP0//MxX4FYBH4FsN9wD4HvoJjPDhpDT901fonLsZwBIAN4nIlGTxJQCOAnCWc25n\nsmwygPUALoJvKl4O4Hj4FkxaPYDbANwE4DQAmwH8QkR+COA4AOcn+zkOwLX9bH82fKvoa/ABOQHA\nwyIyRnmQ9QCeTLZbCOAUAL8BcJ2IXBA8O3FLANwHf+6fAXCLiPwzgK8C+BaAcwAcDOBnqe0OAHA3\ngC8m2/4G/hyfl1rvlwD+DMC3AcwD0APg3/t5fOcB+AWAVwCcAeBvARwG4DERqStYry+4pg3y8U5P\nfrcOcvsgETkJ/ly2A/gL+HN4GIAnC157twMYD+CE1OanAmiEf10N5vm+A8Aa+HP3LbWizrmi/gD4\nRwAOwJzk7xOTv89LrbcwWX5OavmLAB4YwHGc8jO2YL1GAOvgQ+ZTAHoBfDuy71IARyf7+ljB8sXJ\nsmMLln0kWbYKQKZg+Y/gX/CZVJ3fA1BTsGxast4VBcuWAVhW8PclALoAzEzV88Zkf6XKY5mWHPfc\nfs792QXLmpJzsxVAfcHyC5N19w/svyQ5XzcCeL5g+QnJdl9Irf9fyfK5yd+1AHYAuCW13nQAWQAX\nFSy7NKljv3UpWG9ucowTkrrVw/9ztAN4tmC9tQAWB15bC9PnK7LOHwC8UfhcJI+hB8CPCpa9DuDO\n1L7uAfDKnj7f8G8gDsCigf5/DsdHgPkA3nDOLU/+fgjAuwi/q9+X+vslAANt+t0CYHY/P+8nvHOu\nFcBZAI4FsBTA4wCuKtyJiJSLyHeSZtYu+CftiaT4YOyuwzn3eMHfryW/H3LO5VLLSwFMSm3/W+dc\nR0H91gJYAWCO8jhPgm/arUm1dJYCaAbwYWVbzX8X1GM7fGtmhfugZdT3OADgQ30LxH9su1NENsCf\nqx4A52L3c3UkgBx8C6/Q3am/58D/g96Remzrk2MfW1DHy51zpc65dQN8fEuTuu2Ab+08Ct9i2atE\npAbALPhW7/tfdjvn1gB4Cv6Np8/tAD7b17IRkWb4d/rbC9bZ0+c7fY6DivoloIh8Ar5yV4lIY0HR\nLwF8TUQOcs69ntos/WVMN4DKAR5yo3PuDwNYbwX8O/SHAfybcy6fKv8+gAvgm/5PA2gDMDWpd7ou\nuzUfnXNZEQH8dx6Fssnv9PYt/dSvBcAfKfUfD/+5tSdQ3qxsq+mvzurjEJFaAA8C6IRvbq5O1vkq\ngL8q2G4SgO3OuXSd049/fPL7oQHWcU+cD+D38N9DrS0M3r2sCYAA2NhP2SYA+xf8/VP4j7lnAPgJ\n/MeF0mR5nz19vvs7br+K3QvQ9y7/zeQn7WwAFxe5Dv25DMBMAC8AWCQijzrndhSUzwNwm3Pun/oW\nJC/0YpgQWLZB2WYr/Lvz1wPlw9ntOQf+BX2Mc+7JvoXpL7bgX5RNIlKWCoH049+a/F4A4OV+jtc2\nhLq+HnmD6AJQXrggeUfeU9vhm+IT+ymbiII3OefcGhF5CsCX4APgS/Af99YXbLOnz7frd61+FC0A\nRKQcwF/CN136+yJiEYAvi8glLvkAMxxE5BgA303qdBeA5wFcB/+xoE81/m/anlOkKp0sIjV970bJ\nF1pHAviBss398C2Ut51zm4tUr4GqTn6/f76SL3g/m1pvBYAM/BelPy9YfmZqvb4W1wzn3K17t6pR\n6+C/qCt0yp7uxDnXISLPADhTRBb2fRQUkf3hv3BOf/F5G4Drk56QOdi95QQU8fkuZgvgFPimyT84\n55alC0XkBvh/vLnwn8X2hikicmQ/y9c55zYmL8w7ADwM4F+ccy7pSvm5iCwteMHdD2C+iLwI4E0A\np8M/ccWwC8ADInI1gAr45uBO+IAMWQTfVHxC/MjKVQBqABwC/06c/ucrpqfh63utiFyW1ONi+C+n\nGvpWcs49kLzT/VhExsKf1zMAHJGskk/W2yki30j2Nw7+e4kdAKbAf3Ze5pz7GQCIyKXwXwQeuAff\nA2j+E77nYxH8OJUj4Fsig3EJ/PdZ94rIf8B/ufk9+Mfyw9S6S+BD4afwr4f09yJFe76L+SXgfPgk\nXxIovxOBMQFDsADA8n5+vpiU/xhAFYD5fa0O59wSADcDuEZEZiTrXQD/7fSV8K2EOvjWTDHcBv9C\nuQbArQC2ADjeKQNTko8rR8F3S34T/sugW+DfdfdWmA6I8127p8G/u98N//3JTdj9M2yf0+DD9Sr4\nVkAl/D8K4P8x+vZ5A4DPwH+JeDv841wI/4b1XMH+SpLjyl56OLfCfzw8Hb6b7cSkznvMOXc//Jtg\nI/xjvR7AqwCOds69m1q3NTneFAD3OOfaUuVFe75lGFvflCJ+PPmVzrmR+B5kVBCRa+A/Xo1xyog1\nKo7hGgpMBBFZAP+x4GX4L9tOgu8tuJr//CODAUDDqQN+VOSB8N93rAHwHQBXj2SlLONHACLDOCEI\nkWHD+hHgT0vOZHOjCEoqwwMlpa4uWAYAuS1b9nZ1dlNSXR0sy3d2FvXYQyKRjoVR3HJ+ML9kwL0i\nbAEQGcYAIDKMAUBkGAOAyDAGAJFhDAAiwxgARIZxKPAo0DavvyuYP7Dx+JxaXlYXHkb/N4c9pW7b\nkNmllr+xq7/5Sj4wrfI9tfzjlc8Ey/7upbOCZQCwfUODWj7xcf39q/FXzwXL8l1d6rbRfv59eJxA\nIbYAiAxjABAZxgAgMowBQGQYA4DIMAYAkWEMACLDhnVGoBGdD6Ako5fn9b52zVtXaXfxAsZ+RJ/K\n3Tm9T3nbzvA19QAgq2uCZT1TssEyALhw9sNq+Z/UvKaWb8mFjw0AFz43L1jWs6pe3bZ3sl732kZ9\nPoHSkvQNnz6w/V19jMGhl61Vy3MtI307hjDOB0BEA8IAIDKMAUBkGAOAyDAGAJFhDAAiw+x0Aw7x\n8s23LwvfHDh3SIe+73V6N17sbu4uEtP58vAOyluHlvH5Ur1yma7B35ezpz6y78jNwmLnRbtlaHZs\nr75pr77zmef/LnLwkcNuQCIaEAYAkWEMACLDGABEhjEAiAxjABAZxgAgMszOtOBDHO9QOWtbsKx1\nk34L7kykL91FrlSWyJXK+YZwn3Z2rL5x9QtVanmmW+9SzlWoxciXKYWRpyQ7Jnw5LwCUtuvvX9oY\nhvIt+ks/O7FHLZfZh6vlbuWLavlowRYAkWEMACLDGABEhjEAiAxjABAZxgAgMowBQGSYnXEAEe6o\nI9TyKQ3haaDbOyr1fbfHOvr14lyt3h9e83p5sGzKD57Wdz6KtVwQnoMBAHbO1Mc4VGwLn/d8Rh+E\nUNmgT0aw9bBatXzMSrV41GALgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjOMAEtsO1efub988\nNljW1KDfF+C9bGQcQMfQnoa8svu1V+i3Lncz9Fts5/OR9wjR+9Pzyvz6mXcjkwlEJgwo7dDrVqJ0\n5XdP1PddpdxaHACyjYO/H8JowhYAkWEMACLDGABEhjEAiAxjABAZxgAgMozdgImusXq3TlNduLus\nszt8OS4A1DTsUsvb83oXpHTo3Yj737s9WLbuEn3bCTdGLmXOxKYF199DMtlwd1ppp37J7TvH6d2E\nef20q1OSuwq9m6+7S995vkE/9r6CLQAiwxgARIYxAIgMYwAQGcYAIDKMAUBkGAOAyDCOA0h0jdUv\nDx2jXB7a3q73pdfWdukH79X72mumtqnl+edfDZZVL9UvBy5fulwtH0nlH9OnBW//qH5enXK5caZN\nHx+Rrwrfch0Aupv0cQT7CrYAiAxjABAZxgAgMowBQGQYA4DIMAYAkWEMACLDOA4gkavX+32ry7LB\nMonMEF1Rpu9bevQcrq/S+7tl9uHBsuYbR28/f0xOH14Bp0w5DgC5unBffSYypbiLPCeIzCewr2AL\ngMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjOMA+pTq8wFMqt4ZLFtT2qxu29YZm3tfP/bGzY1q\neefF4XsWlNynzwcwfkX4ngIAILnI7b+r9fnznTJGovTtzeq22Xr92GUtysT/AHrrw331vQ362Ay1\n4gAkMl/AvoItACLDGABEhjEAiAxjABAZxgAgMowBQGQYA4DIMI4D6KN3OaNUwn3KU5tb1W3fWj1h\nMDV6n8vpfdLZFWOCZbkp+r7XL9Tnx+/YVqWWl1Tk1PLS8nB5tv1D6rbI6X3tFRv1cQDaNf+5iT3q\nti6rvzdWVOvb7yvYAiAyjAFAZBgDgMgwBgCRYQwAIsMYAESGmekGzDQ1qeVSrk/z/FZb+JLfUya+\npG57zapJajkiM0yXNeldTlO//4y+A0XbvCP1YzdHpixfp3fV1azaESzrHVenbrvxkzVqeXez3ncr\nSg9leaV+Trs79O7PMXUdavm+gi0AIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwM+MAMC58ySwA\nSInep9yRDU9/PbV8q7qti+w706lfktvbo5d3nzw7WNZTq2/rIm8BO2fogxRKevX917wVfomVrWlR\nt80df4BarvXzA8Cxn34hWPb0O9P0jcv0xx25IzykLDJdek/4dvPDiS0AIsMYAESGMQCIDGMAEBnG\nACAyjAFAZBgDgMgwM+MAeibVq+WxcQBbW2uDZYeXb1S3LWvq0o/9nn7de7ZDf5rWfT5c9+rGNnXb\n7m59au18q96fve3j+nnbcWz4seWy+nwA6NLnGqhdrZ+Xqky4r72iTN93b53eTx+ZRR4lDfpjy72n\njx0ZLmwBEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGmRkHkK3X+7sFer9v767Bn6rDJuvjBFY9\nP1Mtz2b0XueSneG6dbXp/dH5yP0QMp36e4TTpwMAdoTrlomMvYh2tkcs3zQ9WDa+tl3ddkzzZrX8\nhZbJann9ZH38BDgOgIhGGgOAyDAGAJFhDAAiwxgARIYxAIgMYwAQGWZmHEBvpT6Tu3ORmd6VPuuW\nXHiuAADI5vXTHOtLL6mITIDfFt5/rJ8/+hYQnQBfL86Xh8+bRKoWu2dBPtLVvnVdU7Bs1uz16rYr\nN+2nlne0VqnlPc2R8RVq6fBhC4DIMAYAkWEMACLDGABEhjEAiAxjABAZZqYbMFurZ12uUz8VNc2d\nwbK5VXqXz1eWT9OPPVbfPp/VO40yveG+OCmPdH/mh3hJbqRcO7oo9QYAFzmvsW7Csm3hFa6Y9JC6\n7bm7Pq+Wb2/Rp5nvrY48Z2rp8GELgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyzMw4gJ5avc9Z\nOvWe2QMOCk/j/EJWv/33hN/r/dnvnBq53Der57QMYfpsiVwGHZ32O3a58FCm9o5sm6vSV6jeGK5c\na+RS5KHqqdFPXEVxDz9gbAEQGcYAIDKMAUBkGAOAyDAGAJFhDAAiwxgARIaZGQeQq9TLM916h/Z+\n1duDZU906rf3rnknPJcAAJTV6MfOt1br5crU29F++Eh/eGzq7tj+8xXhFWLX88fmC8hFpgWv2hKu\n/CvZCeq2u3r128kjcsv22CzzowVbAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYWbGAcT6nGP9\n4ePK24Jly1sPVLeVHv16/3zkPtfRug9FpMM6cmfz+DiBIfSHS2SahHxl5Bbc2XDZLe8erW57aMMm\ntfzNvD6OoKR3KBMhDB+2AIgMYwAQGcYAIDKMAUBkGAOAyDAGAJFhdroBI9Nbx7qzpldsDpYt/p85\n6raHdrbqO4feDRi7LBYlQ7jkdojTY5f0xG4/rpRF6lYSuxy4Wq98riJ8gBffmKpu+8k/Xq2WIxe7\nVHnfuB6YLQAiwxgARIYxAIgMYwAQGcYAIDKMAUBkGAOAyDAz4wAiV9xGza58O1jW+Ix+s+d8gz6t\nd1WVct0qgM4yfU5zp01RHYl4p4whGIhcZHpsVWRsRqSrHajQxwH0VoYPUPu6/oKonqM/J9Kjn9hs\nHccBENEoxwAgMowBQGQYA4DIMAYAkWEMACLDGABEhtkZB1Cm91dLpDu7sSTc5zz2Of323y6j9wl3\nd+tPQ0nk1uXaGIfY9f6xa/KHOiW5evzItN+xuQby3XrltBnPy3foT3hb5H7yJV163XpqOQ6AiEY5\nBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyzMw4gNh9AXqr9H7hllxZsCzT0aNu2z1Bnw9gxoQNavmb\nkVt4lw7xmn6Ni+06UjenlGtlAJCL3BegvLJXLe+YUhssq1+jD5DodpGxGVP1sR+928PHHk3YAiAy\njAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDDMzDqByi96n3DmrSy2/fP2pwTL37MvqtrFbErgnatTy\n6Z0bIzso3jgASOS69mIeO2YIdZMy/Vl5bP7MIR26fKdePlqwBUBkGAOAyDAGAJFhDAAiwxgARIYx\nAIgMM9MN2Full9fX6Zd33jz918GyeThqMFV6X76jY0jbF9VIdvPFDKVuTr8c+FMT3lDL72qdpZZ3\nj9njGo0ItgCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsPMjAOYtLxbLd+Ua1bLZ7V8PVh2EFYO\nqk59pFR/Glx+FPfFj2b58P3HXa8+pfgdDx6jljeu0q8HrluvTxU/WrAFQGQYA4DIMAYAkWEMACLD\nGABEhjEAiAxjABAZJm40X+9NREXFFgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCR\nYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjAFA\nZNj/AuZZIU40WeT7AAAAAElFTkSuQmCC\n",
-            "text/plain": [
-              "\u003cFigure size 432x288 with 1 Axes\u003e"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "def show(idx, title):\n",
-        "  plt.figure()\n",
-        "  plt.imshow(test_images[idx].reshape(28,28))\n",
-        "  plt.axis('off')\n",
-        "  plt.title('\\n\\n{}'.format(title), fontdict={'size': 16})\n",
-        "\n",
-        "import random\n",
-        "rando = random.randint(0,len(test_images)-1)\n",
-        "show(rando, 'An Example Image: {}'.format(class_names[test_labels[rando]]))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "TKnEHeTrbh3L"
-      },
-      "source": [
-        "Ok, that looks interesting.  How hard is that for you to recognize? Now let's create the JSON object for a batch of  three inference requests, and see how well our model recognizes things:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "colab_type": "code",
-        "id": "2dsD7KQG1m-R",
-        "outputId": "c56e8d06-b1d3-4528-9ac5-860c2091dd7d"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Data: {\"instances\": [[[[0.0], [0.0], [0.0], [0.0], [0.0] ... 0.0], [0.0]]]], \"signature_name\": \"serving_default\"}\n"
-          ]
-        }
-      ],
-      "source": [
-        "import json\n",
-        "data = json.dumps({\"signature_name\": \"serving_default\", \"instances\": test_images[0:3].tolist()})\n",
-        "print('Data: {} ... {}'.format(data[:50], data[len(data)-52:]))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "ReQd4QESIwXN"
-      },
-      "source": [
-        "### Make REST requests"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "iT3J-lHrhOYQ"
-      },
-      "source": [
-        "#### Newest version of the servable\n",
-        "\n",
-        "We'll send a predict request as a POST to our server's REST endpoint, and pass it three examples.  We'll ask our server to give us the latest version of our servable by not specifying a particular version."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 318
-        },
-        "colab_type": "code",
-        "id": "vGvFyuIzW6n6",
-        "outputId": "f731f319-8390-4df9-909c-7cffa56d7fcc"
-      },
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAvUAAAEtCAYAAACIx59SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3Xm8HUWd9/Hv7y7ZCCEEEvYlrAIq\nMCgCDpuC8oALIijKFleGcYNH53HAEQLjhijojIIoMoEBgUFRFBABISwCiiOrLGExCgQSspI9N7n1\n/PGrQ/p2Tlefc+8lscLn/XrldXO6eqnurq7+nerqOhZCEAAAAIB8dazpDAAAAAAYGIJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQuWRQb2ahhX9T\n47yTzOy51ZLrNcDMDoj7e0A/lp1qZpNq5tnNzCaa2ZgmacHMvtLudleXmO9gZl0181XuY2K9b2sy\nvaWyZmYTYr62bmV7rzVm9tZ4fGbUnbsW1jXVzC6rmWeimYWBbKe0vtV+XbRbhuMy65jZNDM7ss1t\n1dYbq5OZdZrZl83sL2a21MyeNLOTm8z3CzM7f03ksR2t1g9mNtnMJhc+t10G1lZVdfSrtJ1QmhbM\nbOKrve1WmdlwM5sX87XrANdVe48bSExSsb7JZnbXYKyrjW2Ojuf2H9pc7pdm9r02l5nUiFf/XpjZ\nkWZ2v5ktMbMXzex7ZrZuaZ6TzexhM2upEb5upr1L/16U9JvStPe1uyNoajdJZ0ham28U7e7jGZIG\ncsO4Xl5GXxjAOtZmJ8S/YyX9nzWZkYz05zr9vKSZkn72quRo9Tlf0r9J+rGkd0m6WtK3zOzfSvOd\nKekTZrbDas7fq+Wf47+G10Jd3aqB1tFrk/dJGhX/f/yazEhGRsvLUMtBvZntJ+kdkr7+amVqdTCz\nD8nr0AclvVfSREkfknRNadYL5ffoE9SCZOtcCOHeUiaWSppZng78PQohvCTppTWdj79HZjZM0gck\nTZa0p7zC+NWazNPayMyGSvqMpIkhhEF7SrG6mdmWkj4u6d9DCI2nIzeb2ShJXzKz80MIsyUphHC/\nmd0v6WT1DYazFEJ4dE3nAVk4QdJsSU9KOsbMvhhCWL6G87Q2+hdJvwohPL+mMzJA/y7p9hDChMYE\nM5sp6WozOzSEcIMkhRAWm9mlkr4g6b/qVjroferNbHczu9PMFsXHs//UZJ7xZna5mb0UH+M+YGa1\nLf6Fx6X7mNn/mNl8M5tuZqfG9EPio4yFZnafme1RWt7M7BQze8LMlpnZC/Fxx6jSfGPN7Cdm9rKZ\nzY0HdHRFno4ws3vj/s41s6vjDbCdYzZBK0/Wk7aya9PWpfk+Gx99zzez281sl3b3z8y2juueUFp2\nlUd55o/bvxLXs8jMbjWz1yUee443s+vNbIGZ/dXMTm88Mmp1HwvbbgRAXyrMO7E0T7KsWZPH62b2\n4VhGFsTz+7CZndgsD3H+PeI6/rEw7TNW6vphZtvHaYfFz2PN7EIzmxLz92wsU5uV1r+Dmf3cvAvM\nEjP7WyxDdV2ZzjSzP8V9mBnPzV6pZUoOl7SevPX155LebWbrl7bRKCsnmtlZsRzMNbNfmdnmNfnr\nNLMfxvwdlJivy8xONbPHzeuCaWb2bfMvHa0wM/uSmT1nZovN7A4z2608Q911EecbFadPi3l5Ii5n\nMX2C2ijD0eHyFt2rmmR8fzO72fyR/UIze9DMPpbY0UEpU2Y20sz+M05fGue7xcxel9iPPeX3i1+X\npt8oaZhWfdJzpTywGZ5YZ9V+DjOz88zskXidvhjL3OtK8zWu773M7ycvx3P3H+XyY2bbmNdNi8zv\nO9+VNLTF/LzS/abdMhCP81Olaf8bl9muMO2r5veyRll7h5ndYCvr3kfM7PNm1llaV1v1WVxmOzP7\nb/N7yWIze8bMLrDS9R/nrSyjlqijrdRlqbC+Pl3KWi3Tdczs/VbR7SXmJdkQaWZHm9ehL8Vjeb+Z\ntdQyGpffTNJB8nJ/kaSNJL2zyXxTzeyyuL3H4jH9oxXuL4ltfMS8/vrXmvkGFJOY2XtjeVtqXi9/\noMk8h5jZPbH8zDPvcrdjaR6zRL0br5m/xNl/VChDExJ521Re1/ykSdr4WK5fjHl/Jl7nqX0902ru\no9ZCfWlmn4vnc7GZzYnntDKmNbMNJW2r5vWptGoPmCsl7Wxm+6T2Rxr8oH6U/GBfJn+ccJ+kC8zs\nwMYMZraFpN9L2lXSKZLeI+lPkn5mZu9pcTuXSHpYvuO/kPQ1Mztb0jmSzpb0QUnrSPqFmQ0pLPdV\nSedKulnSuyV9U9IESddb3/5K18gfL58W17Vc0n+WM2EeRP5M0qOSjpR0oqTXS7rdSv2ialwvqREg\nHqWVXZuK3UaOlXSYpM9J+oikLSVda32Dv1b3r1Vnyo/BpfLzeZOkXybm/7mkW+WBzC/i8o2KsZV9\nLNo7/p1UmPeiQnptWSuLFedlkm6PeTxS0o9U8YUtul/SXPV9xPw2SYubTFsu6Y74eYykJZJOlXSI\nvHVhe0m/s74Bx/WSNpN0kvwm8K+Slqr+2txM0nnyfZ8gaYakO8zsDTXLNZwQ9+uX8vM7RNLRFfOe\nKmk7SR+Vl7+95cexKfNA7mcxbweEEG5J5OMyeZeOn8jL99clfUzS5S3ux/GSDpX0aflx2EjSb61v\nf+fa6yL+vV5+bX07zndjXO6rcT3tlmHJz/1jIYSZxYlm9l5Jv5Uf9xPlx+piSVsl1jVYZeo8+VOa\nMyUdHLf/gNLXwYr4d1lp+tL49/Wl6XfIr9G91b6hktaVH+vD5PsxTNI9ZrZxk/n/W9LTko6QdIGk\nT8mPkSQp3gNulrR7TJsgaby83LWr3TJwm6RtG0GVeeC8m5rXH5MLT3O2kZePj8qPwSXyx/ONstjf\n+kySNpX0rPxJyjslnSXp7ZJuKM7UQhmtq6Nb0WqZrnOtpGkxn8V9eJ2k/SX9oGb5bST9VNIx8mP5\nK0kXWZNGyQrHyq+vS+VdKpaougvOvvIueV+Wxxedkq4zs8rzZmanybthfDKE8I3EfAONSbaT9B/y\nOvAISU9JurIUwx0ivw4WxPyfFLdxV+nLWF29+0LchuT1fqMMXZ/I38Hy43Vnab/HS/qDpP0knS4v\nS2dK2rBmf1u5jybrSzM7Rn68rpDfi46Rl6VU97yq+rRHUtCq9ekDkubH/UoLIbT8T9JUSZdVpE2K\nmTmwMG2opFmSfliY9mN5l4gNSsvfLOmBmu1PiNs4vTCtS34ieiSNL0x/T5x3//h5jPwGNKm0zmPj\nfO+Jnw+On48uzffrOP2A+HmkpHmSLi7NNz6eqJNLx21Si/u2XZO0IH+k112YdmScvk+b+7d1/Dyh\nNN8Bpf1bX37Rnl+a7//G+SYWpk2M0z5SmvdhSTe1so8VxyRI+soAylpje1vHz1+QNLudMh+Xu1bS\nbfH/HfJHrN+OZW5knH6lpHsT6+iUtEXMz/vitA2L56a//+K6uyQ9Iem7Lcy/ifwLyIWFfXqunP9C\nWZlcmv6FOH3TUhm/LJabu+RB1ral5SZKCoXP+8b1HF+a75g4fbcWysdMSeuU8twj7yYitX5dvEvN\nr4uL4vIb9rMMPybp8tI0i8frj5I6EstOLed7MMqUpEckndtmGds5rvek0vTT4/QLS9O75Teu0wZS\ntgv7OUJ+UzulML1xLs4szX+dpCmFz5+I8+1VmNYh6c8q1A+J7U8uXgPtlIFY/nolnRA/Hy5pjvw+\neEWcNjKW2X+qWIfJr+8vxWU7Ctdh2/VZk/V3SfrHuE+7t1lGq+roPsdsIGU6Tp+oQt1R2PbE0jzz\n1Lc+ODces+FtHI+OeEx+JOnBFpd5VNLjhc9XyL+4jW6y/3MkrV+Y9qa4Lx8uTJskr5M75A2KCyUd\nVlrXAepnTJIo5+XrpFPS45LuLEz7ozwe6Spto0exXlH78cjHWzzOF0h6vsn0S+XxyqaJZSdJmlpT\n9la5j6qmvpT0PUl/aueai8vNkHRVadp+8Xg80WT+O1WIp6r+DXZL/aIQwm2NDyGEpZKmyFuVGw6R\ntwjMM3/03hVbm38jaVcrPRKv8Moji+B91p6SV+J/KczzePy7Rfy7l7zFodzCeKU8wNk/ft5bfjMq\nv9R2Zenz3vKWqMtL+/Fs3PZ+LexHO24OIfQUPj8c/zaObav716o3yJ92XF2a/tPEMuVv2I+o77kf\nTK2UtbL7JK0fH3++K9UyUnKrpL1jy9Fu8m/o35RXWvvGeQ6Ut8q9wsxOMn9cvUB+Dv4WkxqPKWdJ\nekbSN8zsE2a2fYv5kZkdZGa3mdmsuO4eSTsU1p1yrLwCu1SSQgi98nLzlvIj1OiG0udy2WvYVB7Q\nj5B/2Xy6Jh+HyG82Py1dQzfF9FauoRtCCAsbH0IIUyXdq5WtiK1eF/vJg6/yY93L4vL9aXGW/JiU\n3+vYUd7aeVE89i0bpDJ1n6QJZnaamb3JSl06mgner/wWSWea2TvNR614n7y1V/JjV5y/Rx5gbNrO\n/jWY2QfM7PdmNle+nwvlQUuz8lmudx5W37K5t6RnQ+FdsHjc/6c/eWtH8PcMHtTKVvm3yVvWb5HX\nGZKXvS4V6g8z28S8W8pf5ddIj/wJwWhJ4+Js/arPzGxIPPePm9niuO5Gy+eOhb/9KqPtaqFMt+qH\n8rrnQ3G9w+RPJC8NISyuycP2ZnaFmT0vPx498ndIavNgZm+WtJP8iVHDJfKnSx9sssg9IYQ5hc9V\n9WmXvJ76sKSDQgipFmxpcGKS8nWyQh4D7GlmHWa2jvyl1qtC4X2BGHv9Tivr08GORxqa1aeSvzh7\nXQhhWjsra/E+Wldf3idpt9hF5yAzG9Hi5r8r6Ugz+7SZjTHvLn6BPP5sds29pBbq08EO6uc0mbZU\nXrgbxskfS/WU/p0T0zfox3aWVUxTYduNRyF9HpPGgjmrkL6JpDmlAFqSppc+NyrWW7TqvrxBre1H\nO2aXPjcee7e7f63aJP6dUZpePg51eWznEWo7WilrfYQQbpc/Mt9C3lXopdg37o0127pN/iRgH/mN\n+MEQwnR5AHug+bsN4+TBvyTvdy/vr36L/BHjnvKKTo08Bv/6fbC85ePrkqaY9wM8KZUZ8+G/bpC3\nTHwsrvfN8uChleN9gvzG+ecYnI2WP42Qmj8yrit7DW+Ut+heFY9PnXHyin+h+l4/jTLXyjXUbDvT\n5Y9VpdavizHyVs/y49AXS+tp1zCtPF4Njf1qawjgQSxTn5E/yv+o/IY0w7wPe93NaIK8RfJG+fU3\nSSu7uTTrfrJYUn/61L9b/g7CY/KA5i3y8v2SmpfvZuWz2F9+E1WXk9XhNq0M4Btf/m+TtJGZ7Ryn\nTQshPCG90hXsl/KnR1+RfxF4s1Z2vWmc6/7WZ1+Xt2pfJu/as6dWdoNoHN9+ldF2tVKmWxUDumsl\nNbrMHCW/bi+sycNIeU+BXeVd1faVH++L1dp7FyfEv78q1Kf3yctrbX0aG6SkVfd3lPz83C3vWlJn\nMGKSqutkiHwElvXlT3GaXe8vqm99qvJ8A4hHGprVp5LvW7v1aav30br68lJ5F6S3yBunZ5vZNVY/\nlPY58ifB35Efk3sVe6xoAPXpgMam7qdZ8laBsyvS2/qm1YbGhbSx/LGrJH9RT14gGukvyFs/ukuB\n/Ual9c2KfycU11cwf6AZblOr+7ck/i2+ayCtesE3CtU49d2/8nHISgjhp/KW4ZHyx5dnS7rRzDZP\ntEg9LO/m8TZ5v9xG8H6rvK/ds/Ivkb8rLHO0pN+GED7fmBD7/ZXz84yk483M5DeVT0s638ymhhDK\nL9E0vF/eqnBEsYya99edm9h9xdaAxgvWzb4YHWdmX+5n69yN8grxbDNbEkJIvqQkv4aWaOXTjrJW\n6oJm5XEjSY2REVq9LmZLGmNmQ0qB/caF9P6YJb8RFjX617f1MqAGqUyFEBbIg/FTzWwreVe+b8jL\n8BerNh58tIkDzF9WGyPvYtUIIJuNbz1GK/e1HUdLeir0HRWiW/0PBF7QyjJftLrqstsknWL+ktsu\nkm4NIbxoZo/J65S3qe9Tvm3lXTKOCyG80tIZv+z00c/67Gh563XxRf+RpXn6W0Yblmjl8I5F5XPY\nUpluw/nyd2r2kPd9vjPUj160t/ypxL4hhFfKsbXw2x3m72t8KH58sMksY81s+xDCky3lvq/Z8qeq\n10n6iZkdE9Kj6QxGTFJVny6Tf0kZLu8e0uzdlo3Vtz5tTEvVu+2aJe/qUzZT7ZfVlu6jdfVlbEi5\nUNKFcdl3yLvnXiUP9JuK95kTzeyL8qc0z8nP0Ux5K35ZS/XpmvhF2RvlN4I/hxD+2ORfs29hg+Fe\n+Ukovwz4QfmXm8nx8z3yrgnvL81XXu5u+QnYrmI/nmgzf439brtlK2p1/6bHbZVfxDis9PlheQvq\nUaXp5c/taHcfl7Uxb1tCCAtCCNfJL8ZNlGjFiBftZHkL6L7qG9TvLn9h+w8hhEWFxUbIW0iKPpLa\nRgjhAfk7C9Kq56dohPwRXWhMMP8BmFa6Op0Ql3u/vIWw+O8b8la/ypeN64QQzpH39f2OmZ1SM3tj\n5JT1Kq6hVoL6Q+MjYUmvjKiwl/w6llq/Lm6X14fl8n1MXL6xvnbL8OPyl/CKpsj71n48Bt6tGvQy\nFUL4awjh2/LrPVXmistMCyE8Ig/cTpbv4+TiPOYvtA6T909t1wj5zbboOHm93B/3SNrCCqNaxNbw\nVUb1aFG7ZeB2+fV6lvym/Eicfqu8dXo39Q3qGy2AxUCjW14Wm2qnPlNr5ajVMlpVR/9V0g5WGKjC\nfHzx8suabZXpOiGEW+Xl8VxJb1X9C7KNPEh9j/f68pcn67xLHmydqVXr00ad0+8x60MIk+WjvRwq\n6YqaLxqDEZOUr5NOeZ34hxBCb+zq+L+Sjip2Q4nB7j5aWQ+0Wu/2pz7doslxuEnSu8xskybLVGn7\nPlpXX4YQ5oQQrpJ37Wu1Pp0bQngodtX7mPzp0MVNZh2vFurTNdFSf7r8UdId5r8INlXekvV6SduE\nED76amw0hDDbzL4t/7a1UP7YZSf54827FPtlhhBuNv9VtQvNhx16Ul4QX19a38tm9i+Svm9mY+X9\n/OfJvy3uL39JaJVhlxIarQmfMrNL5BXMQ026Awx0/4KZXSXpY2Y2RV5IDpO38hTXN8fMviPpNDOb\nL3+k9w/yQic17/M12Pv4qKTDzKzxuH9au33miszsLHmrw23yVuDNJX1W/oJ23Xj2t0n6vrwSaPQ/\nvV9eiR4ov2EX3Sjpi+ajFvxB3hrX5xdF42Py78q/0T8lD1omyAOaW1XtRnkwNcnM/kveB/DLWtk6\n3VQMDD4kHxu3/AMXMrMH4nqPl4960S8hhHPNbIWk88ysI1aCzeabbGZXyFsaz5Ufp175y1OHyltB\nptRsbrGkm8zsHHlleKakl+UjFrR8Xciv37sk/SBez3+Oefi4pK+HlaPXtFuG75B0cjwOvTFPwfyX\nWK+RdKuZ/UDeCraTpHEhhDMq1jUoZcrM7pF373hY/uh5f3mL/iUV222s+yR5IP8XeQvcCfIXLN/e\npFW40UJ1R2H5reOyZ4YQJiY2daOkw83sPHkr5Zvkj8CTT6ESLpF3q7gmHrsZ8i4arby/1UxbZSDe\nK/4kH2Hm6thIIHmd8qn4/+L1/pg8KP5qvI565CPF9TGA+uxGSSeY2cPyMnKEPCAr5rnVMlpVR18p\n6ZOSLjYfwnK8/MvlvCZ5SZbpfrhAfg20+oNvd8vrjO+b2Rnyd8n+LS6/Xs2yJ8ivoW/FFt0+YsPG\nsWZ2euG8tyWEcKf5iDO/lnSVmR0dVu0ePFgxyfS4jTPk5/sk+f2l2H3vy/J68zrzX44eKa9358lb\nqNupd6fLW9+PNrOH5A2JfwkhzFJzd8RtvVE+amLDGfL6+m4z+5q8XG8m6ZAQwrEV62rpPlpXX5rZ\nD+VxwD3yumUHeSPETUows4PlceUj8gaQd8h/1+Mzwd8NK847Oq73W6l1Shr00W+eazJ9slYdPWNz\neV+i5+Xf5l6Q9yU6tmb7E9Rk1IG4jbtK07ZW6a1qeV+wU+SBbGO735c0qrTsWPnb6/PlN5LGkI6v\nvGlemPdQeaX6sqRF8i8BF0vauXTcJrVwfM+Ix6Tx7XHrOH2VEQbUZBSbNvZvtPylnpnyx2A/kAf2\nffZPHhB8Vd5XbnE8zvvE+T5XmG9inNZV2s4kld42r9rHiuPxVnmrwBIVRjpotaxp1dFvDpP3eXtB\n3kLwrHwUiso35gvr2imuqzxCzLUV5WK4/ObyUixH18lvbMX9GCevGKbEsjNb3qr3zhby8xl5gLRY\n3s/voPL+N1nm8Lj94xLzXC6vuEaqYmQClUZdqKob5AFLr6T/VywnpXk65MNkPhjP87z4/2/KW/BT\nxyDE8nma/NHlEvkXrt1K87V6XYySj2TwQpxvSlzOBlCGG+Vm/yZpjW4XC+K/B1UYQUqlemOwypS8\ni8b98VgvlN+sPttCmft0PIZL4nqvkbRLxbw/kvTH0rRdYl6bjvJSKhNfkQeqi2L+d29yPCao+f2g\nWTnbRh5YLIrH77vy7hnJ89esXmm3DBSOeZ9918qRcaY2mX83efCzSF62z5J/wRxwfSYfIelKeRA+\nR37Nv1nNR3+qK6NN6+iYdqL8frhYHjjv0eQc1pbpxDntM09h+iYx7Zy6Ml3az/tjXp+WfzlaZZul\nZcbK64kfJ+ZpjLx0QOGaXiWGarK/k1S6x8m7Cc2TDxc9RE3q4ThfbUySKOd3yUcOfCSWqSckfbDJ\nvIfIg9jFMU/XStqxNE+r9e7h8i+HjeEcJyTy2Cm/7s5okratPG6bGcvj0yqMWqPm8UjtfVQ19aX8\ni91keUC/NK7vvPJ+Nsnv/nGb8+N6fyfp3RXzHhP3aYPUOkMIfrMCWmVmR8rfht8vhHBn3fzAa535\nj/A8FUL4+JrOy+pgPurIC5K+EEL4cWH6J+VfwrYKfbuqAYPGzD4h74a0Qwjhqbr5kRfzHzg7Rn5+\nXxMBrJn9WtLMEMJxtfO+Ro4J+sHM3iJvDfq9/FviHvLH2E/Ihyyk8AA1zOyt8u5r24X8f9q8lpl9\nTv4YeZdQeLHPzC6Xv0v1tTWWOay1zEcS2lYe0N8bQjiiZhFkyMzWk3evOSn4i+JrNfNfSP+9vD6t\n/ZK6JvrUIx8L5GPbfkreNWGG/AWQUwnogdaEEH4X+9ZupZr3HtYSS+WP0Pu87BpCqHzRExgE58u7\nh94t7yqGtVAIYZ6ZHaf+j4aVm43l9WlLT51oqQcAAAAytyaGtAQAAAAwiOh+A6BtB3ccxSM+4FV2\nc+/V7fyOAYDXOFrqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIXNeazgAA4LXNutK3\norBiRSIxDGjbHSNGJNN7Fy1Kptvuu1Smhfv/3K88AUB/0FIPAAAAZI6gHgAAAMgcQT0AAACQOYJ6\nAAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJljnHoAWBuY1aTXtOH0JsaCl9S5/TaVaTMO2Ci57Lir\nH02mr5g7L5n+aqobh77OMx8YVZk2/v4BrRoA2kJLPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDM\nEdQDAAAAmSOoBwAAADJHUA8AAABkjnHqAeC1oGYc+jovHlQ9Fv2cN/Ukl124yS7J9C3PurtfeRoM\nXVttkUx//r3p9O75g5kbAOg/WuoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0A\nAACQOYJ6AAAAIHOMUw8AawHr6k6mh55lyfSeg/ZIps/bMVSmdb+U3vbSbZek02/aOpn+4tx1K9NG\nDEvv15zn1kumd6+/NJm+3rozk+nzpqXXDwCrCy31AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5xqkHgBx0dCaT68ah7xydHk99ypHp9VtiOPcVQ6vHsJek4SPT\nY8GbpZfv6KhOr1t2ux1fSKY/M23DZPqceesk09WV3j4ArC601AMAAACZI6gHAAAAMkdQDwAAAGSO\noB4AAADIHEE9AAAAkDmCegAAACBzDGkJ4LXFrDot1AxPWDOspEJvTXp6/dZVXSWH5cvT667x9Od3\nTqYPnZFevnNJ9XFbtGU6byOG9iTTn3tp/WR6R2f1ce3tTbdNzV40PJneuyx9Toeumx6Os3tI9b7X\nDSO6Yu68ZDoAtIOWegAAACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4A\nAADIHOPUA8hLapx5qX6s+bpO3uh9AAAIJklEQVT0lN4V/V9W6XHopYGNRT/jn/dJpi8blx4rfvRD\n3cn03kTWu0YtSy47e846yfQwZ0g6fYPq9Xd3pc9Jd+fAzllHR7q8jBxePY59z67bpNd9+/39yhMA\nNENLPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJHUA8AAABkjnHqAeRl\nIOPMS1JHZ2WSdVanSVJYnh7rvS5vAxmH/oXPp8ehn79det3Dnk+PQ790THr7IfHzAMOGp8epX/DC\nyPTKR6bHkg+9iXUvHppcdvjQdN5U+7MHNTMk/PWQYcn08bf3e9UAsApa6gEAAIDMEdQDAAAAmSOo\nBwAAADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgc4xTD2D1S4wVXys1aLkkWU1bRW/1mOgh\nkTYYOrcbn0yfevQmlWkrhqfHwB/5dLo6X75OMlkrhqbXv2xM9bEZsiy9basZ671reM34/wkrVqTP\n95Jl6fH5tSKdt6WL0sv39lYvv9Wez6W3DQCDiJZ6AAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJkj\nqAcAAAAyR1APAAAAZI6gHgAAAMgc49QDaJt1pauOsHx5egWv5njwof/r7tpi82T64h03SqbP3mlo\nevmN02PBdyyrTuuenx5Pfdl66XUvXzedHrrT6RpS/fsAITFWuyStt/m8ZPrQ7nR5mT2vepD9FcvT\nv3lQlzd11ByXxTXj/3dWLz9zQfrHAcbuvWsyHQDaQUs9AAAAkDmCegAAACBzBPUAAABA5gjqAQAA\ngMwR1AMAAACZI6gHAAAAMseQlgDaVjtkZY2urbesTFu8w7jksj0j00MYLlsn3VaxfHh12vytk4tq\nxfCaISl70uldC9PDK4ZE1peNSq97xbB0utWNMjq8eshKSbLF1ce9Z1n6mC8bkt743OnrJtO7Ry2t\nTBs2PDEOqKSFcxMnXFL3Ounlx45ekEyft6h6/TttOD257HPjtk+mA0A7aKkHAAAAMkdQDwAAAGSO\noB4AAADIHEE9AAAAkDmCegAAACBzBPUAAABA5gjqAQAAgMwxTj2AQbfgqLek0zetHvO8o2Y89SUb\nptNDZ8147Suqx4rvWF6z7IL0OPPL10kvv2SjFcl0pVY/JD2OfOfcdHWeGgNfkjpHpg98R0f19nsW\ndSeXXbxwaHrbL6d/e2Do2IH9LkJKz9xhyfQZvekDlxonf/SQxcllp9X8rgEAtIOWegAAACBzBPUA\nAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHOPUA2jb/A/ulUxffvysZPqC\nJzeoTBs2Pd3W0L0gmazQkR5LvqN6WHGFzvSyyXHkJXXXjGPf253eN0sMRd+zbs2Y5jV5WzEsvXxI\nD4Mv66pefsy4l5PL7rTBjPTKt0snj+peUpnWZTVj/2+RTn5xyahk+rih6QI3e9mIyrRpi9ZLLjt8\n2sJkOgC0g5Z6AAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgc\n49QDaNvoyc8k06fsuU0yfdzOL1WmbfXmOf3KU8OS5d3J9OmLRlamzZyzbnLZ5XOHJNO7X+5Mpvd2\n14wVnxhrPozpSS672zZ/S6aPHZYeb32b4TOT6StCdRvQaRs+kVz27FnbJ9Nvmr5TMv2cHa6rTBvT\nOTS57IpQM75/jUUhfdx/s2jLyrSnlmyUXPbO0Zv1K08A0Awt9QAAAEDmCOoBAACAzBHUAwAAAJkj\nqAcAAAAyR1APAAAAZI6gHgAAAMichQEO9wXgtefgjqNetYqjc/31k+kvv32HZPqcHdLDSnbtWT1k\n5rZj0sM6brlOerjNzYam0zuVPmwrVD2mZU9vegTiRxdskky/55nxyfT1bxuWTB975UOVab0LFyaX\nHaje325RmXbg2CnJZR+anx428sWFo5LpsxaOSKYvX15d3nqWpc/ZDp9KDw174+yLEoOcAkBftNQD\nAAAAmSOoBwAAADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYYpx5A217NceoB\nuJt7r2acegAto6UeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmbMQwprO\nAwAAAIABoKUeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADL3\n/wEBR2EX21X4vwAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "\u003cFigure size 432x288 with 1 Axes\u003e"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "!pip install -q requests\n",
-        "\n",
-        "import requests\n",
-        "headers = {\"content-type\": \"application/json\"}\n",
-        "json_response = requests.post('http://localhost:8501/v1/models/fashion_model:predict', data=data, headers=headers)\n",
-        "predictions = json.loads(json_response.text)['predictions']\n",
-        "\n",
-        "show(0, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(\n",
-        "  class_names[np.argmax(predictions[0])], test_labels[0], class_names[np.argmax(predictions[0])], test_labels[0]))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "YJH8LtM4XELp"
-      },
-      "source": [
-        "#### A particular version of the servable\n",
-        "\n",
-        "Now let's specify a particular version of our servable.  Since we only have one, let's select version 1.  We'll also look at all three results."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 920
-        },
-        "colab_type": "code",
-        "id": "zRftRxeR1tZx",
-        "outputId": "c04d6187-9f67-40df-b43b-08819bc20110"
-      },
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAvUAAAEtCAYAAACIx59SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3Xm8HUWd9/Hv7y7ZCCEEEvYlrAIq\nMCgCDpuC8oALIijKFleGcYNH53HAEQLjhijojIIoMoEBgUFRFBABISwCiiOrLGExCgQSspI9N7n1\n/PGrQ/p2Tlefc+8lscLn/XrldXO6eqnurq7+nerqOhZCEAAAAIB8dazpDAAAAAAYGIJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQuWRQb2ahhX9T\n47yTzOy51ZLrNcDMDoj7e0A/lp1qZpNq5tnNzCaa2ZgmacHMvtLudleXmO9gZl0181XuY2K9b2sy\nvaWyZmYTYr62bmV7rzVm9tZ4fGbUnbsW1jXVzC6rmWeimYWBbKe0vtV+XbRbhuMy65jZNDM7ss1t\n1dYbq5OZdZrZl83sL2a21MyeNLOTm8z3CzM7f03ksR2t1g9mNtnMJhc+t10G1lZVdfSrtJ1QmhbM\nbOKrve1WmdlwM5sX87XrANdVe48bSExSsb7JZnbXYKyrjW2Ojuf2H9pc7pdm9r02l5nUiFf/XpjZ\nkWZ2v5ktMbMXzex7ZrZuaZ6TzexhM2upEb5upr1L/16U9JvStPe1uyNoajdJZ0ham28U7e7jGZIG\ncsO4Xl5GXxjAOtZmJ8S/YyX9nzWZkYz05zr9vKSZkn72quRo9Tlf0r9J+rGkd0m6WtK3zOzfSvOd\nKekTZrbDas7fq+Wf47+G10Jd3aqB1tFrk/dJGhX/f/yazEhGRsvLUMtBvZntJ+kdkr7+amVqdTCz\nD8nr0AclvVfSREkfknRNadYL5ffoE9SCZOtcCOHeUiaWSppZng78PQohvCTppTWdj79HZjZM0gck\nTZa0p7zC+NWazNPayMyGSvqMpIkhhEF7SrG6mdmWkj4u6d9DCI2nIzeb2ShJXzKz80MIsyUphHC/\nmd0v6WT1DYazFEJ4dE3nAVk4QdJsSU9KOsbMvhhCWL6G87Q2+hdJvwohPL+mMzJA/y7p9hDChMYE\nM5sp6WozOzSEcIMkhRAWm9mlkr4g6b/qVjroferNbHczu9PMFsXHs//UZJ7xZna5mb0UH+M+YGa1\nLf6Fx6X7mNn/mNl8M5tuZqfG9EPio4yFZnafme1RWt7M7BQze8LMlpnZC/Fxx6jSfGPN7Cdm9rKZ\nzY0HdHRFno4ws3vj/s41s6vjDbCdYzZBK0/Wk7aya9PWpfk+Gx99zzez281sl3b3z8y2juueUFp2\nlUd55o/bvxLXs8jMbjWz1yUee443s+vNbIGZ/dXMTm88Mmp1HwvbbgRAXyrMO7E0T7KsWZPH62b2\n4VhGFsTz+7CZndgsD3H+PeI6/rEw7TNW6vphZtvHaYfFz2PN7EIzmxLz92wsU5uV1r+Dmf3cvAvM\nEjP7WyxDdV2ZzjSzP8V9mBnPzV6pZUoOl7SevPX155LebWbrl7bRKCsnmtlZsRzMNbNfmdnmNfnr\nNLMfxvwdlJivy8xONbPHzeuCaWb2bfMvHa0wM/uSmT1nZovN7A4z2608Q911EecbFadPi3l5Ii5n\nMX2C2ijD0eHyFt2rmmR8fzO72fyR/UIze9DMPpbY0UEpU2Y20sz+M05fGue7xcxel9iPPeX3i1+X\npt8oaZhWfdJzpTywGZ5YZ9V+DjOz88zskXidvhjL3OtK8zWu773M7ycvx3P3H+XyY2bbmNdNi8zv\nO9+VNLTF/LzS/abdMhCP81Olaf8bl9muMO2r5veyRll7h5ndYCvr3kfM7PNm1llaV1v1WVxmOzP7\nb/N7yWIze8bMLrDS9R/nrSyjlqijrdRlqbC+Pl3KWi3Tdczs/VbR7SXmJdkQaWZHm9ehL8Vjeb+Z\ntdQyGpffTNJB8nJ/kaSNJL2zyXxTzeyyuL3H4jH9oxXuL4ltfMS8/vrXmvkGFJOY2XtjeVtqXi9/\noMk8h5jZPbH8zDPvcrdjaR6zRL0br5m/xNl/VChDExJ521Re1/ykSdr4WK5fjHl/Jl7nqX0902ru\no9ZCfWlmn4vnc7GZzYnntDKmNbMNJW2r5vWptGoPmCsl7Wxm+6T2Rxr8oH6U/GBfJn+ccJ+kC8zs\nwMYMZraFpN9L2lXSKZLeI+lPkn5mZu9pcTuXSHpYvuO/kPQ1Mztb0jmSzpb0QUnrSPqFmQ0pLPdV\nSedKulnSuyV9U9IESddb3/5K18gfL58W17Vc0n+WM2EeRP5M0qOSjpR0oqTXS7rdSv2ialwvqREg\nHqWVXZuK3UaOlXSYpM9J+oikLSVda32Dv1b3r1Vnyo/BpfLzeZOkXybm/7mkW+WBzC/i8o2KsZV9\nLNo7/p1UmPeiQnptWSuLFedlkm6PeTxS0o9U8YUtul/SXPV9xPw2SYubTFsu6Y74eYykJZJOlXSI\nvHVhe0m/s74Bx/WSNpN0kvwm8K+Slqr+2txM0nnyfZ8gaYakO8zsDTXLNZwQ9+uX8vM7RNLRFfOe\nKmk7SR+Vl7+95cexKfNA7mcxbweEEG5J5OMyeZeOn8jL99clfUzS5S3ux/GSDpX0aflx2EjSb61v\nf+fa6yL+vV5+bX07zndjXO6rcT3tlmHJz/1jIYSZxYlm9l5Jv5Uf9xPlx+piSVsl1jVYZeo8+VOa\nMyUdHLf/gNLXwYr4d1lp+tL49/Wl6XfIr9G91b6hktaVH+vD5PsxTNI9ZrZxk/n/W9LTko6QdIGk\nT8mPkSQp3gNulrR7TJsgaby83LWr3TJwm6RtG0GVeeC8m5rXH5MLT3O2kZePj8qPwSXyx/ONstjf\n+kySNpX0rPxJyjslnSXp7ZJuKM7UQhmtq6Nb0WqZrnOtpGkxn8V9eJ2k/SX9oGb5bST9VNIx8mP5\nK0kXWZNGyQrHyq+vS+VdKpaougvOvvIueV+Wxxedkq4zs8rzZmanybthfDKE8I3EfAONSbaT9B/y\nOvAISU9JurIUwx0ivw4WxPyfFLdxV+nLWF29+0LchuT1fqMMXZ/I38Hy43Vnab/HS/qDpP0knS4v\nS2dK2rBmf1u5jybrSzM7Rn68rpDfi46Rl6VU97yq+rRHUtCq9ekDkubH/UoLIbT8T9JUSZdVpE2K\nmTmwMG2opFmSfliY9mN5l4gNSsvfLOmBmu1PiNs4vTCtS34ieiSNL0x/T5x3//h5jPwGNKm0zmPj\nfO+Jnw+On48uzffrOP2A+HmkpHmSLi7NNz6eqJNLx21Si/u2XZO0IH+k112YdmScvk+b+7d1/Dyh\nNN8Bpf1bX37Rnl+a7//G+SYWpk2M0z5SmvdhSTe1so8VxyRI+soAylpje1vHz1+QNLudMh+Xu1bS\nbfH/HfJHrN+OZW5knH6lpHsT6+iUtEXMz/vitA2L56a//+K6uyQ9Iem7Lcy/ifwLyIWFfXqunP9C\nWZlcmv6FOH3TUhm/LJabu+RB1ral5SZKCoXP+8b1HF+a75g4fbcWysdMSeuU8twj7yYitX5dvEvN\nr4uL4vIb9rMMPybp8tI0i8frj5I6EstOLed7MMqUpEckndtmGds5rvek0vTT4/QLS9O75Teu0wZS\ntgv7OUJ+UzulML1xLs4szX+dpCmFz5+I8+1VmNYh6c8q1A+J7U8uXgPtlIFY/nolnRA/Hy5pjvw+\neEWcNjKW2X+qWIfJr+8vxWU7Ctdh2/VZk/V3SfrHuE+7t1lGq+roPsdsIGU6Tp+oQt1R2PbE0jzz\n1Lc+ODces+FtHI+OeEx+JOnBFpd5VNLjhc9XyL+4jW6y/3MkrV+Y9qa4Lx8uTJskr5M75A2KCyUd\nVlrXAepnTJIo5+XrpFPS45LuLEz7ozwe6Spto0exXlH78cjHWzzOF0h6vsn0S+XxyqaJZSdJmlpT\n9la5j6qmvpT0PUl/aueai8vNkHRVadp+8Xg80WT+O1WIp6r+DXZL/aIQwm2NDyGEpZKmyFuVGw6R\ntwjMM3/03hVbm38jaVcrPRKv8Moji+B91p6SV+J/KczzePy7Rfy7l7zFodzCeKU8wNk/ft5bfjMq\nv9R2Zenz3vKWqMtL+/Fs3PZ+LexHO24OIfQUPj8c/zaObav716o3yJ92XF2a/tPEMuVv2I+o77kf\nTK2UtbL7JK0fH3++K9UyUnKrpL1jy9Fu8m/o35RXWvvGeQ6Ut8q9wsxOMn9cvUB+Dv4WkxqPKWdJ\nekbSN8zsE2a2fYv5kZkdZGa3mdmsuO4eSTsU1p1yrLwCu1SSQgi98nLzlvIj1OiG0udy2WvYVB7Q\nj5B/2Xy6Jh+HyG82Py1dQzfF9FauoRtCCAsbH0IIUyXdq5WtiK1eF/vJg6/yY93L4vL9aXGW/JiU\n3+vYUd7aeVE89i0bpDJ1n6QJZnaamb3JSl06mgner/wWSWea2TvNR614n7y1V/JjV5y/Rx5gbNrO\n/jWY2QfM7PdmNle+nwvlQUuz8lmudx5W37K5t6RnQ+FdsHjc/6c/eWtH8PcMHtTKVvm3yVvWb5HX\nGZKXvS4V6g8z28S8W8pf5ddIj/wJwWhJ4+Js/arPzGxIPPePm9niuO5Gy+eOhb/9KqPtaqFMt+qH\n8rrnQ3G9w+RPJC8NISyuycP2ZnaFmT0vPx498ndIavNgZm+WtJP8iVHDJfKnSx9sssg9IYQ5hc9V\n9WmXvJ76sKSDQgipFmxpcGKS8nWyQh4D7GlmHWa2jvyl1qtC4X2BGHv9Tivr08GORxqa1aeSvzh7\nXQhhWjsra/E+Wldf3idpt9hF5yAzG9Hi5r8r6Ugz+7SZjTHvLn6BPP5sds29pBbq08EO6uc0mbZU\nXrgbxskfS/WU/p0T0zfox3aWVUxTYduNRyF9HpPGgjmrkL6JpDmlAFqSppc+NyrWW7TqvrxBre1H\nO2aXPjcee7e7f63aJP6dUZpePg51eWznEWo7WilrfYQQbpc/Mt9C3lXopdg37o0127pN/iRgH/mN\n+MEQwnR5AHug+bsN4+TBvyTvdy/vr36L/BHjnvKKTo08Bv/6fbC85ePrkqaY9wM8KZUZ8+G/bpC3\nTHwsrvfN8uChleN9gvzG+ecYnI2WP42Qmj8yrit7DW+Ut+heFY9PnXHyin+h+l4/jTLXyjXUbDvT\n5Y9VpdavizHyVs/y49AXS+tp1zCtPF4Njf1qawjgQSxTn5E/yv+o/IY0w7wPe93NaIK8RfJG+fU3\nSSu7uTTrfrJYUn/61L9b/g7CY/KA5i3y8v2SmpfvZuWz2F9+E1WXk9XhNq0M4Btf/m+TtJGZ7Ryn\nTQshPCG90hXsl/KnR1+RfxF4s1Z2vWmc6/7WZ1+Xt2pfJu/as6dWdoNoHN9+ldF2tVKmWxUDumsl\nNbrMHCW/bi+sycNIeU+BXeVd1faVH++L1dp7FyfEv78q1Kf3yctrbX0aG6SkVfd3lPz83C3vWlJn\nMGKSqutkiHwElvXlT3GaXe8vqm99qvJ8A4hHGprVp5LvW7v1aav30br68lJ5F6S3yBunZ5vZNVY/\nlPY58ifB35Efk3sVe6xoAPXpgMam7qdZ8laBsyvS2/qm1YbGhbSx/LGrJH9RT14gGukvyFs/ukuB\n/Ual9c2KfycU11cwf6AZblOr+7ck/i2+ayCtesE3CtU49d2/8nHISgjhp/KW4ZHyx5dnS7rRzDZP\ntEg9LO/m8TZ5v9xG8H6rvK/ds/Ivkb8rLHO0pN+GED7fmBD7/ZXz84yk483M5DeVT0s638ymhhDK\nL9E0vF/eqnBEsYya99edm9h9xdaAxgvWzb4YHWdmX+5n69yN8grxbDNbEkJIvqQkv4aWaOXTjrJW\n6oJm5XEjSY2REVq9LmZLGmNmQ0qB/caF9P6YJb8RFjX617f1MqAGqUyFEBbIg/FTzWwreVe+b8jL\n8BerNh58tIkDzF9WGyPvYtUIIJuNbz1GK/e1HUdLeir0HRWiW/0PBF7QyjJftLrqstsknWL+ktsu\nkm4NIbxoZo/J65S3qe9Tvm3lXTKOCyG80tIZv+z00c/67Gh563XxRf+RpXn6W0Yblmjl8I5F5XPY\nUpluw/nyd2r2kPd9vjPUj160t/ypxL4hhFfKsbXw2x3m72t8KH58sMksY81s+xDCky3lvq/Z8qeq\n10n6iZkdE9Kj6QxGTFJVny6Tf0kZLu8e0uzdlo3Vtz5tTEvVu+2aJe/qUzZT7ZfVlu6jdfVlbEi5\nUNKFcdl3yLvnXiUP9JuK95kTzeyL8qc0z8nP0Ux5K35ZS/XpmvhF2RvlN4I/hxD+2ORfs29hg+Fe\n+Ukovwz4QfmXm8nx8z3yrgnvL81XXu5u+QnYrmI/nmgzf439brtlK2p1/6bHbZVfxDis9PlheQvq\nUaXp5c/taHcfl7Uxb1tCCAtCCNfJL8ZNlGjFiBftZHkL6L7qG9TvLn9h+w8hhEWFxUbIW0iKPpLa\nRgjhAfk7C9Kq56dohPwRXWhMMP8BmFa6Op0Ql3u/vIWw+O8b8la/ypeN64QQzpH39f2OmZ1SM3tj\n5JT1Kq6hVoL6Q+MjYUmvjKiwl/w6llq/Lm6X14fl8n1MXL6xvnbL8OPyl/CKpsj71n48Bt6tGvQy\nFUL4awjh2/LrPVXmistMCyE8Ig/cTpbv4+TiPOYvtA6T909t1wj5zbboOHm93B/3SNrCCqNaxNbw\nVUb1aFG7ZeB2+fV6lvym/Eicfqu8dXo39Q3qGy2AxUCjW14Wm2qnPlNr5ajVMlpVR/9V0g5WGKjC\nfHzx8suabZXpOiGEW+Xl8VxJb1X9C7KNPEh9j/f68pcn67xLHmydqVXr00ad0+8x60MIk+WjvRwq\n6YqaLxqDEZOUr5NOeZ34hxBCb+zq+L+Sjip2Q4nB7j5aWQ+0Wu/2pz7doslxuEnSu8xskybLVGn7\nPlpXX4YQ5oQQrpJ37Wu1Pp0bQngodtX7mPzp0MVNZh2vFurTNdFSf7r8UdId5r8INlXekvV6SduE\nED76amw0hDDbzL4t/7a1UP7YZSf54827FPtlhhBuNv9VtQvNhx16Ul4QX19a38tm9i+Svm9mY+X9\n/OfJvy3uL39JaJVhlxIarQmfMrNL5BXMQ026Awx0/4KZXSXpY2Y2RV5IDpO38hTXN8fMviPpNDOb\nL3+k9w/yQic17/M12Pv4qKTDzKzxuH9au33miszsLHmrw23yVuDNJX1W/oJ23Xj2t0n6vrwSaPQ/\nvV9eiR4ov2EX3Sjpi+ajFvxB3hrX5xdF42Py78q/0T8lD1omyAOaW1XtRnkwNcnM/kveB/DLWtk6\n3VQMDD4kHxu3/AMXMrMH4nqPl4960S8hhHPNbIWk88ysI1aCzeabbGZXyFsaz5Ufp175y1OHyltB\nptRsbrGkm8zsHHlleKakl+UjFrR8Xciv37sk/SBez3+Oefi4pK+HlaPXtFuG75B0cjwOvTFPwfyX\nWK+RdKuZ/UDeCraTpHEhhDMq1jUoZcrM7pF373hY/uh5f3mL/iUV222s+yR5IP8XeQvcCfIXLN/e\npFW40UJ1R2H5reOyZ4YQJiY2daOkw83sPHkr5Zvkj8CTT6ESLpF3q7gmHrsZ8i4arby/1UxbZSDe\nK/4kH2Hm6thIIHmd8qn4/+L1/pg8KP5qvI565CPF9TGA+uxGSSeY2cPyMnKEPCAr5rnVMlpVR18p\n6ZOSLjYfwnK8/MvlvCZ5SZbpfrhAfg20+oNvd8vrjO+b2Rnyd8n+LS6/Xs2yJ8ivoW/FFt0+YsPG\nsWZ2euG8tyWEcKf5iDO/lnSVmR0dVu0ePFgxyfS4jTPk5/sk+f2l2H3vy/J68zrzX44eKa9358lb\nqNupd6fLW9+PNrOH5A2JfwkhzFJzd8RtvVE+amLDGfL6+m4z+5q8XG8m6ZAQwrEV62rpPlpXX5rZ\nD+VxwD3yumUHeSPETUows4PlceUj8gaQd8h/1+Mzwd8NK847Oq73W6l1Shr00W+eazJ9slYdPWNz\neV+i5+Xf5l6Q9yU6tmb7E9Rk1IG4jbtK07ZW6a1qeV+wU+SBbGO735c0qrTsWPnb6/PlN5LGkI6v\nvGlemPdQeaX6sqRF8i8BF0vauXTcJrVwfM+Ix6Tx7XHrOH2VEQbUZBSbNvZvtPylnpnyx2A/kAf2\nffZPHhB8Vd5XbnE8zvvE+T5XmG9inNZV2s4kld42r9rHiuPxVnmrwBIVRjpotaxp1dFvDpP3eXtB\n3kLwrHwUiso35gvr2imuqzxCzLUV5WK4/ObyUixH18lvbMX9GCevGKbEsjNb3qr3zhby8xl5gLRY\n3s/voPL+N1nm8Lj94xLzXC6vuEaqYmQClUZdqKob5AFLr6T/VywnpXk65MNkPhjP87z4/2/KW/BT\nxyDE8nma/NHlEvkXrt1K87V6XYySj2TwQpxvSlzOBlCGG+Vm/yZpjW4XC+K/B1UYQUqlemOwypS8\ni8b98VgvlN+sPttCmft0PIZL4nqvkbRLxbw/kvTH0rRdYl6bjvJSKhNfkQeqi2L+d29yPCao+f2g\nWTnbRh5YLIrH77vy7hnJ89esXmm3DBSOeZ9918qRcaY2mX83efCzSF62z5J/wRxwfSYfIelKeRA+\nR37Nv1nNR3+qK6NN6+iYdqL8frhYHjjv0eQc1pbpxDntM09h+iYx7Zy6Ml3az/tjXp+WfzlaZZul\nZcbK64kfJ+ZpjLx0QOGaXiWGarK/k1S6x8m7Cc2TDxc9RE3q4ThfbUySKOd3yUcOfCSWqSckfbDJ\nvIfIg9jFMU/XStqxNE+r9e7h8i+HjeEcJyTy2Cm/7s5okratPG6bGcvj0yqMWqPm8UjtfVQ19aX8\ni91keUC/NK7vvPJ+Nsnv/nGb8+N6fyfp3RXzHhP3aYPUOkMIfrMCWmVmR8rfht8vhHBn3fzAa535\nj/A8FUL4+JrOy+pgPurIC5K+EEL4cWH6J+VfwrYKfbuqAYPGzD4h74a0Qwjhqbr5kRfzHzg7Rn5+\nXxMBrJn9WtLMEMJxtfO+Ro4J+sHM3iJvDfq9/FviHvLH2E/Ihyyk8AA1zOyt8u5r24X8f9q8lpl9\nTv4YeZdQeLHPzC6Xv0v1tTWWOay1zEcS2lYe0N8bQjiiZhFkyMzWk3evOSn4i+JrNfNfSP+9vD6t\n/ZK6JvrUIx8L5GPbfkreNWGG/AWQUwnogdaEEH4X+9ZupZr3HtYSS+WP0Pu87BpCqHzRExgE58u7\nh94t7yqGtVAIYZ6ZHaf+j4aVm43l9WlLT51oqQcAAAAytyaGtAQAAAAwiOh+A6BtB3ccxSM+4FV2\nc+/V7fyOAYDXOFrqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIXNeazgAA4LXNutK3\norBiRSIxDGjbHSNGJNN7Fy1Kptvuu1Smhfv/3K88AUB/0FIPAAAAZI6gHgAAAMgcQT0AAACQOYJ6\nAAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJljnHoAWBuY1aTXtOH0JsaCl9S5/TaVaTMO2Ci57Lir\nH02mr5g7L5n+aqobh77OMx8YVZk2/v4BrRoA2kJLPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDM\nEdQDAAAAmSOoBwAAADJHUA8AAABkjnHqAeC1oGYc+jovHlQ9Fv2cN/Ukl124yS7J9C3PurtfeRoM\nXVttkUx//r3p9O75g5kbAOg/WuoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0A\nAACQOYJ6AAAAIHOMUw8AawHr6k6mh55lyfSeg/ZIps/bMVSmdb+U3vbSbZek02/aOpn+4tx1K9NG\nDEvv15zn1kumd6+/NJm+3rozk+nzpqXXDwCrCy31AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5xqkHgBx0dCaT68ah7xydHk99ypHp9VtiOPcVQ6vHsJek4SPT\nY8GbpZfv6KhOr1t2ux1fSKY/M23DZPqceesk09WV3j4ArC601AMAAACZI6gHAAAAMkdQDwAAAGSO\noB4AAADIHEE9AAAAkDmCegAAACBzDGkJ4LXFrDot1AxPWDOspEJvTXp6/dZVXSWH5cvT667x9Od3\nTqYPnZFevnNJ9XFbtGU6byOG9iTTn3tp/WR6R2f1ce3tTbdNzV40PJneuyx9Toeumx6Os3tI9b7X\nDSO6Yu68ZDoAtIOWegAAACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4A\nAADIHOPUA8hLapx5qX6s+bpO3uh9AAAIJklEQVT0lN4V/V9W6XHopYGNRT/jn/dJpi8blx4rfvRD\n3cn03kTWu0YtSy47e846yfQwZ0g6fYPq9Xd3pc9Jd+fAzllHR7q8jBxePY59z67bpNd9+/39yhMA\nNENLPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJHUA8AAABkjnHqAeRl\nIOPMS1JHZ2WSdVanSVJYnh7rvS5vAxmH/oXPp8ehn79det3Dnk+PQ790THr7IfHzAMOGp8epX/DC\nyPTKR6bHkg+9iXUvHppcdvjQdN5U+7MHNTMk/PWQYcn08bf3e9UAsApa6gEAAIDMEdQDAAAAmSOo\nBwAAADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgc4xTD2D1S4wVXys1aLkkWU1bRW/1mOgh\nkTYYOrcbn0yfevQmlWkrhqfHwB/5dLo6X75OMlkrhqbXv2xM9bEZsiy9basZ671reM34/wkrVqTP\n95Jl6fH5tSKdt6WL0sv39lYvv9Wez6W3DQCDiJZ6AAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJkj\nqAcAAAAyR1APAAAAZI6gHgAAAMgc49QDaJt1pauOsHx5egWv5njwof/r7tpi82T64h03SqbP3mlo\nevmN02PBdyyrTuuenx5Pfdl66XUvXzedHrrT6RpS/fsAITFWuyStt/m8ZPrQ7nR5mT2vepD9FcvT\nv3lQlzd11ByXxTXj/3dWLz9zQfrHAcbuvWsyHQDaQUs9AAAAkDmCegAAACBzBPUAAABA5gjqAQAA\ngMwR1AMAAACZI6gHAAAAMseQlgDaVjtkZY2urbesTFu8w7jksj0j00MYLlsn3VaxfHh12vytk4tq\nxfCaISl70uldC9PDK4ZE1peNSq97xbB0utWNMjq8eshKSbLF1ce9Z1n6mC8bkt743OnrJtO7Ry2t\nTBs2PDEOqKSFcxMnXFL3Ounlx45ekEyft6h6/TttOD257HPjtk+mA0A7aKkHAAAAMkdQDwAAAGSO\noB4AAADIHEE9AAAAkDmCegAAACBzBPUAAABA5gjqAQAAgMwxTj2AQbfgqLek0zetHvO8o2Y89SUb\nptNDZ8147Suqx4rvWF6z7IL0OPPL10kvv2SjFcl0pVY/JD2OfOfcdHWeGgNfkjpHpg98R0f19nsW\ndSeXXbxwaHrbL6d/e2Do2IH9LkJKz9xhyfQZvekDlxonf/SQxcllp9X8rgEAtIOWegAAACBzBPUA\nAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHOPUA2jb/A/ulUxffvysZPqC\nJzeoTBs2Pd3W0L0gmazQkR5LvqN6WHGFzvSyyXHkJXXXjGPf253eN0sMRd+zbs2Y5jV5WzEsvXxI\nD4Mv66pefsy4l5PL7rTBjPTKt0snj+peUpnWZTVj/2+RTn5xyahk+rih6QI3e9mIyrRpi9ZLLjt8\n2sJkOgC0g5Z6AAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgc\n49QDaNvoyc8k06fsuU0yfdzOL1WmbfXmOf3KU8OS5d3J9OmLRlamzZyzbnLZ5XOHJNO7X+5Mpvd2\n14wVnxhrPozpSS672zZ/S6aPHZYeb32b4TOT6StCdRvQaRs+kVz27FnbJ9Nvmr5TMv2cHa6rTBvT\nOTS57IpQM75/jUUhfdx/s2jLyrSnlmyUXPbO0Zv1K08A0Awt9QAAAEDmCOoBAACAzBHUAwAAAJkj\nqAcAAAAyR1APAAAAZI6gHgAAAMichQEO9wXgtefgjqNetYqjc/31k+kvv32HZPqcHdLDSnbtWT1k\n5rZj0sM6brlOerjNzYam0zuVPmwrVD2mZU9vegTiRxdskky/55nxyfT1bxuWTB975UOVab0LFyaX\nHaje325RmXbg2CnJZR+anx428sWFo5LpsxaOSKYvX15d3nqWpc/ZDp9KDw174+yLEoOcAkBftNQD\nAAAAmSOoBwAAADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYYpx5A217NceoB\nuJt7r2acegAto6UeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmbMQwprO\nAwAAAIABoKUeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADL3\n/wEBR2EX21X4vwAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "\u003cFigure size 432x288 with 1 Axes\u003e"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsoAAAEtCAYAAAARP0bnAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3XmcHVWZ//Hv051OOgshEAg7hB1H\nRURlc0BgFFCQQQYHRsFf3AaXAUfn5w8BFXR0FB1cEUVQIqKgoOIoEomQgIhIGFZBEvYtLCEhIVt3\nejm/P55zSaX61Kl7e6FZPu/Xi1e49dR+T5167qlTpy2EIAAAAADrahvtHQAAAABeiEiUAQAAgAQS\nZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAA\nACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCB\nRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkA\nAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABI\nIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAErKJspmFJv57MM4708wefV72ehSY2f7x\nePcfxLIPmtnMmnl2M7PTzWzDRCyY2Rda3e7zJe53MLMxNfNVHmNmvQcmpjdV1sxsRtyv6c1s7+Wi\ndP32mtkDZna+mW05iHUNuC7MbK6ZzR3OfX6+mNmRZvakmU1oYZlB1w0jwcxeb2bfN7O7zWyVmT1s\nZj8xs21L820W43uM1r42q5kyZWbT4/cwozBthpm9b6T374Wu1bp3iNta5373QqmHC+Wj8d8aM1tg\nZl83sw0Gsb4Bx9XMvf6Fysw+YWa3m5m1sMwL4rttMLN/MLMLzew+M1sd//2umU0rzffaWPdt3cx6\n61qU9y7994Sk35emvaPVg0HSbpJOkzTiFdkoavUYT5M0IFFuweXyMvr4ENbxUjVTfm72l3SmpMMl\nXWVm40dxn0ZV/KH3JUlfDSGsGu39GYJjJL1S0rckvVXSpyTtLukmM9uqMVMI4XFJ50r66mjs5Ah4\nXF6mLy9MmyHpZZ8o6+Vxf2nWl+Tl5C3yevB4Sb9qJUF8qTGzKZJOlfT5EEIY7f0Zgg9JmirpC5IO\nkX/Xh0u6wcwmNWYKIdwiabak/2xmpdkWwBDCDcXPZtYt6enydOCFKISwSNKi0d6PF6jHCtfxdWa2\nXH7TeKukX47aXo0gM+uQ1Ju5EfyjpOmSfvi87dTIOCOW/eeY2Z8kPSDpg5I+WwidI+lOM9sjhHDj\n87iPwy6E0C2JexPq3F+o+66J9cLpkl4r6eZR26sRZGbj4vVR5f2S1kj61fO0SyPlI6W67xozWyDp\nGkn/rHXr9nMk/drMTg4hLMytdNj7KMcm7T/GZu17zOxDiXm2jY8CF5lZt5ndama1LdOFZv59zOzn\nZrY8PiY9OcYPMbNbzGylmc0zs9eVljcz+7iZzY+PXR43s7PMbHJpvo3N7Kdm9qyZLTWzCyRNqdin\nI83shni8S83skmab84vHJen8+PGewqOh6aX5TjR/TL7czK4xs1e2enypx5NxeuoReruZfSGuZ5WZ\nXW1mu8T5Tk8cyrZmdrmZrTCzh8zss2bW1soxFrbdSGZOLcx7emmebFmz9KOxd8UysiJ+v3eY2fGp\nfYjzvy6u4+8L006wUncYM9sxTjs0ft7YzM4xf7S3ysweiWVqi9L6dzKzX5nZU2bWZf6Y/BKr78by\nOTO7OR7D0/G72Su3TI158d8d4vpnWuxWVdruoLpVmNnO8TiXmj8Su8HMDinE3xnP366JZX9nZrcV\nPo8xs5PNuxZ0m9lCMzvTzDoL8zTK+UfM7CtmtlBStyqu4+gDkmaFEJaUtj/GzE4ys7vid7TIzGaZ\n2S6Z4z0o7nfj2vmrmf2HmbWX5suWRzN7g5nNNrPF8bzdb2ZnZ45B5SQ5TntI/qNxi9L0uyTdEY+9\nZXH/LjWzR+P+zTez/7LSk4lYbq4zszfHcts4JwPqfTM7pvDd3pmap2Jf1qnbYjl9k6Q3FuqQuRXL\ntsey+enCtFfHZa4rzfuomX218Ln2WjSzSWb27Xh9d8fr/Q+5MlQ4F1fHMrcilpX/k5ivsoxapu4t\nn7PC+lL3g6bKdB0z+42Z3ZKYvq2Z9VsiZyjM02neVeKv8Xw8EdeXPY81ynVfso6zQXarMLM94ne9\nwjw3ucoK3Z3M7JPm9+upiWXvMrNfFz5PMLMzzPOANfHfUy3eZ+M8je/uSDM718wWSXqyZjc/IOnn\nIYS+0vYnmtmXzbswdMfz/Qsz2yRzvM2W2Y+Z2d/M641nzOym4rVuZgeb2fVmtiyuZ76Zfba8nqJU\n3ae13+8WpelXSnpW/tQpa7gT5cmSfirpQnnrzDxJ3zWzAxozmD/6+4uk10j6uLxZ/GZJvzCzw5vc\nzo/klfs7JF0m6b/M7Az5I8QzJB0taaKky8xsbGG5L0r6mrzJ/e2SviI/SZcXC5q8Re0wSafEdfVK\n+nZ5J+IF/QtJd0k6Sv4I51XyXzHrNXkskj8qbCRd79Tabi3FLgPHSjpU0sckvVfS1vJfQ8WEqtnj\na9bn5OfgAvn3eaWk/8nM/ytJV0s6Qv69fE5S4wJp5hiL9o7/zizMe14hXlvWysyT3Qvlvy6PkH9n\n5yqfPN0iaanW7QJyoKTViWm9kq6NnzeU1CXpZPkjoE9K2lHSn6yQ0MnPyxaSPizpYPlj8m7VX5tb\nSPq6/NhnSHpK0rVm9uqa5ao0+q8uHeTylcxsc0nXya/5f5P/sl8qL5dvjbP9RtIyeTkvLruJpIPk\nZbDhQkmfln//h8ofr71f0k8Smz9V0k6S/lVeX3RV7OM4eTeUPybCF8uvrd/Jy80H5df8ZpUHLW0n\n6Sr5Y/9D5XXW6XE9jW1my6P5o8LfS+qTf8dvlfR51TwJrDi+V0iaJulvifC18rI3GFtLulX+yPMQ\nSd+UH/P5iXm3j/GvSTpSfu1fYmY7FPbzzfLv9Z44z1fjMjsPYt8+Ir9+b9faOuQjqRljgnCt0tf5\nHmY2Me7fzvJr7+rCfM1ci1+Xl/vPyR/5Hy8/b7m6R/JydKmkd8vLyG8knZdIJnNltNW6N7cv2TLd\npO9K2s0G9o3/V0krlb6OG8ZJWk9+PIfK681OSX82s01b3I+Gkaz7dpVf3xvIy8Z75Peua8zsNXG2\nn0pql+caxWVfJ+kVinVfvNf/Xp7UflNeH5wn6TNKd5/6tiSTdJwyyaCZbSNpF5Xqvpg7zZZ0gvw+\nfJi8/l4Sj6dKbZk1s3fLu/xdJOltcd5LFbsGmdl28lzjAfl5OVxeb0zMbLfKm+K/69R9IYReSX+W\n11t5IYSm/5P0oKQLK2IzJQVJBxSmjZO0WNL3C9N+IG/ZmFpafrakW2u2PyNu47OFaWPkFVOPpG0L\n0w+P874pft5QnoDMLK3z2Djf4fHzW+LnY0rzXRGn7x8/T5Lf2H9Ymm9b+SOMfy+dt5lNHtsOiViQ\n3zg6CtOOitP3afH4psfPM0rz7V86vg0krZB0dmm+T8T5Ti9MOz1Oe29p3jskXdnMMVackyDpC0Mo\na43tTY+f/6+kJa2U+bjcryXNif/fJq8ozoxlblKcfrGkGzLraJe0Vdyfd8RpGxW/m8H+F9c9RtJ8\nSd9s8rx+MS7TKWkveSWyUtLmhXP8YGLZuZLmVpWbinn+W/4jYofSPs+XdHNh2rmSHpXUVpj273HZ\nzeLnfeP23lPar3fH6buVyvnNkqyJc7JnnP8tpekHxuknZpYdcA5KcYvn+lRJzzSOr648Snp9XO+u\nQywfY+Q366ckbZCIvz9uZ/MhbqdxnMdK6lehjo9lokfSjoVp0+Q/Ak4pTPuTPMErloG94v7Nrdl+\n4zufUdrudU3u/8flifG4+PkyeVK3UtLBcdqHVLjum70WJf1V0teGeH7b4rrPlXRbi2V0hhJ1b+qc\nDaVMx9iDKtyHNLAebpN0n6QfFObpkL8D9b0Wz0m7pAmSlkv6eJPl41/jvk+Q3+8fl7RQ0vhCmRlQ\n1uqOq2KeS+UJ+JTCtMnye8gvC9NmS/pzaXvfiOe2UR6Pi9vbrzTfqfKcY1rpu/tVk+fw6Dj/jqXp\n71PN/Sl1Dposs2epUPcnlmvkN5OHeM2sJ+lueZ0yJhH/T3njSVtuPcPdorwqhDCn8SF4n5gF8laH\nhkPkv3qXmT8uGlP4pfQaK3WDqHBFYRu9ku6VtCCE8EBhnrvjv42XV/aSNFbeglN0sfxG/Kb4eW95\n5f2LxHxFe8sL/E9Kx/FI3PZ+TRxHK2aHEHoKn++I/zbObbPH16xXy3+9XVKafmlmmctLn/+qdb/7\n4dRMWSubJ2kD87diDzN/gaEZV0vaO7YE7yZvBfqK/IfJvnGeAyTNKS5kZh82s9vMbIX8O3g4hhqt\nY4sl3S/py2b2QTPbscn9kfkj7Dlmtjiuu0fectpsy9spcZnV8l/VPZLeFmr6ag3SfvIfEfc2JgRv\nwbtI3rLUuOYvkLfOFVv1jpN0VfAXzySvP9ZIurR03V1Z2FbRZSHWiDU2j/+WH90dJK+wz21iHc8x\nH1HiHDN7KO5vj7wVbIo8QZTqy+M98pvsOWZ2rBVexGvRWZL2kXRsCOGZRLxxzJsnYllmNjk+Cr5P\nfj30SPqxPJEql+d7Qgj3ND6EEJ6SJ+9bx3W1S3qDpEtDCP2F+W6QJyAj7Wr5D8d94hO4N8nvS9dp\nbZk8UNJNIYQVjYWavBbnSZphZqeYj0rSVHcF8y5dF5nZY3G9PfIWxeK6B1VGW9Vkma4Vv9tzJB1j\nZuvHyUdI2iROr9uPfzazv5jZUvn5XilvuGq27jsn7vtKeb1xr6RDQgirmz2GFuwn6bchhOdaq0MI\nz8pbS4v35Ask7dV4uhLrtH+Rd4do9C0+RNJDkq5P1H0d8hygqNn+xrm674kQQu4p8gBNltl58rr/\n2/H6KY8ydGtc7mIzO8pKo1Y0uR9j5PeYLeQNn72J2RbJG9myL7kOd6KcqoS75ZVPwzT544ee0n+N\nRwcD+uk0sZ01FdNU2HbjRKzzuCmevMWF+GaSniklpdLAPj6NL+4PGngsr1Zzx9GKJaXPjYun1eNr\nVuOx8lOl6bm+Tql97EzNOAyaKWvrCCFcI3/0uJW8Ellk3ndsQL/Ykjnyi2kfeUJ8WwjhSfkN9ADz\nvuLTVHgca2YnSDpbXj6OlLSH1lZknXF/grxF4yZ594EF5n1QP5zbGTPbXf5jc4W8NXAveYJxW+74\nS34Yl3mtpI1CCLvG8zMSNlT6Me8T8oSq8RjvOnlCdJz0XHeB3bVut4tp8h+EK7XuNdcop+XrrtnH\ny43zVn7hZaq81bfpm2hMsv5H/qjyC/Lk6g1a+4i68f1ny2MIYZm8vC2Ul6WHzftm/lML+/JleQva\n+0IIV1bM1ji2wYx4cr68lfVb8rL8BkkfjbFyWSzXD9K61+xG8ht+qo6p62M5HG6X15UHyK+LyfKW\n+Dny69zkrXXF67zZa/EEeYL2PnmS8JR5X9vKYQhj15vZ8i5Ln5L/KH+D/NodV5i15TLaqmbLdAt+\nIG8NPi5+/pCkG4OPRpDbj7dL+pn8Cdi75E+C3iBPeJrdhy/EZXaVt/TuG0K4vcX9b1au7it2X/il\nvE5rnI+D5HVdue7bRgPzjcZLuCNR9z3W5DoktVRmL5B3m9lT/mN0iZn90uL7RLFR5WB5jvpjSU+Y\nv9fSVINfLK8/kvRmSUdkvt+m6r6W+7oNg8XyvjBnVMRHokVLWltJbyrpzsbE+KtjaiH+uLyVp6OU\nLJc7ry+O/84orq9g+VB3uEXNHl+jj2ax77ZUfZFN07rHV9mJ/8UghHCpvDVykvymd4akWWa2ZbEV\nq+QOSU/Lbw6v1dob5dXyfoePyH+Y/amwzDHyltD/aEyw0ji2cX/ul/SeeBNu9OE928weDCFcUZ4/\n+id5S8qRxTJqPhZos/3sHg8h3JSJd2lgGZG8nCxOTM9ZIi+XZZvKW8KekfyHg5ldKOnf44+F4+QJ\nSLFlZHHct32VVq4/mmlNbqxXGtj37mlJG5rZ+BYSke3l3SaOCyE894Qn3uTX3bma8hhCuFXSP8Xr\n+PXyPu8/N7PXhBD+mtsJMztV0kmSTggh/Dgza+NH9NNNHl9j/Z3yfrmnhxC+WZg+2H7yT8tv/Kk6\nZhN5a9qIieXvGvl1vlzeFfAZM7tanly9UdLGWvfJUVPXYmyBPlnSybFP6FGSviyvN06q2KW95YnR\nviGE514otIEv+g6mjDY0ez9oukw3I4Sw2Mx+Lul4M/u9/MdJMy+UHiPp3hDCjMI+dKi1hqCHmqj7\nUk+2BzO0Xq7ue66xJ4Sw0sx+Je9Cdpq8+9L9IYTiPWWxvM/uP1ds68HS58HUfcXy87T8natWNFVm\nYyPROfKnZRvIfxicKf8RtGecZ46kOebvj7xR/n7G5WY2PYRQV1d9T96l5KgQwlWZ+Zqq+0bjL/PN\nkv+SuzOEcFPiv9wQJkNxg7xSOqY0/Wj5D4a58fOf5b90y6025eWul1emO1Qcx/wW969x3IMdx7bZ\n43sybqt8ARxa+nyH/BfuO0vTy59b0eoxrmlh3paEEFaEEH4rv1g3U+YJQLyo58pbzPbVuonya+Uv\nid0Y1h17d4L8pl/03tw2YlL0iTgpV0FNkHcPeq4iNP/DLMPZzeUhSZuY2caFbWyvwb1UdY38seL0\nwroaL6/cEh9FNvxY/hj1SPlN45el8zpL3gKyfsV1N9gf2o2uWtuVpl8pb/VuZVSIRithMXHqkB9P\nUl15DCH0xi4In5HX26/I7YCZnShP7k4NIZxVs7+N9yoeqJmvbJy8riyX8xktrkfSc91x5kk6ytZ9\ni39Pef/SwehWa3XI1fKnP4dp7XX+v/K68HQN/EHc8rUYQngohHCmvI6tu86ldcvRBvIfJ0XNlNGq\nurfZ+0HLZboJZ8ftnid/36fcvTFlgvyHSdFx8nI4XB6StJMVBgIws/3k/V1bdY2kt1nh5f74/2/X\n2ntywwWStjezg+VdUcrdKGfJnz6tqKj7WvqhW5Cr+zZt8cdQs2X2OSGEZ0IIP5P0cyWuhxBCdwjh\nanl3x4la+/JlkpmdKb8W3htCuKxmf7eV9EjdD8zRaFH+rPxRwbVmdpb8V9AG8hO0XQhhRAaHDyEs\niSfwZDNbKX9c9gr5zeQ6xf61IYTZ5sMBnWNmG8n7CR6t0hcYQnjWzD4p6TsxmbhCfrFvIe97NDeE\n8NMWdvGu+O9HzexH8oJ2ewhhTWaZwRxfMLOfSXq/+fiC8+WV4v6l9T1jZt+QdIr5GLt/kD8Gf3+c\npar1dTiP8S5Jh5rZLPmv74VDSIRkZp+Xt0zNkbc8binpRHnLUd14y3MkfUd+U2y8HXyL/MfSAfJf\nu0WzJJ1kZqfIy/uB8lak4v7sKn97+WfyfnLt8iSjV+u+VV82S/6S20wzO1/eH/IzavExWY1L5C86\nXGhmX5M/Fj9ZLbY6Rl+XH9dsMztNPiTPR+T7vc4NOYSwwMz+Im9t20LrPnpUCGGumV0kb4X9mvzc\n9ssTqbdJOimEsKDVHQwhPGze93IPFW5QIYQ5ZvYLSV8z7yN8tbx7wH6SLg8hzE2s7m/ym+0XzaxP\nXs4/Xp6prjya2WHybhOXyZPYiTG+XP6DPsnMjpG/CDRLUnmosmeDDwlXtKekeSGErsI6Tpe3bG0b\nQngwtZ0QwjIzu0HSf5jZ4/Ky8T4NHIapFafJb9CXmdk58hbcz8kfVQ/GXZI+YmZHy18gW17TiDFH\na7/fMyRP4M3sWnnyfG3pptrUtWhmf5Z3XbhD/pTkTfInSD/K7Mv18mvlO/G6mSgf7eVpSY2+vc2W\n0cq6t5n7gZos060IIdxgPkzcfpK+HZr7Iz+zJB1hZl+X9Ft5K/cJGt4RKy6WX3c/NB8Oblt5A8ay\nQazrP+Xl5irzkbmC/AnCBA28Z1wlrwd+IP9BU34K9BN5Y8tV8V5/m/xJwPbywQuOaPIclt0o/7G0\nhzxXaLhQPnrKRWb2JfloZevJu0R8I4Rwd3lFarLMmtn3tbYee0p+3Ryn+K6J+QgZ+8nzmEe09v6z\nUP7uU5KZnST/rn4oHwqxWPctCiHcV1pkT60dqapaaO0NwgeVH/Xi0cT0uSq9QSq/IZwnr0zWyB/z\nz5a/bJLb/gyl39ydq9KbzVr7husHCtNMfnHPL2z3Oyq9WSmvnC+Sf5FLtXZ4tAFvActvznPkhWOV\nPLH+oaS/K523mU2c39PiOWm0UEyP04NKoz8o/YZ3s8c3RX4RPi1/NPQ9eeW4zvHJE7cvym9Sq+N5\n3ifO97HCfKfHaWNK25mp0sgJVcdYcT7eKG/N6VJhpI1my5oGvm19qLw/1OPyiuEReaVU+7a//EdH\nUGlkC/mIGKlyMV7+xvyiWI5+K69wi8cxTX6jXBDLzhJ5C8TBTezPCfLkabW8Fe7N5ePPLDugPFXM\nd4S8Ulotr5QPSpzj/RPlZsB+yFuiL5PfbLrkT0AOqdjuR+M61xkBoxBvkw+TeFtc17L4/1+RtzRL\nieu/ieM9Q/64szy98Xb/Avl1tUhege+cOQe7yW86q+JxfF7eytF0eYzn7Gfxe+4qbHfPmuOYGbeT\n+q/8vYyX113/Vpr+1bjNKTXbmi5vJFguv+GdpXRdMleJ0SeUqBvlLzHNj+fkTvkTmwFlqmJfynXi\npvGcLU8df8V6nlBpZAt5vfrctdvqtRjL1i2xrK6UJ8yVo1QUljswLrdanuifqFjftlJG4zxV95dm\n7we1ZTr1nSozMoI8+QmSXtnkNdomb/xZGPfjGvlTvQHlKFM+ausE+fB998Tzfr2k1zVzXKn9kCdj\nf5D/QFopT4j3qNjuV+M6r6+Id8bv/2759bEklrnTFe+/WlsfvbmZcxqX+ZniyE6l6ZPiPjVe4Hxc\n/kL/tMw5qC2z8mFj58rrjG759fN1xVxF3oXj1/I6sTtu9xIVynPFccxVdd1X/l62kjeyHFZ3fiwu\nADTFzI6SF9j9QgipMWeBF6XYtWS+PDm4rm7+l4LY0nqepC2DvzzYmH69vGU7Oe4wMBzM/2Jkfwih\n6p0DPA/M/7DM1fKE9+Ga2V8SYuvzhyVtH0p/aGXAvCTKqBL7Bh4qf+TSJf9V/Sl5MrFPoPDgJcbM\nzpWP2XzYaO/L88HMbpYPoff5wrQJ8hbJvwv+F/2AYRNfztpd3vL+eUn/GFocggzDz8xmS5ofQvi3\n0d6XkRZfRL5f0qdCCBfUzT8afZTx4rFC3k/oo/K3gJ+Sd7g/mSQZL1Gfkb+JPyEMrr/fi4b5XzL7\ntfwPwjwnHvdg/gIW0IzN5N0Zlkr6L5LkF4wT5P2/7WVwf58ufz8oNxrQc2hRBgAAABJGY3g4AAAA\n4AWPrhfAS9xb2t7JY6NBaJ+a//sCzx5Q/RfHJ176l+HenZb0HbB7ZWzMs/mh6sP/pv5+EurM7r/E\nRnsfAAw/WpQBAACABBJlAAAAIIFEGQAAAEggUQYAAAASSJQBAACABBJlAAAAIIFEGQAAAEhgHGUA\nL0ptE/N/Zfm+z+yajb//0D9k468af3c2vue431TGFv53e3bZXcd2ZuND9XTfnypjT/bl20e6Qn7f\nT5x/TDbe/6NplbHJF92QXRYAXmhoUQYAAAASSJQBAACABBJlAAAAIIFEGQAAAEggUQYAAAASSJQB\nAACABBJlAAAAIMFCCKO9DwBG0Fva3vmivcgXfG+PytjvDvlGdtntOjqy8Sf7urPxJ/rGZePL+6vH\nQt60fUV22fXb+rLxsWbZ+NL+bFgLe9erjHVYb3bZDdu6svFN88Msa5xVD8//sccOyC778J4r8yt/\nAZvdf0n+SwPwokSLMgAAAJBAogwAAAAkkCgDAAAACSTKAAAAQAKJMgAAAJBAogwAAAAkVI/jAwAj\n7LGT9snGHzj87MrYtV0Tsss+sjo/PFy/JmXjbcqPwTY5M4zaor6J2WUX5UeHU5/yI431hXwbx8S2\n/NB3OYv68+f1od78sHldofq8n7Xl3Oyyh1/1jmxc//BoPg4Aw4wWZQAAACCBRBkAAABIIFEGAAAA\nEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEhhHGcCoOe/4b2fj9/Wsroz1hPWzy3a29WTj+3Vm\nw7XuXLOmMramvz277Kr+/FjEW41Zmo1v3J4f4/nW7imVsbGWH8Q5Nw6yJG3YviIbb1eojF3XNT67\n7Nk7XJyNn7jl0dl476OPZeMA0CpalAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAEEmUA\nAAAggUQZAAAASGAcZQCjZueO7mx8SWa44I6a8YDrxkne/qr3ZuPbfT+//G8vrp7hsdX5sYgPmZA/\n7gd68sd22YqdsvE3jr+vMra0Zgzn/cfnx2i+ctWEbHxR3+TK2I5jn8guu0l7/pa0+u82y8Y7GEcZ\nwDCjRRkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgATGUQYwajZo\nrxmTt39lZaxd+fF+69oBdv7Eo9l436JF2fg4qx4redMxy7PLvuehg7LxJ/d+Nhuv03NXe2Xso1Me\nyS77tlcfmI3fc9LO+fix362M3ZgfPlodVr3fkrTw7/PjU29zZX79ANAqWpQBAACABBJlAAAAIIFE\nGQAAAEggUQYAAAASSJQBAACABBJlAAAAIIHh4QCMmLbOziEt3xOqf8tv2NZVs3R+6Lnui8Zn42Pe\nXLP6jF3H5o+7bvi3e765Vzbesdyy8cuOrz43F288Nrvs+J3y53X7i2qGrju2OjS2Zki/rpCPd7x6\nWX7bADDMaFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBcZQB\njBjbfpuaOW7IRnPjKG/S3jOIPVpr740eyMbnqX3Q6379aR/Oxqfqz9n4TjOXZ+NtK2vGkB5Tve9t\nf7wlv+h207PxsKxmHOUR9A94BuiSAAAK7ElEQVRbL8jG//Y87QeAlw9alAEAAIAEEmUAAAAggUQZ\nAAAASCBRBgAAABJIlAEAAIAEEmUAAAAggUQZAAAASGAcZQAjpmuzSSO27vXa8tXXiv78WMMHTb4j\nG5/X9rqW96lhk1mPZOO9NcvPuPh32fgx6z2Tjd/a3V0Z+8TxH80uO/O8b2TjX3rqgGz84d4VlbEO\ny49Nvaq/Lxvfd726cZS3y8YBoFW0KAMAAAAJJMoAAABAAokyAAAAkECiDAAAACSQKAMAAAAJJMoA\nAABAAokyAAAAkMA4ygBGzPKtxg5p+TYLg152YV9+TN79OvPLf7FmTN+DN9+tMmavn5Jd9qEzN8jG\nz985G9b52iYbf8ddiypji1+R/04+sM/R2fj8j2+VjX/rX+ZVxm5fkx/beml/vu3m4AlPZePfZxxl\nAMOMFmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABIYRxnAiOna\n2Ia0fE+o/i0/ztqzy06w3mz84d4V2fg9Z+2ZjYcx1WM8f3Cfa7LLztpofjb+yZtfm41P73w6G//Q\nlMcqY7uc+L3ssmecu1c2vvmrBj82dqflx6bOfd+SNKmtZvBrABhmtCgDAAAACSTKAAAAQAKJMgAA\nAJBAogwAAAAkkCgDAAAACSTKAAAAQALDwwEYMas36R/S8j2hegi4jprh4SZavh1gfs+4bPz+I8/J\nxnMW9KzMxv/UNT4bP2GjPw5625J0bdekytge47qyy15x7/VD2nZfqP7OO616SD1J6smHa9mY/C0t\n9OaHDASAMlqUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIYBxl\nACOmf6M1I7buZf2rs/F333tUNv697X+ejc9aNTUb7wodlbEpbfk2iAlt3dn4/T2Ts/E667VVj5V8\nXdfE7LJT2/NjQN/Xs3E2vqBrs8rYpze6O7vsrd3581LHXrljNh5u+9uQ1g/g5YcWZQAAACCBRBkA\nAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEhhHGcCImbR+fqzjOtuMqV7+ipVb\nZZd98uJtsvGtT5uUjS/sXZWN53RYXzberpBfQc04y3X6ZJWxiTXr3rAtP/b1yjHLsvFTrvyXytin\n35UfR3moujbNjxE99rYR3TyAlyBalAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAEEmUA\nAAAggUQZAAAASGAcZQAjZsv182Pu9oX+bHyzMdVjHc9bsW122c5nasYqrvFsf2c2nhuPuC0zjvHz\noT9Ut4F0Wm9+2Zp1T2nrysanzcsE35Vfd278Z0l6qm9lNh7aRve8A3jpoUUZAAAASCBRBgAAABJI\nlAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAExlEGMGK2m7Q4G3+mf3U2vlH7xMrYY11T\nsssu2WVo7QCrwrhsfLLy4wnn1I0XPFRtVj0act226+Kv6OjIxm0Iw1e3K79wR82+rd44f0vLf6MA\nMBAtygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkkygAAAEACiTIAAACQwPBwAEbMuLaebLx6ELN6\n8+7fJr/ubbuHsHapL+TbETqsr3rZmmHM6oZBG6rc9jsz+y1JS/o6s/GdOtqz8QmPD/68j6vZtzar\nGx4uH88PKAgAA9GiDAAAACSQKAMAAAAJJMoAAABAAokyAAAAkECiDAAAACSQKAMAAAAJJMoAAABA\nAuMoAxgx49vz4yh3hcGPJzz23vHZ+NS9nxj0uiVpYtvgxwOuGye5Ll43DvNQtt9RM3r1yjC2Zu35\nsY7H3v9kZWzWqnHZZXcft7Jm2/nz0jOxZnEAaBEtygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkk\nygAAAEACiTIAAACQQKIMAAAAJDCOMoARs6RmYNuuMPjxgi0/HLCO3up/s/EV/V3ZeIe1t7pLz5uO\nmoPvz5zXnpr2ka7QUbP1/DjKq161eWXs2uU7Z5fdr/OmbHxZ/5psvG/C4MflBoAUWpQBAACABBJl\nAAAAIIFEGQAAAEggUQYAAAASSJQBAACABBJlAAAAIIFEGQAAAEhgHGUAI2Z1X35M3k4b/Li3/R35\nZXcf/0A2vrAvPx5wp/W0vE/DpU/58aXrRjrO6Qn59pGhHvdDh1ePP931xI7ZZU+blh/7Ov+NST1T\n6uYAgNbQogwAAAAkkCgDAAAACSTKAAAAQAKJMgAAAJBAogwAAAAkkCgDAAAACQwPB2DEdPflq5iN\n2sYOet39O67Kxqe0dWfjS/o6s/GJNcOkrcm0M7Rr8MPeNbN8Xby/Zni5nPrh4fLtK1O2WloZW3Tn\nxtllx70mP/Bdv/Lfqcb05+MA0CJalAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAEEmUA\nAAAggUQZAAAASGAcZQAjZkXvuGy83QY/3u/UKSuy8U3a82PqLu3Pbzs3TnKdntCej9cs31czDnJd\nvD9U73ub5c9L3RjNC3pWZuOn7nJFZez/3feu7LJ1+mqGp24f3zek9QNAGS3KAAAAQAKJMgAAAJBA\nogwAAAAkkCgDAAAACSTKAAAAQAKJMgAAAJBAogwAAAAkMI4ygBGzurcjG3+yrzsb33pM9fLjvrVh\nft3fzbcDbNq+KhvvqhkLOatmeOj6cZDz8TarGVDYqscT7szEpPrj3n7M+Gz8+AUHVMam/7ZmBOmj\n8+GuzPjQkjSmoze/AgBoES3KAAAAQAKJMgAAAJBAogwAAAAkkCgDAAAACSTKAAAAQAKJMgAAAJBA\nogwAAAAkMI4ygBEztXNlNt5VM17wiv6uylj/2Pyy87q2ycZnTH4qG//J8qnZeIeN3Ji97aoZJ7lu\neeuvjK2pGSd5Vf+4bHzXsfnz9tjTUypjOzyxIrtsne6afd9ti8ey8WeGtHUAL0e0KAMAAAAJJMoA\nAABAAokyAAAAkECiDAAAACSQKAMAAAAJJMoAAABAAokyAAAAkMA4ygBGzI037ZSNr7dVfrzgRX3V\nYxWvd/uT2WUv2mXzfFz5ONLqztu2uq0yFnbdJbvsAz35cZY3yg+jrL/ctkM2vpNuzK8AAEpoUQYA\nAAASSJQBAACABBJlAAAAIIFEGQAAAEggUQYAAAASSJQBAACABIaHAzBiNr7JsvHN3jkpG1/Wv7o6\n2N8/mF3CKApj87ecDdvz47+t3zY+Gx+zomb8OABoES3KAAAAQAKJMgAAAJBAogwAAAAkkCgDAAAA\nCSTKAAAAQAKJMgAAAJBAogwAAAAkMI4ygBGz3iPd2fhpi16ZjS9eUz3Oclj27KD2qcE6xmbjoben\nZgUvz3YGa8uPjR16e6uDt96dXfbtd74rG99y0tJsfJMbGVsbwPB6edb0AAAAQA0SZQAAACCBRBkA\nAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIsBDCaO8DAAAA8IJDizIAAACQQKIMAAAAJJAo\nAwAAAAkkygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkkygAAAEACiTIAAACQQKIMAAAAJJAoAwAA\nAAkkygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkkygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkk\nygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAn/H/LwGtpeIZShAAAAAElFTkSuQmCC\n",
-            "text/plain": [
-              "\u003cFigure size 432x288 with 1 Axes\u003e"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsQAAAEtCAYAAAAP9nZUAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3XmcHUW99/HvbybLkJAQCAQCAYKI\nLAqCIpuILKJccAEB5VFEuLghihuoXL0sssgFvaIXUUSvKAgR5BHUQAQewipBQLaAbLInJGQjZJvJ\nJFPPH786mZ7OOXXOmcmQZOrzfr3ySk5XdZ/uPtXVv66qrlgIQQAAAECuWlb3DgAAAACrEwExAAAA\nskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZA\nDAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAA\ngKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwR\nEAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMA\nACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIWjIgNrPQwJ/nY97LzOzlN2SvVwMz\n2zce7769WPd5M7usTp6dzewMM9ugSlows7Ob/d43StzvYGaD6uSreYyJ7e5fZXlDZc3Mjo37Nb6R\n7xvo4nlr5Jred3Xv6xvJzH5hZn9ocp3zzKy9v/apWWY23swuMrMpZrYk/o6bVMm3h5ktNLOxq2M/\nm2FmM8zs53XyHBSPdY/CspPN7MP9v4drNjN7n5md9gZ8T1v8Db5dWLbar49YfurVdWvMNfxGMLPB\nZvaMmX2myfUeMrPr+mu/mhXL9uVm9k8zW25mD9XId4aZ3d3oduu1EO9Z+jND0l9Lyw5r9MuQtLOk\n0yU1FCyupZo9xtMlrRQQN2GivIy+0odtDCRnqee1+6u4fO/S8n+slr1bDcxse0nHSTpzde9LH20n\n6XBJsyXVvAGEEKbE9DPemN3qd/fIy+zUwrKTJWUfEEt6n6R+D4jXYAerZ732mKT7Ssv2WW17t3qc\nIKlV0m9W94700cGSdpP0oKRnE/kulPQ2M2soTk226MXKcwUz65A0u7wcWBOFEGZJmrW692NNEUL4\nl6R/VT6b2UHxn/eGEJbVW9/MhoYQOvpr//pDA/v8dUlTQgiPvlH71E9uCiGMlSQz+5KkAxJ5L5F0\nlZl9J4Qw+w3Zu34SQpgvifsRVhJC6PFgb2YLJS1sNH4ZaPWdmbXI67tLQwidb+yerXInhxC+Lklm\n9hdJ46plCiG8Zma/l3SKpD/W2+gqH0NsZruY2Z1mttjMnjazL1TJs5WZ/c7MZplZR2yOrxvBF7rA\n9zKzq81sgZnNNLNTY/pBZvagmS0ys/vM7J2l9c3MvmZmT5rZUjN7JXYzjizl28jMrjSz183sNTP7\nraRRNfbpo7GbcnHMe42ZbdHkOTtW0q/jx6cL3TnjS/lOMrPn4nHfbmZvbfb4YtdqiN9ZXHelISFm\n1mpmZ8ftLDazW81su5jvjCqHspWZTTTvkn3BzE6LF2HDx1j47hD/+Z1C3jNKeZJlzaoMmTCzT8Qy\nsjD+vo+a2eer7UPM/864jb0Ly75spWEsZrZNXHZI/LyRmV1iZk/F/XsplqnNStt/i5n90cxeNbN2\nM3sxlqF6w0/ONLN/xGOYHX+bPVLrNMO6u6I/ZD7UYo6kFwrpHzKzv5t3z88zs2vNbOvSNlbq8rbq\n3as7mNmfzOuDyjn4fWm9jc3s0lgWO8zscTM7rpTnC3Hbe8ZzOl/S7YljHC7pKElXVknbJP5+L8fv\nezGeh9bE9r5mXhfMM68L7jaz95fyDDaz75vZs/FYZ8cyvHshz7Fm9rB5PTY//vvfa32vJIUQulLp\nJRMldUg6pol1isdwsJlNir/vongNnVS51gv5ZpjZL83sGPM6aZGZ3Vs81kLek+M5bo95GirLVhoy\nYWYzJG0s6XjrrjeqDrsws81i+hGFZUfGZb8sLFvPzJaZ2fHx83Az+0ksg4vMbLqZXWdm21TZ/u8K\nZXZ6LOfr1zmmuuUo5hthZj+IZakjfs81ZjbazM6T9C1JrVYaHlA+Z4XtVa6fTQrLjjG/18wyv+88\nYGafSO1/lf0083rwqipplX3ZN7H+2HjtP2Ne37xoZr+1KkOCesvMLjS/J+xsZreZ2SJJv4hprWb2\nnfj9S2Od8EMzW6ew/s7xOA4tbffQuHzn0rK/x/O5IJajb5TW2z1eY/PN7x+TzexdpTzXmdlUMzvA\nPN5pl/QficM8UNKWql7f7W5+754Xv+8xMzspcb5GmscW/4zXwDTze8CbSvm2NLMJ5nVBR8x3nZmN\niOlDzewC82GlHbGc3W5m70gcR7P13QRJe5rZDvUyJm+6vTBSfrIvlPQ9eVfkz8zsyRDCZEkys80l\n3SvpVUlfk7fgfVzStWZ2aAjhTw18z28k/VZeYI+UdK6ZjZI3o58jaaGk8yVdZ2ZbhxCWxvXOkXSq\npJ9K+rOkHeTdyG83s/cWTvL/lfR2eeF6Ou7f/5R3wjwA+5k80PuepBHyrsjbzWynEMKCBo5F8hvU\n2ZK+G4+nMj622NV/tKQnJX1F0hBJF0i63sy2K7TuNXp8jTpTfg4ukHSLpHdKSv0+f5Sfix9J+lBc\n/6W4rJFjLNpT3h16mbxFS4V1pAbKWpl5UHuFpJ/Inxhb5F3NVR92ogclvSYfunFXXLa/pCXqOZxj\nf0nLJN0RP28gqV3+e8yStKmkb0i6O/5mlbFrEyXNk3dlzZa0mbwc13tY3Ux+nl+WNFxePu4ws3eu\n4tbOn8vL0v+R1CZJZvYR+W89SdLHJK0n/23vMrO3hxBebXTjZmaSbozH8XlJc+RP+4cU8qwvLwuS\nl58XY/qvzGxQCOHS0mYnSPqdpIvk3YO17C1pXUl3lvZpQ3mr47B4XFMlbSIfHtYqaXmN7W0pL6sv\nyK/RwyRNMrMDCmXyNEknysvFVPm5201xGJGZHSC/Xn4ob80ZJL+OU2W0KSGEDjP7u6SDJP13Lzbx\nJvlvf6GkpfL9P09+DGeU8r5P0lvlx7tMXkdNNLPxIYSFkmRmJ8rrmEslXSu/Jq+R/zbNOljSzfJr\n9ftx2cxqGUMI08zsafm1WxlDXu3a3lf+u98aPw+TNFR+rDMlbSjpS5LuMbNtQwhzYr4JkkbLf8dp\n8jJ0oOJ1lFC3HJlZm6TJ8nN1rqS/S1pf0r/J68afyuucT8jLuSQ1W/9L0lbxOJ6Jn/eTdLmZDQkh\nXNbIBkIIlYeS75vZRrHnruLzkp4IIdyW2MSGkhZI+qa8jhwnr7/vMLO3rsLWziHyeu0i+b2rst3/\nkfQF+TV5s6R3yH/77eXlrWFmtpO8rP1aXpd1SdpW0phCnn3i99whv691yu/7t8X6/YnCJjeV9L/y\nMvCk/DzVcpCkaSGE50r7tL/8en5IXo5nyMvV+MS2RsjvUafJY7kxkk6S9Ld4DcyP+f4gv1a+Ir/X\nj5X0Afm5lrx+/Yy8fvinvJ7bQ16WV5V75HXPQZIeT+YMITT8R9Lzkq6okXaZpCBpv8KyofIb3C8K\ny34lDxBGl9a/WdJDdb7/2PgdpxWWDZL/IJ2Stios/3DM+974eQN5q8hlpW0eHfN9OH4+MH4+qpTv\nxrh83/h5XUnzJf1vKd9W8pvEV0vn7bIGj+3NVdKCPDAfXFh2RFy+V5PHNz5+PraUb9/S8a0vf7C4\nuJTv6zHfGYVlZ8Rlx5XyPirvyq17jDXOSZB0dh/KWuX7xsfPJ0ua20yZj+tdL2ly/HeLpLnyyrFT\n0rpx+QR513utbbRK2jzuz2Fx2YbF36a3f+K2B8krxB83sV7ldxtUJe2gmHZVlbSp8vF4LYVl28oD\nxXMLy2ZI+nlp3ba43W/Hz+Pi5/cn9vMcSYsqv2Nh+eWSplf2Q37TCpK+3+Dxny6/VltLy8+XV6A7\nJNY9T1J7Ir0l/iZ3SPp9Yfktkq5MrPddSdP7WB6+FM/DJok8F0h6vS/fE7dj8TjPkjSzlDZDXteP\nLCzbO+7bR+PnwTHfdaV1Px3z/bzO91fK6R6l7/1lg/t/iaR/Fj4/Ea/tIGnLuOxCSc8nttEqDxDa\nJZ1QOC9LJX2uj+e3Vjn6YgPXzXmSljVyzuLyyvVTtdwU9uVy+TCrqtd0tetDfj9ZLOmUwrJN5XXo\nV2sdQ439GCRpm/id/9bEelMk3VIj7cK4vU+Xlm8hr9cuLC2vXGP7xM87x8+HlvIdGpfvHD9/Jh5z\na2I/H5CPdW4tLGuTNwRcVlh2nQoxTgPHf4+kiVWWPxLL/eDEug+Vr9Eq18D68nrzuLhssDzgPyax\n3l0qxVC9uEb+ovqx46OSrq63rVU9ZGJxKLTOBR/L8pS8UFUcJOkGSfPNbFDlj/xlvbdbafhCDTcW\nvmOZ/On1qdDzyafyFLV5/HsP+VPJFaVtTZD/iO+Nn/eUXwDXVslXtKf8Sfx3peN4KX73qh6sf3Po\n+SRcaQWsnNtGj69RO8pbHq8pLU+9jT+x9Hmqev72q1IjZa3sPknrm9kVZvbB2KvQiFvlXS5t8opv\nlDxo6pD0nphnP3mLzQpmdoJ5d/dC+W/wYkzaNv49R/5CwHlm9lkrdbmmmL9lO9l8KMMyeSX7lsK2\nV5Ue467MZwh5qzxQXtHiFEJ4Un5+my1nM+Stwz8ws+OtNOwiOkhecb5cpc4YK+nNqX1O2FT+gFRu\n8X2/pLtCCOnWhJLY7Xijmb0qr0M65eWj+JvcJ+lQM/ue+dCvwaXN3CdprPnwjIMbrA97Y5akEWbW\ndCusmY0zs1+Z2YvyY+yUB/JjqlxTd4YQXi98LtdbW8mHOFxdWu/38pt9f7tV0nbm3fKbyn+rS+XX\naqWVeH+tfG1/MnZTz5dff6/LH8q3lbxVVB7Y/IeZfclKw9tSGixH75f0QgjhpqaPuAnmQ+SuNrPp\n6q5njlaT9UwIYZ78XvS52CskScfHbSZf8DJ3kvnQnIVxH56Kyf1a38kf4Fq08n218rnZ+u6BuL2r\nzYdO9HjB3Mw2krdAX+UfV9R1y+TDv8pxxbwQQs1hYSWbqvROjfmwkx3lgXZTLe3mQ7seMLPX4/7N\nlQfGlWugU9LDkk43sy+av8Bcdp+kI83sdPMZcFb1qIWKSi9t0qoOiOdVWdahnl1EY+Rj1zpLfy6I\n6aN78T1LayxT4bsrBa9HF30MqOcU0sfKC1m5cJS73SpdHLdo5WPZUY0dRzPmlj5XBs43e3yNqkzL\nVO7+rtr9mNjHet2DvdVIWeshVhxHyh+S/ihplpndEruxUibLb3Z7yQPfh0MIM+VB2n7xZjdG3V2q\nMrMvS7pYXj4+Ku9WrozZa4v7E+Q9EvfLu3efMh8PeEJqZ+L4qhvkLfjHx+2+S175rOrzXR7SUrWc\nRTPUZDmL5XN/eSvFBZKeMR+rd3wh2xh5AFC+zi6P6eVrrdFZRdrUfR0VjVbP4Tl1mY+du0Xenf5F\n+QPzu+RlovibnCFv8T5CPtvDbPPxketLUgjhr/LhKVvLeybmmNlfmwmoGrQk/r1OMldJvGFNlA+F\nOFPes/Quddff5fJXr96q1DM96pXgQ4qKgXR/uS3+vV/880rwLunJ8mt7Q0lvU89r+0h5QPSQfAz6\n7vJzMF89j/8weVf0dyRNNR97emohIFxJE+Wo6TLarPhwc4u8+/wUeXD4LvlwpN7UMxfLH14PMB9v\n/hl5q121urzoZHkL7kT5Od1N3YHoqqzvFpce3qTa99XX5GW52fruQflwwlHyh75ZZnaHdY+rr8QV\nlR7I4p+j1fu6Tqpe31W212x99yn5sI975cPmKtdAu3r+Jh+Ul93TJD1uPv775EL6qZJ+IK/z7pHX\nhz/rh4aAJWqgruuvaDxljnzM3n/VSJ/eT99bqZg3kXf3SlpRwY8upL8ib0UcXAqKNy5trzJO7Nji\n9goaHT+8qjR6fJWxq0PUU60LbYx6Hl/5PKxVQgh/kPSH2DK2r7wcTjKzcaH2GOtH5WPX9pe0i7pv\njrfKK4OX5A9gxemujpL0/0IIK16WMLOtquzPs5KOiTfJt8u74i42s+dDCDeW80eHy5/IP1osozGo\nei1x+L1RbqUrlrOyTdQzAGpX/XKmEMLTko6ON8mdJX1V0i/N7NnYCzBH3gt0So19fKL0udGWxTmq\nPlatMpa7GYfIh1EdHgozN5RbYGNPxjmSzjGfC/jD8pvfEPkwAYUQJkiaYP7iyf7y3oiJSo/pa9YG\n8vNUDljr2V7STpKOjNeSpBVBYm9U6pke9Ursjemv1vEVQggzzexx+Xk2dbcE3yr/nfYrLZf82p4a\nQvhsYX+HyceDF7c9Qz4M4QvmL/QcJx/rOUPdLxiXNVSO5GV0Z/VOo/eA98ivg0NDCPcX9qXcq9GQ\nEML9ZnaffNxwm7yX4JL0WpL8fN8QQii+iFuttbGvqtUbxfpuWuH7R8kbSZq9ryqEcIOkG8xfyttH\nXiZuNLNx6o4rzlX1nq5yb1YzvSjV6rtKGWu2vjtK0gMhhC9WFsT7T48HlBDCNEmfjelvi/++wMym\nhRCuig++Z0o60/yF80PlAXKLvJysKhuo+1hrWh3/U90keYX6WAjh/ip/+muakynyoOWo0vKPyx8M\nbouf75E3+x9eylde72/yoPfNNY7jySb3r3LcTbXYFDR6fDPjd72tlO+Q0udH5eM2yze63t74pOaP\ncWkTeZsSQlgYQviLvEIeq0SLfmzJvU3emvse9QyId5G3Wvw9hLC4sNowdb+UUXGcagjuIfkYbWnl\n36domLxiXFEZmr8Y0V/DU1YIIcyVD4X5WLGly3y4x67qLmeSvxRUr5wVt90VfKqkSgtCZd1J8kDs\n2RrX2sJeHs4T8mEDG5aW3yRp7yZvusPi3yumr4s3gF1rrRBCeCWEcIl8fOhKv3cIYUEI4Xr5exdb\nruJWk60kPVNluEg9leMsPogNlbfw9MZz8jrpY6XlH5cHor3RoebqjVvV3UJcvLbHyW/Kz4QQii1o\nw1T4naNjU18QQng8hHCKfBxtvWtbql+ObpI03swOTGyrQz7LRDmArcwWU96P8gti1X7rMVXyNeNi\nSR+Rv6z9SAjhbw2s01RduordJR8HW76vfjL+fVv8uzIcrpn6bknsEfqxPFDdLD5EPSxpxxp13YN9\nOJYn5C/EFvdhprx37rgmH3Sa/k1CCFPlEyksU/X6bloI4afyGCx1jfTGVvJ3bJJWRwvxafI3Yu8w\ns4vkL5ytLz8BbwohJKcX6q0Qwlwz+6GkU82nVLlBfpM9W17oJ8Z8N5vZXZIuiTfKyiwTbytt73Uz\nO0XST+O4nxvlXWabybtzbgshrDS9SUJlvOKJZvYbeWF7JHTPkLGqji+YT2l1vJk9JS8kh8hbS4vb\nm2dmF8rHwC2Qd529Q95FL/XujeVmj/FxSYeY2ST5EInpIYRe9yCY2ffkLVGT5T0R4+Rvxj4Uer75\nXM1k+Zvby9U9K8GD8oei/eQzXRRNkvQtM/sPeXnfX95NXtyfneSV4e/lLaCt8hvrMhW6aKuYJG9F\nvczMfi0fO/yfKrRg9LPvylsvrjezS+Tdf2fJx2n9uJBvgry1+7/kN/B3KLaCVpjZbvLWkKvlcyQP\nlnelLlX3zeZ8+bm7K5bJp+QvMW0vafcQQvnhtVGVGUF2k18vFefLr/nJ5lPrPSbvKTlM/oJItfJ6\nUzyOK8zsx/Kydaa6b5SV471R3s1Ymb1kV3nZ+FFMP0/eMnq7vPV0C3nX+ZQq3bnF7bbIh+ZI3S2H\nHzSz1yTNCCHcVVpl98LxV7YxQd4amOqGfkR+7Zxv3dOsfUPdQ9SaEkLoNLOzJF0Uy9K18t/1ZPkD\neW88Lh/ucLB8yNerIYQXE/kny3tmKv9WCOFlM3tGPp/zL0r5J0m6sFCud5e3BK94MDOzjeVDXq6U\n17HL5WV4HfkL5LU0VI7kLczHy2dnOlc+FnM9+SwT5wZ/n6ZS355iZrfIX7D7RwjhOTO7V9Jp5mOg\n58rrnXIr4Z3y3+CSWHeOlN+/Z6rGvK8NmCDvEdlTPttKIyZJ+rKZfVP+nwZ9QN6S2O9CCC/Gcvl1\nM6vUy7vIf5MbQwh3xnyLzexPkr5iZi/Jf6/DY94VYszwVvnvPE1+P/qmvO6rzBF/kqSb4vYuV/cs\nDrvJX4Q9q5eHc4f8um0L3bMcSX4v+aukO83sJ/J65y2Stg4hfLPGtibJ3305W37NvFvSv6u7pVxm\ntqW8/F8lr7O75A/OrfJ4QrFc3i5/CJgvH/63t7x3pibz8f57xY+bSFrPuqdPfCiE8Ewh75by83yH\n6gnNvc33vNKzTLxcZflt8uCwuGycpF/KC8RS+Q9ws6Sj63z/saoyS0H8jrtKy8bHvJ8pLDP5E8qT\nhe/9qQpvQcd8G8l/xAXym9Zv5U+1QXEWhkLeg+UF4nX50//T8mlQdijkeV51ZpmI+U6P56TS+jc+\nLg8qzbagKrNFNHF8o+QX2mx5ZfhzeVDc4/jkBfcceRffknie94r5vlLId4aqzFYQy8TzjRxjjfPx\nbvlLCO0qzGzRaFnTyrNMHCK/8F+Rt568JG9927SB32b7uK0ppeXX1ygX68in5JsVy9Ff5E+pxeMY\nI3+h5KlYdubKK4cPNLA/X5a3ri2R3wzfVz7+BrZR9XeLaZU30feuse6H5IF+u/wauVZegRbztMoD\n5RflN9aJ8hcuVryRLr8JXy6/bhbLu/UmSzqgtK3R8unyXpCX7ZnxXH2xkKfylvy4Js7Bw5J+VmX5\n2Fg2ZsSy8qL8um6N6SvNMiEf4/dUPCePym+IE+TTSlXynCoPiOfG431C/oBR2e6h8rqw+L2/kLRx\nneOovOlf7c+kUt6t4/L3lZb/WYnZFAr5dpW34iyWX0P/qe5ZDzYp5FtptgdVmZEgLj8lbqs9np/d\nVWWWkkQ5Lc4ysaN8+NJiNTZTxQbym3W5rrpE1WccapUPtXollutb43eu2F/5C8mXyoPShfKb/RT5\nUJN657duOYr5RsofpF6UXxPT5Q/XG8T0QbHszI7HV5z1YUvFl9vjcZwpD1DLv+EH5NfIEvk1eoJW\nnkGi7iwTpf3+TTwnI+udi5h/3XguZ8nvs9fJA7aVylGd7dSbZWJhjbRW+Tjwf8Xz/LI8qF+nlG+M\n/KXzufGc/0j+YB3UPcvE/vJ6cJr8+p4mH48+vrStXeTTv85Wdz1wraT9C3mukw/dafT4x8kbWz5S\nJW1P+b2xEsdMlfSlQnqPWSbkDRf/Hcv8Inmdtb38XnBhzLOevA79Z8zzmrxn/bDCdk6T37/mxe99\nXD5/dkudY6nM3lHtz1dLeU+M5XxYvXNkcQWgIfEp7Br5dDN31ssPrMnM5xI/R/5QtFb9r1S9ZWan\ny7t8tw3xBhCHv8yS9L0Qwk9W5/5h4DKzIfIGoomhMAYbbwwzu07eU3BE3cwDhJndI+n+EMKX6+Yl\nIEYt8c3XQ+QtNu3y/5jj2/IW6L0ChQdruXiDflzeqnHR6t6f/hZfznpO0okhhKsLy3eUt/JsFUJY\nUmt9oDfMbD35sMNPy7vWdwpNTmuIvovX+QPyMcrNvue01jGz98pb5LcJIdSdkWN1jCHG2mOh/C3Y\nE+Xdc6/Kx3qeSjCMgSCEsNT8vxWv+996DhDjJZ1fDIYlKfj/brjK/itcoGRP+Xs2M+TDnAiGV4MQ\nwqNm9jn5ULUBHxDL30/7VCPBsEQLMQAAADK3OqZdAwAAANYYDJkABqADW47Ms+un9n8C5ur0iC06\nYvdk+tAv1O55e35q+n8GbRnTnk5/Lj117rLh6X0Po2r/z6uhM932seWW6VkHh77/+WR6rm7uuqa3\ncyUDWMPQQgwAAICsERADAAAgawTEAAAAyBoBMQAAALJGQAwAAICsERADAAAgawTEAAAAyBrzEAMY\nOKzOM35Ynkze6VsPJ9Mv3mxK7cQ+/ufP/3r3wmT62NYhyfRhLbXTX1lWZ9uD1k2m7/6pE5Lpoy6/\nJ5kOAGs6WogBAACQNQJiAAAAZI2AGAAAAFkjIAYAAEDWCIgBAACQNQJiAAAAZI2AGAAAAFljHmIA\nA0dXep7her698S3J9EeW1q4y71syPrnu5oPnJNPbWtJzAT/QsV4yfXHX0JppLdowue4xI2cn01/b\nNpmsUelkAFjj0UIMAACArBEQAwAAIGsExAAAAMgaATEAAACyRkAMAACArBEQAwAAIGtMuwYA0RaD\n0lOfzepYWjNtm6EzkusOUXpKuDldw5PpbdaZTB89eGHtbS9PH1c9SzerfdwAMBDQQgwAAICsERAD\nAAAgawTEAAAAyBoBMQAAALJGQAwAAICsERADAAAgawTEAAAAyBrzEAPIxqDxW9TJ8VAydUFXW820\n5bLkukMsPQ9xvXmGF4WhyfTOULs67wrpto9/ddaew1iSNthwQTIdANZ2tBADAAAgawTEAAAAyBoB\nMQAAALJGQAwAAICsERADAAAgawTEAAAAyBoBMQAAALLGPMQAsjF/17F9Wv/1xDzEmwyan1y3PQzu\nU3q9eYxb1FUzra0lPcfxnK70HMdbrz8nmZ4+cgBY89FCDAAAgKwREAMAACBrBMQAAADIGgExAAAA\nskZADAAAgKwREAMAACBrBMQAAADIGvMQA8jG7J3SbQDzu5Yk02ct26Rm2maDXkuuO7olve1tBi1M\npj+8dHQyvSvRvpGao1iSRrd0JNNnLVk3mT5E6XmKAWBNRwsxAAAAskZADAAAgKwREAMAACBrBMQA\nAADIGgExAAAAskZADAAAgKwx7RqAbAzfJT09WGdIT0+22eB5NdMWhSHJdbcd3J5MP33mPsn07465\nK5n+aOewmmnty9PTpo1tTe/7C9PTU75toxeS6QCwpqOFGAAAAFkjIAYAAEDWCIgBAACQNQJiAAAA\nZI2AGAAAAFkjIAYAAEDWCIgBAACQNeYhBpCNw7d8OJm+oCsk05eG1pppOwxamFz31iVjkulT35me\nA3n96bXnGZakIZ3La6YNtmW7cytFAAAIRElEQVTJdYe1pOchtnnpdABY29FCDAAAgKwREAMAACBr\nBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGvMQA8jGtm2vJNMXJ+YZlqTOULvK3GLQ\nusl1D77/sGT6ZnosmV5PW2Ku4fauevMItydTu4ak50gGgLUdLcQAAADIGgExAAAAskZADAAAgKwR\nEAMAACBrBMQAAADIGgExAAAAskZADAAAgKwxDzGAbOzVNj2ZPn15er7e5bJef/eIa0b0el1Jmrd8\ncTJ9xyFtNdMeaB9WZ+uvp5PXWV5nfQBYu9FCDAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAA\ngKwREAMAACBrBMQAAADIGvMQA8jG2EHrJtNfWJaeb3d4S0evv3vU9Y8k07vqrP+Vlw9Kpv943KSa\naW0tnXW2ntY6d3Cf1geANR0txAAAAMgaATEAAACyRkAMAACArBEQAwAAIGsExAAAAMgaATEAAACy\nxrRrANCgES3tNdMWdy1Nrtu1eHGfvvv+aVsk04duXrs6b607qVva4NdpOwEwsFHLAQAAIGsExAAA\nAMgaATEAAACyRkAMAACArBEQAwAAIGsExAAAAMgaATEAAACyxjzEABAtlyXTR1pHzbQrFmy1qnen\nh/bpw5Ppg621Ztpy2j4AIIlaEgAAAFkjIAYAAEDWCIgBAACQNQJiAAAAZI2AGAAAAFkjIAYAAEDW\nCIgBAACQNeYhBoBoUdfQZPrmQxbXTPvNC3sk111Xz/Zqnyq2uLErmb74o0trpg22ZX36bgAY6Ggh\nBgAAQNYIiAEAAJA1AmIAAABkjYAYAAAAWSMgBgAAQNYIiAEAAJA1AmIAAABkjXmIASAaYsuT6akW\nhOkvjE6u+5Y+zkM87O4nk+nrtaxTM21kS3ufvntQ7emXAWBAoIUYAAAAWSMgBgAAQNYIiAEAAJA1\nAmIAAABkjYAYAAAAWSMgBgAAQNYIiAEAAJA15iEGkI1Ji4cm0zcdND+Z3hlqpw2dMbg3u9SwsHRp\nr9dts84+ffegRX1aHQDWeLQQAwAAIGsExAAAAMgaATEAAACyRkAMAACArBEQAwAAIGsExAAAAMga\n064ByMZdC9+STP/kqHuT6W1WO23Zm5f0Zpca1tXe3ut120O9KeE6kqnLhvX6qwFgrUALMQAAALJG\nQAwAAICsERADAAAgawTEAAAAyBoBMQAAALJGQAwAAICsERADAAAga8xDDCAbEx7bNZl+4nvuSabP\n7WqtmXbwtlOT6z6ZTO1fG7QurJMjPU9xa3qaYgBY69FCDAAAgKwREAMAACBrBMQAAADIGgExAAAA\nskZADAAAgKwREAMAACBrBMQAAADIGvMQA8jGiLvXSaa37ZNuI1jQNaRm2pkb355c9yjtlUzvq47Q\nWTOtzZbXWTs9D7F19WKHAGAtQgsxAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAA\ngKwREAMAACBrzEMMIBtjb5udTJ/1rZBMXxRqz0P8t47hvdqnVeXZztrzELfK+rTtQNMJgAGOag4A\nAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgAAABZIyAGAABA1ph2DUA2lj/+VDL96c7RyfTRLYtq\npm3UWjtNklp22i6Z3vXIE8n0ehaEwTXThtuyPm07tPZpdQBY49FCDAAAgKwREAMAACBrBMQAAADI\nGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGvMQA0CUmmdYktoS8/lu0JKe6/f1bddLpq/7SDK5\nrskLd6iZdsTIB5PrPrK0PZnOPMQABjpaiAEAAJA1AmIAAABkjYAYAAAAWSMgBgAAQNYIiAEAAJA1\nAmIAAABkjYAYAAAAWWMeYgADh1k6PYRk8tFTjk+m3/zui2qm1Zuqd8Ze6X178zV1NlDHtI5RvV63\nVenzMnReOh0A1na0EAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAA\nssY8xAAGDqvzjB+WJ5M3+ktbMn34e2rPJbygKz1X74kH3pRM/6tGJtPrWae1s2bacqXnQK6X3trB\nPMQABjZaiAEAAJA1AmIAAABkjYAYAAAAWSMgBgAAQNYIiAEAAJA1AmIAAABkjYAYAAAAWWMeYgAD\nhrW2JtNDV3oe4pFXTkmmP3pW7bmCR7csTq7bGdL71ld/embHmmmn7HF3ct2Zy9PzDC8am247WS+Z\nCgBrPlqIAQAAkDUCYgAAAGSNgBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSNadcADBhhWWe/bv/P\nr+1SM+3Csfcn1x036KFk+o0HfzWZPvSG+5Lpra1dNdM2bB2eXHdES/q8dYxOT8sGAGs7WogBAACQ\nNQJiAAAAZI2AGAAAAFkjIAYAAEDWCIgBAACQNQJiAAAAZI2AGAAAAFljHmIAA0fo3/lyb71yt5pp\nO+y5XXLdUX9YN5k+4oYpvdqnivWuqr39/UZ8JLnu3EXDkumb3rmsV/sEAGsLWogBAACQNQJiAAAA\nZI2AGAAAAFkjIAYAAEDWCIgBAACQNQJiAAAAZI2AGAAAAFmz0M/zdgIAAABrMlqIAQAAkDUCYgAA\nAGSNgBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSN\ngBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgA\nAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgAAABZ+/8QwCyVXUs1XAAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "\u003cFigure size 432x288 with 1 Axes\u003e"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "headers = {\"content-type\": \"application/json\"}\n",
-        "json_response = requests.post('http://localhost:8501/v1/models/fashion_model/versions/1:predict', data=data, headers=headers)\n",
-        "predictions = json.loads(json_response.text)['predictions']\n",
-        "\n",
-        "for i in range(0,3):\n",
-        "  show(i, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(\n",
-        "    class_names[np.argmax(predictions[i])], test_labels[i], class_names[np.argmax(predictions[i])], test_labels[i]))"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "rest_simple.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "MhoQ0WE77laV"
+   },
+   "source": [
+    "##### Copyright 2019 The TensorFlow Authors."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "_ckMIh7O7s6D"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "jYysdyb-CaWM"
+   },
+   "source": [
+    "# Train and serve a TensorFlow model with TensorFlow Serving"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "E6FwTNtl3S4v"
+   },
+   "source": [
+    "**Warning: This notebook is designed to be run in a Google Colab only**.  It installs packages on the system and requires root access.  If you want to run it in a local Jupyter notebook, please proceed with caution.\n",
+    "\n",
+    "Note: You can run this example right now in a Jupyter-style notebook, no setup required!  Just click \"Run in Google Colab\"\n",
+    "\n",
+    "<div class=\"devsite-table-wrapper\"><table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "<tr><td><a target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/serving/rest_simple\">\n",
+    "<img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a></td>\n",
+    "<td><a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/serving/rest_simple.ipynb\">\n",
+    "<img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\">Run in Google Colab</a></td>\n",
+    "<td><a target=\"_blank\" href=\"https://github.com/tensorflow/tfx/blob/master/docs/tutorials/serving/rest_simple.ipynb\">\n",
+    "<img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\">View source on GitHub</a></td>\n",
+    "</tr></table></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "FbVhjPpzn6BM"
+   },
+   "source": [
+    "This guide trains a neural network model to classify [images of clothing, like sneakers and shirts](https://github.com/zalandoresearch/fashion-mnist), saves the trained model, and then serves it with [TensorFlow Serving](https://www.tensorflow.org/serving/).  The focus is on TensorFlow Serving, rather than the modeling and training in TensorFlow, so for a complete example which focuses on the modeling and training see the [Basic Classification example](https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/keras/basic_classification.ipynb).\n",
+    "\n",
+    "This guide uses [tf.keras](https://github.com/tensorflow/docs/blob/master/site/en/r1/guide/keras.ipynb), a high-level API to build and train models in TensorFlow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "dzLKpmZICaWN",
+    "outputId": "da36b678-5ff6-4e2c-dd9e-2dc3170bba8c"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.13.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TensorFlow and tf.keras\n",
+    "import tensorflow as tf\n",
+    "from tensorflow import keras\n",
+    "\n",
+    "# Helper libraries\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "tf.logging.set_verbosity(tf.logging.ERROR)\n",
+    "print(tf.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "5jAk1ZXqTJqN"
+   },
+   "source": [
+    "## Create your model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yR0EdgrLCaWR"
+   },
+   "source": [
+    "### Import the Fashion MNIST dataset\n",
+    "\n",
+    "This guide uses the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset which contains 70,000 grayscale images in 10 categories. The images show individual articles of clothing at low resolution (28 by 28 pixels), as seen here:\n",
+    "\n",
+    "<table>\n",
+    "  <tr><td>\n",
+    "    <img src=\"https://tensorflow.org/images/fashion-mnist-sprite.png\"\n",
+    "         alt=\"Fashion MNIST sprite\"  width=\"600\">\n",
+    "  </td></tr>\n",
+    "  <tr><td align=\"center\">\n",
+    "    <b>Figure 1.</b> <a href=\"https://github.com/zalandoresearch/fashion-mnist\">Fashion-MNIST samples</a> (by Zalando, MIT License).<br/>&nbsp;\n",
+    "  </td></tr>\n",
+    "</table>\n",
+    "\n",
+    "Fashion MNIST is intended as a drop-in replacement for the classic [MNIST](http://yann.lecun.com/exdb/mnist/) dataset—often used as the \"Hello, World\" of machine learning programs for computer vision. You can access the Fashion MNIST directly from TensorFlow, just import and load the data.\n",
+    "\n",
+    "Note: Although these are really images, they are loaded as NumPy arrays and not binary image objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 255
+    },
+    "colab_type": "code",
+    "id": "7MqDQO0KCaWS",
+    "outputId": "18ee19db-cc5e-4141-9e27-ba8f52b2c148"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-labels-idx1-ubyte.gz\n",
+      "32768/29515 [=================================] - 0s 0us/step\n",
+      "40960/29515 [=========================================] - 0s 0us/step\n",
+      "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-images-idx3-ubyte.gz\n",
+      "26427392/26421880 [==============================] - 0s 0us/step\n",
+      "26435584/26421880 [==============================] - 0s 0us/step\n",
+      "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-labels-idx1-ubyte.gz\n",
+      "16384/5148 [===============================================================================================] - 0s 0us/step\n",
+      "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-images-idx3-ubyte.gz\n",
+      "4423680/4422102 [==============================] - 0s 0us/step\n",
+      "4431872/4422102 [==============================] - 0s 0us/step\n",
+      "\n",
+      "train_images.shape: (60000, 28, 28, 1), of float64\n",
+      "test_images.shape: (10000, 28, 28, 1), of float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "fashion_mnist = keras.datasets.fashion_mnist\n",
+    "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()\n",
+    "\n",
+    "# scale the values to 0.0 to 1.0\n",
+    "train_images = train_images / 255.0\n",
+    "test_images = test_images / 255.0\n",
+    "\n",
+    "# reshape for feeding into the model\n",
+    "train_images = train_images.reshape(train_images.shape[0], 28, 28, 1)\n",
+    "test_images = test_images.reshape(test_images.shape[0], 28, 28, 1)\n",
+    "\n",
+    "class_names = ['T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',\n",
+    "               'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle boot']\n",
+    "\n",
+    "print('\\ntrain_images.shape: {}, of {}'.format(train_images.shape, train_images.dtype))\n",
+    "print('test_images.shape: {}, of {}'.format(test_images.shape, test_images.dtype))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "PDu7OX8Nf5PY"
+   },
+   "source": [
+    "### Train and evaluate your model\n",
+    "\n",
+    "Let's use the simplest possible CNN, since we're not focused on the modeling part."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 459
+    },
+    "colab_type": "code",
+    "id": "LTNN0ANGgA36",
+    "outputId": "9733b5ce-820f-43e6-de52-7bef7bcb759d",
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "Conv1 (Conv2D)               (None, 13, 13, 8)         80        \n",
+      "_________________________________________________________________\n",
+      "flatten (Flatten)            (None, 1352)              0         \n",
+      "_________________________________________________________________\n",
+      "Softmax (Dense)              (None, 10)                13530     \n",
+      "=================================================================\n",
+      "Total params: 13,610\n",
+      "Trainable params: 13,610\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n",
+      "Epoch 1/5\n",
+      "60000/60000 [==============================] - 8s 130us/sample - loss: 0.5308 - acc: 0.8174\n",
+      "Epoch 2/5\n",
+      "60000/60000 [==============================] - 5s 86us/sample - loss: 0.3737 - acc: 0.8682\n",
+      "Epoch 3/5\n",
+      "60000/60000 [==============================] - 5s 91us/sample - loss: 0.3388 - acc: 0.8798\n",
+      "Epoch 4/5\n",
+      "60000/60000 [==============================] - 5s 78us/sample - loss: 0.3195 - acc: 0.8860\n",
+      "Epoch 5/5\n",
+      "60000/60000 [==============================] - 5s 82us/sample - loss: 0.3074 - acc: 0.8902\n",
+      "10000/10000 [==============================] - 1s 62us/sample - loss: 0.3414 - acc: 0.8777\n",
+      "\n",
+      "Test accuracy: 0.877699971199\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = keras.Sequential([\n",
+    "  keras.layers.Conv2D(input_shape=(28,28,1), filters=8, kernel_size=3, \n",
+    "                      strides=2, activation='relu', name='Conv1'),\n",
+    "  keras.layers.Flatten(),\n",
+    "  keras.layers.Dense(10, activation=tf.nn.softmax, name='Softmax')\n",
+    "])\n",
+    "model.summary()\n",
+    "\n",
+    "testing = False\n",
+    "epochs = 5\n",
+    "\n",
+    "model.compile(optimizer=tf.train.AdamOptimizer(), \n",
+    "              loss='sparse_categorical_crossentropy',\n",
+    "              metrics=['accuracy'])\n",
+    "model.fit(train_images, train_labels, epochs=epochs)\n",
+    "\n",
+    "test_loss, test_acc = model.evaluate(test_images, test_labels)\n",
+    "print('\\nTest accuracy: {}'.format(test_acc))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "AwGPItyphqXT"
+   },
+   "source": [
+    "## Save your model\n",
+    "\n",
+    "To load our trained model into TensorFlow Serving we first need to save it in [SavedModel](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/saved_model) format.  This will create a protobuf file in a well-defined directory hierarchy, and will include a version number.  [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving) allows us to select which version of a model, or \"servable\" we want to use when we make inference requests.  Each version will be exported to a different sub-directory under the given path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 136
+    },
+    "colab_type": "code",
+    "id": "0w5Rq8SsgWE6",
+    "outputId": "0c318fa8-4368-4b9d-d7c6-d9d35b8f6aad"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "export_path = /tmp/1\n",
+      "\n",
+      "\n",
+      "Saved model:\n",
+      "total 120\n",
+      "-rw-r--r-- 1 root root 118459 Apr 16 23:56 saved_model.pb\n",
+      "drwxr-xr-x 2 root root   4096 Apr 16 23:56 variables\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Fetch the Keras session and save the model\n",
+    "# The signature definition is defined by the input and output tensors,\n",
+    "# and stored with the default serving key\n",
+    "import tempfile\n",
+    "\n",
+    "MODEL_DIR = tempfile.gettempdir()\n",
+    "version = 1\n",
+    "export_path = os.path.join(MODEL_DIR, str(version))\n",
+    "print('export_path = {}\\n'.format(export_path))\n",
+    "if os.path.isdir(export_path):\n",
+    "  print('\\nAlready saved a model, cleaning up\\n')\n",
+    "  !rm -r {export_path}\n",
+    "\n",
+    "tf.saved_model.simple_save(\n",
+    "    keras.backend.get_session(),\n",
+    "    export_path,\n",
+    "    inputs={'input_image': model.input},\n",
+    "    outputs={t.name:t for t in model.outputs})\n",
+    "\n",
+    "print('\\nSaved model:')\n",
+    "!ls -l {export_path}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "FM7B_RuDYoIj"
+   },
+   "source": [
+    "## Examine your saved model\n",
+    "\n",
+    "We'll use the command line utility `saved_model_cli` to look at the [MetaGraphDefs](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/MetaGraphDef) (the models) and [SignatureDefs](../signature_defs) (the methods you can call) in our SavedModel.  See [this discussion of the SavedModel CLI](https://github.com/tensorflow/docs/blob/master/site/en/r1/guide/saved_model.md#cli-to-inspect-and-execute-savedmodel) in the TensorFlow Guide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 272
+    },
+    "colab_type": "code",
+    "id": "LU4GDF_aYtfQ",
+    "outputId": "51a3405c-4bd0-4c0d-833e-168ef7b669ac"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "MetaGraphDef with tag-set: 'serve' contains the following SignatureDefs:\n",
+      "\n",
+      "signature_def['serving_default']:\n",
+      "  The given SavedModel SignatureDef contains the following input(s):\n",
+      "    inputs['input_image'] tensor_info:\n",
+      "        dtype: DT_FLOAT\n",
+      "        shape: (-1, 28, 28, 1)\n",
+      "        name: Conv1_input:0\n",
+      "  The given SavedModel SignatureDef contains the following output(s):\n",
+      "    outputs['Softmax/Softmax:0'] tensor_info:\n",
+      "        dtype: DT_FLOAT\n",
+      "        shape: (-1, 10)\n",
+      "        name: Softmax/Softmax:0\n",
+      "  Method name is: tensorflow/serving/predict\n"
+     ]
+    }
+   ],
+   "source": [
+    "!saved_model_cli show --dir {export_path} --all"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "lSPWuegUb7Eo"
+   },
+   "source": [
+    "That tells us a lot about our model!  In this case we just trained our model, so we already know the inputs and outputs, but if we didn't this would be important information.  It doesn't tell us everything, like the fact that this is grayscale image data for example, but it's a great start."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "DBgsyhytS6KD"
+   },
+   "source": [
+    "## Serve your model with TensorFlow Serving\n",
+    "\n",
+    "### Add TensorFlow Serving distribution URI as a package source:\n",
+    "\n",
+    "We're preparing to install TensorFlow Serving using [Aptitude](https://wiki.debian.org/Aptitude) since this Colab runs in a Debian environment.  We'll add the `tensorflow-model-server` package to the list of packages that Aptitude knows about.  Note that we're running as root.\n",
+    "\n",
+    "Note: This example is running TensorFlow Serving natively, but [you can also run it in a Docker container](https://www.tensorflow.org/tfx/serving/docker), which is one of the easiest ways to get started using TensorFlow Serving."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 578
+    },
+    "colab_type": "code",
+    "id": "EWg9X2QHlbGS",
+    "outputId": "d3d8416d-dee5-48d3-cbcc-288acc210a46"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deb http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal\n",
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "\r",
+      "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r",
+      "100  2343  100  2343    0     0  14029      0 --:--:-- --:--:-- --:--:-- 13946\r",
+      "100  2343  100  2343    0     0  14029      0 --:--:-- --:--:-- --:--:-- 13946\n",
+      "OK\n",
+      "Get:1 http://storage.googleapis.com/tensorflow-serving-apt stable InRelease [3,012 B]\n",
+      "Hit:2 http://archive.ubuntu.com/ubuntu bionic InRelease\n",
+      "Hit:3 http://ppa.launchpad.net/graphics-drivers/ppa/ubuntu bionic InRelease\n",
+      "Get:4 https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/ InRelease [3,609 B]\n",
+      "Get:5 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]\n",
+      "Get:6 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]\n",
+      "Ign:7 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease\n",
+      "Get:8 http://ppa.launchpad.net/marutter/c2d4u3.5/ubuntu bionic InRelease [15.4 kB]\n",
+      "Ign:9 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  InRelease\n",
+      "Hit:10 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  Release\n",
+      "Hit:11 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release\n",
+      "Get:12 http://storage.googleapis.com/tensorflow-serving-apt stable/tensorflow-model-server-universal amd64 Packages [360 B]\n",
+      "Get:13 http://storage.googleapis.com/tensorflow-serving-apt stable/tensorflow-model-server amd64 Packages [355 B]\n",
+      "Get:14 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]\n",
+      "Get:15 https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/ Packages [60.4 kB]\n",
+      "Get:16 http://ppa.launchpad.net/marutter/c2d4u3.5/ubuntu bionic/main Sources [1,636 kB]\n",
+      "Get:19 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [410 kB]\n",
+      "Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [1,103 kB]\n",
+      "Get:21 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [4,171 B]\n",
+      "Get:22 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [301 kB]\n",
+      "Get:23 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [752 kB]\n",
+      "Get:24 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [7,238 B]\n",
+      "Get:25 http://ppa.launchpad.net/marutter/c2d4u3.5/ubuntu bionic/main amd64 Packages [786 kB]\n",
+      "Fetched 5,335 kB in 3s (1,671 kB/s)\n",
+      "Reading package lists... Done\n",
+      "Building dependency tree       \n",
+      "Reading state information... Done\n",
+      "37 packages can be upgraded. Run 'apt list --upgradable' to see them.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# This is the same as you would do from your command line, but without the [arch=amd64], and no sudo\n",
+    "# You would instead do:\n",
+    "# echo \"deb [arch=amd64] http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal\" | sudo tee /etc/apt/sources.list.d/tensorflow-serving.list && \\\n",
+    "# curl https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | sudo apt-key add -\n",
+    "\n",
+    "!echo \"deb http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server tensorflow-model-server-universal\" | tee /etc/apt/sources.list.d/tensorflow-serving.list && \\\n",
+    "curl https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | apt-key add -\n",
+    "!apt update"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "W1ZVp_VOU7Wu"
+   },
+   "source": [
+    "### Install TensorFlow Serving\n",
+    "\n",
+    "This is all you need - one command line!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 323
+    },
+    "colab_type": "code",
+    "id": "ygwa9AgRloYy",
+    "outputId": "485b7d6c-68a4-4ff6-9690-830fc1cd2ba6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading package lists... Done\n",
+      "Building dependency tree       \n",
+      "Reading state information... Done\n",
+      "The following package was automatically installed and is no longer required:\n",
+      "  libnvidia-common-410\n",
+      "Use 'apt autoremove' to remove it.\n",
+      "The following NEW packages will be installed:\n",
+      "  tensorflow-model-server\n",
+      "0 upgraded, 1 newly installed, 0 to remove and 37 not upgraded.\n",
+      "Need to get 136 MB of archives.\n",
+      "After this operation, 0 B of additional disk space will be used.\n",
+      "Get:1 http://storage.googleapis.com/tensorflow-serving-apt stable/tensorflow-model-server amd64 tensorflow-model-server all 1.13.0 [136 MB]\n",
+      "Fetched 136 MB in 2s (58.6 MB/s)\n",
+      "Selecting previously unselected package tensorflow-model-server.\n",
+      "(Reading database ... 131304 files and directories currently installed.)\n",
+      "Preparing to unpack .../tensorflow-model-server_1.13.0_all.deb ...\n",
+      "Unpacking tensorflow-model-server (1.13.0) ...\n",
+      "Setting up tensorflow-model-server (1.13.0) ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "!apt-get install tensorflow-model-server"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "k5NrYdQeVm52"
+   },
+   "source": [
+    "### Start running TensorFlow Serving\n",
+    "\n",
+    "This is where we start running TensorFlow Serving and load our model.  After it loads we can start making inference requests using REST.  There are some important parameters:\n",
+    "\n",
+    "* `rest_api_port`: The port that you'll use for REST requests.\n",
+    "* `model_name`: You'll use this in the URL of REST requests.  It can be anything.\n",
+    "* `model_base_path`: This is the path to the directory where you've saved your model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "aUgp3vUdU5GS"
+   },
+   "outputs": [],
+   "source": [
+    "os.environ[\"MODEL_DIR\"] = MODEL_DIR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "kJDhHNJVnaLN",
+    "outputId": "3dc18177-7c73-4943-e177-5b65400ec453"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting job # 0 in a separate thread.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash --bg \n",
+    "nohup tensorflow_model_server \\\n",
+    "  --rest_api_port=8501 \\\n",
+    "  --model_name=fashion_model \\\n",
+    "  --model_base_path=\"${MODEL_DIR}\" >server.log 2>&1\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 187
+    },
+    "colab_type": "code",
+    "id": "IxbeiOCUUs2z",
+    "outputId": "648d5262-e5c5-4b78-cbcf-b31c06b33581"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-16 23:57:13.903708: I external/org_tensorflow/tensorflow/cc/saved_model/reader.cc:31] Reading SavedModel from: /tmp/1\n",
+      "2019-04-16 23:57:13.905313: I external/org_tensorflow/tensorflow/cc/saved_model/reader.cc:54] Reading meta graph with tags { serve }\n",
+      "2019-04-16 23:57:13.906761: I external/org_tensorflow/tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA\n",
+      "2019-04-16 23:57:13.918934: I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:182] Restoring SavedModel bundle.\n",
+      "2019-04-16 23:57:13.931921: I external/org_tensorflow/tensorflow/cc/saved_model/loader.cc:285] SavedModel load for tags { serve }; Status: success. Took 28202 microseconds.\n",
+      "2019-04-16 23:57:13.931975: I tensorflow_serving/servables/tensorflow/saved_model_warmup.cc:101] No warmup data file found at /tmp/1/assets.extra/tf_serving_warmup_requests\n",
+      "2019-04-16 23:57:13.932059: I tensorflow_serving/core/loader_harness.cc:86] Successfully loaded servable version {name: fashion_model version: 1}\n",
+      "2019-04-16 23:57:13.933039: I tensorflow_serving/model_servers/server.cc:313] Running gRPC ModelServer at 0.0.0.0:8500 ...\n",
+      "2019-04-16 23:57:13.933658: I tensorflow_serving/model_servers/server.cc:333] Exporting HTTP/REST API at:localhost:8501 ...\n",
+      "[evhttp_server.cc : 237] RAW: Entering the event loop ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "!tail server.log"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "vwg1JKaGXWAg"
+   },
+   "source": [
+    "## Make a request to your model in TensorFlow Serving\n",
+    "\n",
+    "First, let's take a look at a random example from our test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 318
+    },
+    "colab_type": "code",
+    "id": "Luqm_Jyff9iR",
+    "outputId": "85e6d60f-3755-4d36-f87d-ad9aaba4ab52"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEtCAYAAADnQL6OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAFtZJREFUeJzt3Xl0XNV9B/DvT6N9l+XdDthgs6QQ\nEic+xQSIKSlQoEkgkLokwaalKSmBcNqTZmNxoDTh0MSnLRQISwyEUGKSkAZSzGpWO3Eo+2LA2MYY\nWza2ZWuxNNLM7R/3Ccavur8rSx5J7u/7OUdHR+++5c6b0XfuzL3vPnHOgYhsKhnpChDRyGEAEBnG\nACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESG\nMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCR\nYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDBu2ABCRG0XEicii\nIu3fKT+fK8Yxh4uILBORZXtpX9OSc3Lu3tjfvkBE5qZeD7tE5BURuVREqgaxv4Ui4lLLnIgs3GuV\nHialw3GQ5CR/IfnzLBH5hnOutwiHWgzghn6WryrCsWjfcyGAlQCqAZwI4DIAMwCcPZKVGknDEgAA\nPgegHsBvAZwM4CQA9xbhOBuccyuKsF/6/+HVgtfHIyIyHsACEbnIObdtJCtWLCJS4ZzrDpUP10eA\n+QC2A1gAYFfy9276mlUiMlNE7hORdhFZlzTT9ko9ReSv0x8JRCQjIo+JyGoRqU+WzRCR20VkTdJc\nfEtErhORptT+FovIOyLyCRF5Oll3lYickpT/vYisFZGdIvJrERmX2t6JyJUi8t1kP7tE5HER+egA\nHss4EbleRDaISLeIvCYiXxnkeek794eIyFIR6RCRt0XknKT8y8n+20XkURE5MLX9PBF5RES2JOs8\nKyL9PcfjROTO5HxsF5GfiMhnkmPPTa17uoisEJFOEWkVkSUist9gHp9iZfJ7RnLMtSKyuJ96D6p5\nLyInicjy5HndISL3iMjBBeXXikiLiJSmtqtIzs+/FiyLPt8isiCp67HJ+WoF8DutjkUPABGZDODT\nAO5yzm0BcA+AP0//MxX4FYBH4FsN9wD4HvoJjPDhpDT901fonLsZwBIAN4nIlGTxJQCOAnCWc25n\nsmwygPUALoJvKl4O4Hj4FkxaPYDbANwE4DQAmwH8QkR+COA4AOcn+zkOwLX9bH82fKvoa/ABOQHA\nwyIyRnmQ9QCeTLZbCOAUAL8BcJ2IXBA8O3FLANwHf+6fAXCLiPwzgK8C+BaAcwAcDOBnqe0OAHA3\ngC8m2/4G/hyfl1rvlwD+DMC3AcwD0APg3/t5fOcB+AWAVwCcAeBvARwG4DERqStYry+4pg3y8U5P\nfrcOcvsgETkJ/ly2A/gL+HN4GIAnC157twMYD+CE1OanAmiEf10N5vm+A8Aa+HP3LbWizrmi/gD4\nRwAOwJzk7xOTv89LrbcwWX5OavmLAB4YwHGc8jO2YL1GAOvgQ+ZTAHoBfDuy71IARyf7+ljB8sXJ\nsmMLln0kWbYKQKZg+Y/gX/CZVJ3fA1BTsGxast4VBcuWAVhW8PclALoAzEzV88Zkf6XKY5mWHPfc\nfs792QXLmpJzsxVAfcHyC5N19w/svyQ5XzcCeL5g+QnJdl9Irf9fyfK5yd+1AHYAuCW13nQAWQAX\nFSy7NKljv3UpWG9ucowTkrrVw/9ztAN4tmC9tQAWB15bC9PnK7LOHwC8UfhcJI+hB8CPCpa9DuDO\n1L7uAfDKnj7f8G8gDsCigf5/DsdHgPkA3nDOLU/+fgjAuwi/q9+X+vslAANt+t0CYHY/P+8nvHOu\nFcBZAI4FsBTA4wCuKtyJiJSLyHeSZtYu+CftiaT4YOyuwzn3eMHfryW/H3LO5VLLSwFMSm3/W+dc\nR0H91gJYAWCO8jhPgm/arUm1dJYCaAbwYWVbzX8X1GM7fGtmhfugZdT3OADgQ30LxH9su1NENsCf\nqx4A52L3c3UkgBx8C6/Q3am/58D/g96Remzrk2MfW1DHy51zpc65dQN8fEuTuu2Ab+08Ct9i2atE\npAbALPhW7/tfdjvn1gB4Cv6Np8/tAD7b17IRkWb4d/rbC9bZ0+c7fY6DivoloIh8Ar5yV4lIY0HR\nLwF8TUQOcs69ntos/WVMN4DKAR5yo3PuDwNYbwX8O/SHAfybcy6fKv8+gAvgm/5PA2gDMDWpd7ou\nuzUfnXNZEQH8dx6Fssnv9PYt/dSvBcAfKfUfD/+5tSdQ3qxsq+mvzurjEJFaAA8C6IRvbq5O1vkq\ngL8q2G4SgO3OuXSd049/fPL7oQHWcU+cD+D38N9DrS0M3r2sCYAA2NhP2SYA+xf8/VP4j7lnAPgJ\n/MeF0mR5nz19vvs7br+K3QvQ9y7/zeQn7WwAFxe5Dv25DMBMAC8AWCQijzrndhSUzwNwm3Pun/oW\nJC/0YpgQWLZB2WYr/Lvz1wPlw9ntOQf+BX2Mc+7JvoXpL7bgX5RNIlKWCoH049+a/F4A4OV+jtc2\nhLq+HnmD6AJQXrggeUfeU9vhm+IT+ymbiII3OefcGhF5CsCX4APgS/Af99YXbLOnz7frd61+FC0A\nRKQcwF/CN136+yJiEYAvi8glLvkAMxxE5BgA303qdBeA5wFcB/+xoE81/m/anlOkKp0sIjV970bJ\nF1pHAviBss398C2Ut51zm4tUr4GqTn6/f76SL3g/m1pvBYAM/BelPy9YfmZqvb4W1wzn3K17t6pR\n6+C/qCt0yp7uxDnXISLPADhTRBb2fRQUkf3hv3BOf/F5G4Drk56QOdi95QQU8fkuZgvgFPimyT84\n55alC0XkBvh/vLnwn8X2hikicmQ/y9c55zYmL8w7ADwM4F+ccy7pSvm5iCwteMHdD2C+iLwI4E0A\np8M/ccWwC8ADInI1gAr45uBO+IAMWQTfVHxC/MjKVQBqABwC/06c/ucrpqfh63utiFyW1ONi+C+n\nGvpWcs49kLzT/VhExsKf1zMAHJGskk/W2yki30j2Nw7+e4kdAKbAf3Ze5pz7GQCIyKXwXwQeuAff\nA2j+E77nYxH8OJUj4Fsig3EJ/PdZ94rIf8B/ufk9+Mfyw9S6S+BD4afwr4f09yJFe76L+SXgfPgk\nXxIovxOBMQFDsADA8n5+vpiU/xhAFYD5fa0O59wSADcDuEZEZiTrXQD/7fSV8K2EOvjWTDHcBv9C\nuQbArQC2ADjeKQNTko8rR8F3S34T/sugW+DfdfdWmA6I8127p8G/u98N//3JTdj9M2yf0+DD9Sr4\nVkAl/D8K4P8x+vZ5A4DPwH+JeDv841wI/4b1XMH+SpLjyl56OLfCfzw8Hb6b7cSkznvMOXc//Jtg\nI/xjvR7AqwCOds69m1q3NTneFAD3OOfaUuVFe75lGFvflCJ+PPmVzrmR+B5kVBCRa+A/Xo1xyog1\nKo7hGgpMBBFZAP+x4GX4L9tOgu8tuJr//CODAUDDqQN+VOSB8N93rAHwHQBXj2SlLONHACLDOCEI\nkWHD+hHgT0vOZHOjCEoqwwMlpa4uWAYAuS1b9nZ1dlNSXR0sy3d2FvXYQyKRjoVR3HJ+ML9kwL0i\nbAEQGcYAIDKMAUBkGAOAyDAGAJFhDAAiwxgARIZxKPAo0DavvyuYP7Dx+JxaXlYXHkb/N4c9pW7b\nkNmllr+xq7/5Sj4wrfI9tfzjlc8Ey/7upbOCZQCwfUODWj7xcf39q/FXzwXL8l1d6rbRfv59eJxA\nIbYAiAxjABAZxgAgMowBQGQYA4DIMAYAkWEMACLDhnVGoBGdD6Ako5fn9b52zVtXaXfxAsZ+RJ/K\n3Tm9T3nbzvA19QAgq2uCZT1TssEyALhw9sNq+Z/UvKaWb8mFjw0AFz43L1jWs6pe3bZ3sl732kZ9\nPoHSkvQNnz6w/V19jMGhl61Vy3MtI307hjDOB0BEA8IAIDKMAUBkGAOAyDAGAJFhDAAiw+x0Aw7x\n8s23LwvfHDh3SIe+73V6N17sbu4uEtP58vAOyluHlvH5Ur1yma7B35ezpz6y78jNwmLnRbtlaHZs\nr75pr77zmef/LnLwkcNuQCIaEAYAkWEMACLDGABEhjEAiAxjABAZxgAgMszOtOBDHO9QOWtbsKx1\nk34L7kykL91FrlSWyJXK+YZwn3Z2rL5x9QtVanmmW+9SzlWoxciXKYWRpyQ7Jnw5LwCUtuvvX9oY\nhvIt+ks/O7FHLZfZh6vlbuWLavlowRYAkWEMACLDGABEhjEAiAxjABAZxgAgMowBQGSYnXEAEe6o\nI9TyKQ3haaDbOyr1fbfHOvr14lyt3h9e83p5sGzKD57Wdz6KtVwQnoMBAHbO1Mc4VGwLn/d8Rh+E\nUNmgT0aw9bBatXzMSrV41GALgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjOMAEtsO1efub988\nNljW1KDfF+C9bGQcQMfQnoa8svu1V+i3Lncz9Fts5/OR9wjR+9Pzyvz6mXcjkwlEJgwo7dDrVqJ0\n5XdP1PddpdxaHACyjYO/H8JowhYAkWEMACLDGABEhjEAiAxjABAZxgAgMozdgImusXq3TlNduLus\nszt8OS4A1DTsUsvb83oXpHTo3Yj737s9WLbuEn3bCTdGLmXOxKYF199DMtlwd1ppp37J7TvH6d2E\nef20q1OSuwq9m6+7S995vkE/9r6CLQAiwxgARIYxAIgMYwAQGcYAIDKMAUBkGAOAyDCOA0h0jdUv\nDx2jXB7a3q73pdfWdukH79X72mumtqnl+edfDZZVL9UvBy5fulwtH0nlH9OnBW//qH5enXK5caZN\nHx+Rrwrfch0Aupv0cQT7CrYAiAxjABAZxgAgMowBQGQYA4DIMAYAkWEMACLDOA4gkavX+32ry7LB\nMonMEF1Rpu9bevQcrq/S+7tl9uHBsuYbR28/f0xOH14Bp0w5DgC5unBffSYypbiLPCeIzCewr2AL\ngMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjOMA+pTq8wFMqt4ZLFtT2qxu29YZm3tfP/bGzY1q\neefF4XsWlNynzwcwfkX4ngIAILnI7b+r9fnznTJGovTtzeq22Xr92GUtysT/AHrrw331vQ362Ay1\n4gAkMl/AvoItACLDGABEhjEAiAxjABAZxgAgMowBQGQYA4DIMI4D6KN3OaNUwn3KU5tb1W3fWj1h\nMDV6n8vpfdLZFWOCZbkp+r7XL9Tnx+/YVqWWl1Tk1PLS8nB5tv1D6rbI6X3tFRv1cQDaNf+5iT3q\nti6rvzdWVOvb7yvYAiAyjAFAZBgDgMgwBgCRYQwAIsMYAESGmekGzDQ1qeVSrk/z/FZb+JLfUya+\npG57zapJajkiM0yXNeldTlO//4y+A0XbvCP1YzdHpixfp3fV1azaESzrHVenbrvxkzVqeXez3ncr\nSg9leaV+Trs79O7PMXUdavm+gi0AIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwM+MAMC58ySwA\nSInep9yRDU9/PbV8q7qti+w706lfktvbo5d3nzw7WNZTq2/rIm8BO2fogxRKevX917wVfomVrWlR\nt80df4BarvXzA8Cxn34hWPb0O9P0jcv0xx25IzykLDJdek/4dvPDiS0AIsMYAESGMQCIDGMAEBnG\nACAyjAFAZBgDgMgwM+MAeibVq+WxcQBbW2uDZYeXb1S3LWvq0o/9nn7de7ZDf5rWfT5c9+rGNnXb\n7m59au18q96fve3j+nnbcWz4seWy+nwA6NLnGqhdrZ+Xqky4r72iTN93b53eTx+ZRR4lDfpjy72n\njx0ZLmwBEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGmRkHkK3X+7sFer9v767Bn6rDJuvjBFY9\nP1Mtz2b0XueSneG6dbXp/dH5yP0QMp36e4TTpwMAdoTrlomMvYh2tkcs3zQ9WDa+tl3ddkzzZrX8\nhZbJann9ZH38BDgOgIhGGgOAyDAGAJFhDAAiwxgARIYxAIgMYwAQGWZmHEBvpT6Tu3ORmd6VPuuW\nXHiuAADI5vXTHOtLL6mITIDfFt5/rJ8/+hYQnQBfL86Xh8+bRKoWu2dBPtLVvnVdU7Bs1uz16rYr\nN+2nlne0VqnlPc2R8RVq6fBhC4DIMAYAkWEMACLDGABEhjEAiAxjABAZZqYbMFurZ12uUz8VNc2d\nwbK5VXqXz1eWT9OPPVbfPp/VO40yveG+OCmPdH/mh3hJbqRcO7oo9QYAFzmvsW7Csm3hFa6Y9JC6\n7bm7Pq+Wb2/Rp5nvrY48Z2rp8GELgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyzMw4gJ5avc9Z\nOvWe2QMOCk/j/EJWv/33hN/r/dnvnBq53Der57QMYfpsiVwGHZ32O3a58FCm9o5sm6vSV6jeGK5c\na+RS5KHqqdFPXEVxDz9gbAEQGcYAIDKMAUBkGAOAyDAGAJFhDAAiwxgARIaZGQeQq9TLM916h/Z+\n1duDZU906rf3rnknPJcAAJTV6MfOt1br5crU29F++Eh/eGzq7tj+8xXhFWLX88fmC8hFpgWv2hKu\n/CvZCeq2u3r128kjcsv22CzzowVbAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYWbGAcT6nGP9\n4ePK24Jly1sPVLeVHv16/3zkPtfRug9FpMM6cmfz+DiBIfSHS2SahHxl5Bbc2XDZLe8erW57aMMm\ntfzNvD6OoKR3KBMhDB+2AIgMYwAQGcYAIDKMAUBkGAOAyDAGAJFhdroBI9Nbx7qzpldsDpYt/p85\n6raHdrbqO4feDRi7LBYlQ7jkdojTY5f0xG4/rpRF6lYSuxy4Wq98riJ8gBffmKpu+8k/Xq2WIxe7\nVHnfuB6YLQAiwxgARIYxAIgMYwAQGcYAIDKMAUBkGAOAyDAz4wAiV9xGza58O1jW+Ix+s+d8gz6t\nd1WVct0qgM4yfU5zp01RHYl4p4whGIhcZHpsVWRsRqSrHajQxwH0VoYPUPu6/oKonqM/J9Kjn9hs\nHccBENEoxwAgMowBQGQYA4DIMAYAkWEMACLDGABEhtkZB1Cm91dLpDu7sSTc5zz2Of323y6j9wl3\nd+tPQ0nk1uXaGIfY9f6xa/KHOiW5evzItN+xuQby3XrltBnPy3foT3hb5H7yJV163XpqOQ6AiEY5\nBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyzMw4gNh9AXqr9H7hllxZsCzT0aNu2z1Bnw9gxoQNavmb\nkVt4lw7xmn6Ni+06UjenlGtlAJCL3BegvLJXLe+YUhssq1+jD5DodpGxGVP1sR+928PHHk3YAiAy\njAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDDMzDqByi96n3DmrSy2/fP2pwTL37MvqtrFbErgnatTy\n6Z0bIzso3jgASOS69mIeO2YIdZMy/Vl5bP7MIR26fKdePlqwBUBkGAOAyDAGAJFhDAAiwxgARIYx\nAIgMM9MN2Full9fX6Zd33jz918GyeThqMFV6X76jY0jbF9VIdvPFDKVuTr8c+FMT3lDL72qdpZZ3\nj9njGo0ItgCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsPMjAOYtLxbLd+Ua1bLZ7V8PVh2EFYO\nqk59pFR/Glx+FPfFj2b58P3HXa8+pfgdDx6jljeu0q8HrluvTxU/WrAFQGQYA4DIMAYAkWEMACLD\nGABEhjEAiAxjABAZJm40X+9NREXFFgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCR\nYQwAIsMYAESGMQCIDGMAEBnGACAyjAFAZBgDgMgwBgCRYQwAIsMYAESGMQCIDGMAEBnGACAyjAFA\nZNj/AuZZIU40WeT7AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def show(idx, title):\n",
+    "  plt.figure()\n",
+    "  plt.imshow(test_images[idx].reshape(28,28))\n",
+    "  plt.axis('off')\n",
+    "  plt.title('\\n\\n{}'.format(title), fontdict={'size': 16})\n",
+    "\n",
+    "import random\n",
+    "rando = random.randint(0,len(test_images)-1)\n",
+    "show(rando, 'An Example Image: {}'.format(class_names[test_labels[rando]]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "TKnEHeTrbh3L"
+   },
+   "source": [
+    "Ok, that looks interesting.  How hard is that for you to recognize? Now let's create the JSON object for a batch of  three inference requests, and see how well our model recognizes things:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "2dsD7KQG1m-R",
+    "outputId": "c56e8d06-b1d3-4528-9ac5-860c2091dd7d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data: {\"instances\": [[[[0.0], [0.0], [0.0], [0.0], [0.0] ... 0.0], [0.0]]]], \"signature_name\": \"serving_default\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "data = json.dumps({\"signature_name\": \"serving_default\", \"instances\": test_images[0:3].tolist()})\n",
+    "print('Data: {} ... {}'.format(data[:50], data[len(data)-52:]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ReQd4QESIwXN"
+   },
+   "source": [
+    "### Make REST requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "iT3J-lHrhOYQ"
+   },
+   "source": [
+    "#### Newest version of the servable\n",
+    "\n",
+    "We'll send a predict request as a POST to our server's REST endpoint, and pass it three examples.  We'll ask our server to give us the latest version of our servable by not specifying a particular version."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 318
+    },
+    "colab_type": "code",
+    "id": "vGvFyuIzW6n6",
+    "outputId": "f731f319-8390-4df9-909c-7cffa56d7fcc"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAvUAAAEtCAYAAACIx59SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3Xm8HUWd9/Hv7y7ZCCEEEvYlrAIq\nMCgCDpuC8oALIijKFleGcYNH53HAEQLjhijojIIoMoEBgUFRFBABISwCiiOrLGExCgQSspI9N7n1\n/PGrQ/p2Tlefc+8lscLn/XrldXO6eqnurq7+nerqOhZCEAAAAIB8dazpDAAAAAAYGIJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQuWRQb2ahhX9T\n47yTzOy51ZLrNcDMDoj7e0A/lp1qZpNq5tnNzCaa2ZgmacHMvtLudleXmO9gZl0181XuY2K9b2sy\nvaWyZmYTYr62bmV7rzVm9tZ4fGbUnbsW1jXVzC6rmWeimYWBbKe0vtV+XbRbhuMy65jZNDM7ss1t\n1dYbq5OZdZrZl83sL2a21MyeNLOTm8z3CzM7f03ksR2t1g9mNtnMJhc+t10G1lZVdfSrtJ1QmhbM\nbOKrve1WmdlwM5sX87XrANdVe48bSExSsb7JZnbXYKyrjW2Ojuf2H9pc7pdm9r02l5nUiFf/XpjZ\nkWZ2v5ktMbMXzex7ZrZuaZ6TzexhM2upEb5upr1L/16U9JvStPe1uyNoajdJZ0ham28U7e7jGZIG\ncsO4Xl5GXxjAOtZmJ8S/YyX9nzWZkYz05zr9vKSZkn72quRo9Tlf0r9J+rGkd0m6WtK3zOzfSvOd\nKekTZrbDas7fq+Wf47+G10Jd3aqB1tFrk/dJGhX/f/yazEhGRsvLUMtBvZntJ+kdkr7+amVqdTCz\nD8nr0AclvVfSREkfknRNadYL5ffoE9SCZOtcCOHeUiaWSppZng78PQohvCTppTWdj79HZjZM0gck\nTZa0p7zC+NWazNPayMyGSvqMpIkhhEF7SrG6mdmWkj4u6d9DCI2nIzeb2ShJXzKz80MIsyUphHC/\nmd0v6WT1DYazFEJ4dE3nAVk4QdJsSU9KOsbMvhhCWL6G87Q2+hdJvwohPL+mMzJA/y7p9hDChMYE\nM5sp6WozOzSEcIMkhRAWm9mlkr4g6b/qVjroferNbHczu9PMFsXHs//UZJ7xZna5mb0UH+M+YGa1\nLf6Fx6X7mNn/mNl8M5tuZqfG9EPio4yFZnafme1RWt7M7BQze8LMlpnZC/Fxx6jSfGPN7Cdm9rKZ\nzY0HdHRFno4ws3vj/s41s6vjDbCdYzZBK0/Wk7aya9PWpfk+Gx99zzez281sl3b3z8y2juueUFp2\nlUd55o/bvxLXs8jMbjWz1yUee443s+vNbIGZ/dXMTm88Mmp1HwvbbgRAXyrMO7E0T7KsWZPH62b2\n4VhGFsTz+7CZndgsD3H+PeI6/rEw7TNW6vphZtvHaYfFz2PN7EIzmxLz92wsU5uV1r+Dmf3cvAvM\nEjP7WyxDdV2ZzjSzP8V9mBnPzV6pZUoOl7SevPX155LebWbrl7bRKCsnmtlZsRzMNbNfmdnmNfnr\nNLMfxvwdlJivy8xONbPHzeuCaWb2bfMvHa0wM/uSmT1nZovN7A4z2608Q911EecbFadPi3l5Ii5n\nMX2C2ijD0eHyFt2rmmR8fzO72fyR/UIze9DMPpbY0UEpU2Y20sz+M05fGue7xcxel9iPPeX3i1+X\npt8oaZhWfdJzpTywGZ5YZ9V+DjOz88zskXidvhjL3OtK8zWu773M7ycvx3P3H+XyY2bbmNdNi8zv\nO9+VNLTF/LzS/abdMhCP81Olaf8bl9muMO2r5veyRll7h5ndYCvr3kfM7PNm1llaV1v1WVxmOzP7\nb/N7yWIze8bMLrDS9R/nrSyjlqijrdRlqbC+Pl3KWi3Tdczs/VbR7SXmJdkQaWZHm9ehL8Vjeb+Z\ntdQyGpffTNJB8nJ/kaSNJL2zyXxTzeyyuL3H4jH9oxXuL4ltfMS8/vrXmvkGFJOY2XtjeVtqXi9/\noMk8h5jZPbH8zDPvcrdjaR6zRL0br5m/xNl/VChDExJ521Re1/ykSdr4WK5fjHl/Jl7nqX0902ru\no9ZCfWlmn4vnc7GZzYnntDKmNbMNJW2r5vWptGoPmCsl7Wxm+6T2Rxr8oH6U/GBfJn+ccJ+kC8zs\nwMYMZraFpN9L2lXSKZLeI+lPkn5mZu9pcTuXSHpYvuO/kPQ1Mztb0jmSzpb0QUnrSPqFmQ0pLPdV\nSedKulnSuyV9U9IESddb3/5K18gfL58W17Vc0n+WM2EeRP5M0qOSjpR0oqTXS7rdSv2ialwvqREg\nHqWVXZuK3UaOlXSYpM9J+oikLSVda32Dv1b3r1Vnyo/BpfLzeZOkXybm/7mkW+WBzC/i8o2KsZV9\nLNo7/p1UmPeiQnptWSuLFedlkm6PeTxS0o9U8YUtul/SXPV9xPw2SYubTFsu6Y74eYykJZJOlXSI\nvHVhe0m/s74Bx/WSNpN0kvwm8K+Slqr+2txM0nnyfZ8gaYakO8zsDTXLNZwQ9+uX8vM7RNLRFfOe\nKmk7SR+Vl7+95cexKfNA7mcxbweEEG5J5OMyeZeOn8jL99clfUzS5S3ux/GSDpX0aflx2EjSb61v\nf+fa6yL+vV5+bX07zndjXO6rcT3tlmHJz/1jIYSZxYlm9l5Jv5Uf9xPlx+piSVsl1jVYZeo8+VOa\nMyUdHLf/gNLXwYr4d1lp+tL49/Wl6XfIr9G91b6hktaVH+vD5PsxTNI9ZrZxk/n/W9LTko6QdIGk\nT8mPkSQp3gNulrR7TJsgaby83LWr3TJwm6RtG0GVeeC8m5rXH5MLT3O2kZePj8qPwSXyx/ONstjf\n+kySNpX0rPxJyjslnSXp7ZJuKM7UQhmtq6Nb0WqZrnOtpGkxn8V9eJ2k/SX9oGb5bST9VNIx8mP5\nK0kXWZNGyQrHyq+vS+VdKpaougvOvvIueV+Wxxedkq4zs8rzZmanybthfDKE8I3EfAONSbaT9B/y\nOvAISU9JurIUwx0ivw4WxPyfFLdxV+nLWF29+0LchuT1fqMMXZ/I38Hy43Vnab/HS/qDpP0knS4v\nS2dK2rBmf1u5jybrSzM7Rn68rpDfi46Rl6VU97yq+rRHUtCq9ekDkubH/UoLIbT8T9JUSZdVpE2K\nmTmwMG2opFmSfliY9mN5l4gNSsvfLOmBmu1PiNs4vTCtS34ieiSNL0x/T5x3//h5jPwGNKm0zmPj\nfO+Jnw+On48uzffrOP2A+HmkpHmSLi7NNz6eqJNLx21Si/u2XZO0IH+k112YdmScvk+b+7d1/Dyh\nNN8Bpf1bX37Rnl+a7//G+SYWpk2M0z5SmvdhSTe1so8VxyRI+soAylpje1vHz1+QNLudMh+Xu1bS\nbfH/HfJHrN+OZW5knH6lpHsT6+iUtEXMz/vitA2L56a//+K6uyQ9Iem7Lcy/ifwLyIWFfXqunP9C\nWZlcmv6FOH3TUhm/LJabu+RB1ral5SZKCoXP+8b1HF+a75g4fbcWysdMSeuU8twj7yYitX5dvEvN\nr4uL4vIb9rMMPybp8tI0i8frj5I6EstOLed7MMqUpEckndtmGds5rvek0vTT4/QLS9O75Teu0wZS\ntgv7OUJ+UzulML1xLs4szX+dpCmFz5+I8+1VmNYh6c8q1A+J7U8uXgPtlIFY/nolnRA/Hy5pjvw+\neEWcNjKW2X+qWIfJr+8vxWU7Ctdh2/VZk/V3SfrHuE+7t1lGq+roPsdsIGU6Tp+oQt1R2PbE0jzz\n1Lc+ODces+FtHI+OeEx+JOnBFpd5VNLjhc9XyL+4jW6y/3MkrV+Y9qa4Lx8uTJskr5M75A2KCyUd\nVlrXAepnTJIo5+XrpFPS45LuLEz7ozwe6Spto0exXlH78cjHWzzOF0h6vsn0S+XxyqaJZSdJmlpT\n9la5j6qmvpT0PUl/aueai8vNkHRVadp+8Xg80WT+O1WIp6r+DXZL/aIQwm2NDyGEpZKmyFuVGw6R\ntwjMM3/03hVbm38jaVcrPRKv8Moji+B91p6SV+J/KczzePy7Rfy7l7zFodzCeKU8wNk/ft5bfjMq\nv9R2Zenz3vKWqMtL+/Fs3PZ+LexHO24OIfQUPj8c/zaObav716o3yJ92XF2a/tPEMuVv2I+o77kf\nTK2UtbL7JK0fH3++K9UyUnKrpL1jy9Fu8m/o35RXWvvGeQ6Ut8q9wsxOMn9cvUB+Dv4WkxqPKWdJ\nekbSN8zsE2a2fYv5kZkdZGa3mdmsuO4eSTsU1p1yrLwCu1SSQgi98nLzlvIj1OiG0udy2WvYVB7Q\nj5B/2Xy6Jh+HyG82Py1dQzfF9FauoRtCCAsbH0IIUyXdq5WtiK1eF/vJg6/yY93L4vL9aXGW/JiU\n3+vYUd7aeVE89i0bpDJ1n6QJZnaamb3JSl06mgner/wWSWea2TvNR614n7y1V/JjV5y/Rx5gbNrO\n/jWY2QfM7PdmNle+nwvlQUuz8lmudx5W37K5t6RnQ+FdsHjc/6c/eWtH8PcMHtTKVvm3yVvWb5HX\nGZKXvS4V6g8z28S8W8pf5ddIj/wJwWhJ4+Js/arPzGxIPPePm9niuO5Gy+eOhb/9KqPtaqFMt+qH\n8rrnQ3G9w+RPJC8NISyuycP2ZnaFmT0vPx498ndIavNgZm+WtJP8iVHDJfKnSx9sssg9IYQ5hc9V\n9WmXvJ76sKSDQgipFmxpcGKS8nWyQh4D7GlmHWa2jvyl1qtC4X2BGHv9Tivr08GORxqa1aeSvzh7\nXQhhWjsra/E+Wldf3idpt9hF5yAzG9Hi5r8r6Ugz+7SZjTHvLn6BPP5sds29pBbq08EO6uc0mbZU\nXrgbxskfS/WU/p0T0zfox3aWVUxTYduNRyF9HpPGgjmrkL6JpDmlAFqSppc+NyrWW7TqvrxBre1H\nO2aXPjcee7e7f63aJP6dUZpePg51eWznEWo7WilrfYQQbpc/Mt9C3lXopdg37o0127pN/iRgH/mN\n+MEQwnR5AHug+bsN4+TBvyTvdy/vr36L/BHjnvKKTo08Bv/6fbC85ePrkqaY9wM8KZUZ8+G/bpC3\nTHwsrvfN8uChleN9gvzG+ecYnI2WP42Qmj8yrit7DW+Ut+heFY9PnXHyin+h+l4/jTLXyjXUbDvT\n5Y9VpdavizHyVs/y49AXS+tp1zCtPF4Njf1qawjgQSxTn5E/yv+o/IY0w7wPe93NaIK8RfJG+fU3\nSSu7uTTrfrJYUn/61L9b/g7CY/KA5i3y8v2SmpfvZuWz2F9+E1WXk9XhNq0M4Btf/m+TtJGZ7Ryn\nTQshPCG90hXsl/KnR1+RfxF4s1Z2vWmc6/7WZ1+Xt2pfJu/as6dWdoNoHN9+ldF2tVKmWxUDumsl\nNbrMHCW/bi+sycNIeU+BXeVd1faVH++L1dp7FyfEv78q1Kf3yctrbX0aG6SkVfd3lPz83C3vWlJn\nMGKSqutkiHwElvXlT3GaXe8vqm99qvJ8A4hHGprVp5LvW7v1aav30br68lJ5F6S3yBunZ5vZNVY/\nlPY58ifB35Efk3sVe6xoAPXpgMam7qdZ8laBsyvS2/qm1YbGhbSx/LGrJH9RT14gGukvyFs/ukuB\n/Ual9c2KfycU11cwf6AZblOr+7ck/i2+ayCtesE3CtU49d2/8nHISgjhp/KW4ZHyx5dnS7rRzDZP\ntEg9LO/m8TZ5v9xG8H6rvK/ds/Ivkb8rLHO0pN+GED7fmBD7/ZXz84yk483M5DeVT0s638ymhhDK\nL9E0vF/eqnBEsYya99edm9h9xdaAxgvWzb4YHWdmX+5n69yN8grxbDNbEkJIvqQkv4aWaOXTjrJW\n6oJm5XEjSY2REVq9LmZLGmNmQ0qB/caF9P6YJb8RFjX617f1MqAGqUyFEBbIg/FTzWwreVe+b8jL\n8BerNh58tIkDzF9WGyPvYtUIIJuNbz1GK/e1HUdLeir0HRWiW/0PBF7QyjJftLrqstsknWL+ktsu\nkm4NIbxoZo/J65S3qe9Tvm3lXTKOCyG80tIZv+z00c/67Gh563XxRf+RpXn6W0Yblmjl8I5F5XPY\nUpluw/nyd2r2kPd9vjPUj160t/ypxL4hhFfKsbXw2x3m72t8KH58sMksY81s+xDCky3lvq/Z8qeq\n10n6iZkdE9Kj6QxGTFJVny6Tf0kZLu8e0uzdlo3Vtz5tTEvVu+2aJe/qUzZT7ZfVlu6jdfVlbEi5\nUNKFcdl3yLvnXiUP9JuK95kTzeyL8qc0z8nP0Ux5K35ZS/XpmvhF2RvlN4I/hxD+2ORfs29hg+Fe\n+Ukovwz4QfmXm8nx8z3yrgnvL81XXu5u+QnYrmI/nmgzf439brtlK2p1/6bHbZVfxDis9PlheQvq\nUaXp5c/taHcfl7Uxb1tCCAtCCNfJL8ZNlGjFiBftZHkL6L7qG9TvLn9h+w8hhEWFxUbIW0iKPpLa\nRgjhAfk7C9Kq56dohPwRXWhMMP8BmFa6Op0Ql3u/vIWw+O8b8la/ypeN64QQzpH39f2OmZ1SM3tj\n5JT1Kq6hVoL6Q+MjYUmvjKiwl/w6llq/Lm6X14fl8n1MXL6xvnbL8OPyl/CKpsj71n48Bt6tGvQy\nFUL4awjh2/LrPVXmistMCyE8Ig/cTpbv4+TiPOYvtA6T909t1wj5zbboOHm93B/3SNrCCqNaxNbw\nVUb1aFG7ZeB2+fV6lvym/Eicfqu8dXo39Q3qGy2AxUCjW14Wm2qnPlNr5ajVMlpVR/9V0g5WGKjC\nfHzx8suabZXpOiGEW+Xl8VxJb1X9C7KNPEh9j/f68pcn67xLHmydqVXr00ad0+8x60MIk+WjvRwq\n6YqaLxqDEZOUr5NOeZ34hxBCb+zq+L+Sjip2Q4nB7j5aWQ+0Wu/2pz7doslxuEnSu8xskybLVGn7\nPlpXX4YQ5oQQrpJ37Wu1Pp0bQngodtX7mPzp0MVNZh2vFurTNdFSf7r8UdId5r8INlXekvV6SduE\nED76amw0hDDbzL4t/7a1UP7YZSf54827FPtlhhBuNv9VtQvNhx16Ul4QX19a38tm9i+Svm9mY+X9\n/OfJvy3uL39JaJVhlxIarQmfMrNL5BXMQ026Awx0/4KZXSXpY2Y2RV5IDpO38hTXN8fMviPpNDOb\nL3+k9w/yQic17/M12Pv4qKTDzKzxuH9au33miszsLHmrw23yVuDNJX1W/oJ23Xj2t0n6vrwSaPQ/\nvV9eiR4ov2EX3Sjpi+ajFvxB3hrX5xdF42Py78q/0T8lD1omyAOaW1XtRnkwNcnM/kveB/DLWtk6\n3VQMDD4kHxu3/AMXMrMH4nqPl4960S8hhHPNbIWk88ysI1aCzeabbGZXyFsaz5Ufp175y1OHyltB\nptRsbrGkm8zsHHlleKakl+UjFrR8Xciv37sk/SBez3+Oefi4pK+HlaPXtFuG75B0cjwOvTFPwfyX\nWK+RdKuZ/UDeCraTpHEhhDMq1jUoZcrM7pF373hY/uh5f3mL/iUV222s+yR5IP8XeQvcCfIXLN/e\npFW40UJ1R2H5reOyZ4YQJiY2daOkw83sPHkr5Zvkj8CTT6ESLpF3q7gmHrsZ8i4arby/1UxbZSDe\nK/4kH2Hm6thIIHmd8qn4/+L1/pg8KP5qvI565CPF9TGA+uxGSSeY2cPyMnKEPCAr5rnVMlpVR18p\n6ZOSLjYfwnK8/MvlvCZ5SZbpfrhAfg20+oNvd8vrjO+b2Rnyd8n+LS6/Xs2yJ8ivoW/FFt0+YsPG\nsWZ2euG8tyWEcKf5iDO/lnSVmR0dVu0ePFgxyfS4jTPk5/sk+f2l2H3vy/J68zrzX44eKa9358lb\nqNupd6fLW9+PNrOH5A2JfwkhzFJzd8RtvVE+amLDGfL6+m4z+5q8XG8m6ZAQwrEV62rpPlpXX5rZ\nD+VxwD3yumUHeSPETUows4PlceUj8gaQd8h/1+Mzwd8NK847Oq73W6l1Shr00W+eazJ9slYdPWNz\neV+i5+Xf5l6Q9yU6tmb7E9Rk1IG4jbtK07ZW6a1qeV+wU+SBbGO735c0qrTsWPnb6/PlN5LGkI6v\nvGlemPdQeaX6sqRF8i8BF0vauXTcJrVwfM+Ix6Tx7XHrOH2VEQbUZBSbNvZvtPylnpnyx2A/kAf2\nffZPHhB8Vd5XbnE8zvvE+T5XmG9inNZV2s4kld42r9rHiuPxVnmrwBIVRjpotaxp1dFvDpP3eXtB\n3kLwrHwUiso35gvr2imuqzxCzLUV5WK4/ObyUixH18lvbMX9GCevGKbEsjNb3qr3zhby8xl5gLRY\n3s/voPL+N1nm8Lj94xLzXC6vuEaqYmQClUZdqKob5AFLr6T/VywnpXk65MNkPhjP87z4/2/KW/BT\nxyDE8nma/NHlEvkXrt1K87V6XYySj2TwQpxvSlzOBlCGG+Vm/yZpjW4XC+K/B1UYQUqlemOwypS8\ni8b98VgvlN+sPttCmft0PIZL4nqvkbRLxbw/kvTH0rRdYl6bjvJSKhNfkQeqi2L+d29yPCao+f2g\nWTnbRh5YLIrH77vy7hnJ89esXmm3DBSOeZ9918qRcaY2mX83efCzSF62z5J/wRxwfSYfIelKeRA+\nR37Nv1nNR3+qK6NN6+iYdqL8frhYHjjv0eQc1pbpxDntM09h+iYx7Zy6Ml3az/tjXp+WfzlaZZul\nZcbK64kfJ+ZpjLx0QOGaXiWGarK/k1S6x8m7Cc2TDxc9RE3q4ThfbUySKOd3yUcOfCSWqSckfbDJ\nvIfIg9jFMU/XStqxNE+r9e7h8i+HjeEcJyTy2Cm/7s5okratPG6bGcvj0yqMWqPm8UjtfVQ19aX8\ni91keUC/NK7vvPJ+Nsnv/nGb8+N6fyfp3RXzHhP3aYPUOkMIfrMCWmVmR8rfht8vhHBn3fzAa535\nj/A8FUL4+JrOy+pgPurIC5K+EEL4cWH6J+VfwrYKfbuqAYPGzD4h74a0Qwjhqbr5kRfzHzg7Rn5+\nXxMBrJn9WtLMEMJxtfO+Ro4J+sHM3iJvDfq9/FviHvLH2E/Ihyyk8AA1zOyt8u5r24X8f9q8lpl9\nTv4YeZdQeLHPzC6Xv0v1tTWWOay1zEcS2lYe0N8bQjiiZhFkyMzWk3evOSn4i+JrNfNfSP+9vD6t\n/ZK6JvrUIx8L5GPbfkreNWGG/AWQUwnogdaEEH4X+9ZupZr3HtYSS+WP0Pu87BpCqHzRExgE58u7\nh94t7yqGtVAIYZ6ZHaf+j4aVm43l9WlLT51oqQcAAAAytyaGtAQAAAAwiOh+A6BtB3ccxSM+4FV2\nc+/V7fyOAYDXOFrqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIXNeazgAA4LXNutK3\norBiRSIxDGjbHSNGJNN7Fy1Kptvuu1Smhfv/3K88AUB/0FIPAAAAZI6gHgAAAMgcQT0AAACQOYJ6\nAAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJljnHoAWBuY1aTXtOH0JsaCl9S5/TaVaTMO2Ci57Lir\nH02mr5g7L5n+aqobh77OMx8YVZk2/v4BrRoA2kJLPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDM\nEdQDAAAAmSOoBwAAADJHUA8AAABkjnHqAeC1oGYc+jovHlQ9Fv2cN/Ukl124yS7J9C3PurtfeRoM\nXVttkUx//r3p9O75g5kbAOg/WuoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0A\nAACQOYJ6AAAAIHOMUw8AawHr6k6mh55lyfSeg/ZIps/bMVSmdb+U3vbSbZek02/aOpn+4tx1K9NG\nDEvv15zn1kumd6+/NJm+3rozk+nzpqXXDwCrCy31AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5xqkHgBx0dCaT68ah7xydHk99ypHp9VtiOPcVQ6vHsJek4SPT\nY8GbpZfv6KhOr1t2ux1fSKY/M23DZPqceesk09WV3j4ArC601AMAAACZI6gHAAAAMkdQDwAAAGSO\noB4AAADIHEE9AAAAkDmCegAAACBzDGkJ4LXFrDot1AxPWDOspEJvTXp6/dZVXSWH5cvT667x9Od3\nTqYPnZFevnNJ9XFbtGU6byOG9iTTn3tp/WR6R2f1ce3tTbdNzV40PJneuyx9Toeumx6Os3tI9b7X\nDSO6Yu68ZDoAtIOWegAAACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4A\nAADIHOPUA8hLapx5qX6s+bpO3uh9AAAIJklEQVT0lN4V/V9W6XHopYGNRT/jn/dJpi8blx4rfvRD\n3cn03kTWu0YtSy47e846yfQwZ0g6fYPq9Xd3pc9Jd+fAzllHR7q8jBxePY59z67bpNd9+/39yhMA\nNENLPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJHUA8AAABkjnHqAeRl\nIOPMS1JHZ2WSdVanSVJYnh7rvS5vAxmH/oXPp8ehn79det3Dnk+PQ790THr7IfHzAMOGp8epX/DC\nyPTKR6bHkg+9iXUvHppcdvjQdN5U+7MHNTMk/PWQYcn08bf3e9UAsApa6gEAAIDMEdQDAAAAmSOo\nBwAAADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgc4xTD2D1S4wVXys1aLkkWU1bRW/1mOgh\nkTYYOrcbn0yfevQmlWkrhqfHwB/5dLo6X75OMlkrhqbXv2xM9bEZsiy9basZ671reM34/wkrVqTP\n95Jl6fH5tSKdt6WL0sv39lYvv9Wez6W3DQCDiJZ6AAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJkj\nqAcAAAAyR1APAAAAZI6gHgAAAMgc49QDaJt1pauOsHx5egWv5njwof/r7tpi82T64h03SqbP3mlo\nevmN02PBdyyrTuuenx5Pfdl66XUvXzedHrrT6RpS/fsAITFWuyStt/m8ZPrQ7nR5mT2vepD9FcvT\nv3lQlzd11ByXxTXj/3dWLz9zQfrHAcbuvWsyHQDaQUs9AAAAkDmCegAAACBzBPUAAABA5gjqAQAA\ngMwR1AMAAACZI6gHAAAAMseQlgDaVjtkZY2urbesTFu8w7jksj0j00MYLlsn3VaxfHh12vytk4tq\nxfCaISl70uldC9PDK4ZE1peNSq97xbB0utWNMjq8eshKSbLF1ce9Z1n6mC8bkt743OnrJtO7Ry2t\nTBs2PDEOqKSFcxMnXFL3Ounlx45ekEyft6h6/TttOD257HPjtk+mA0A7aKkHAAAAMkdQDwAAAGSO\noB4AAADIHEE9AAAAkDmCegAAACBzBPUAAABA5gjqAQAAgMwxTj2AQbfgqLek0zetHvO8o2Y89SUb\nptNDZ8147Suqx4rvWF6z7IL0OPPL10kvv2SjFcl0pVY/JD2OfOfcdHWeGgNfkjpHpg98R0f19nsW\ndSeXXbxwaHrbL6d/e2Do2IH9LkJKz9xhyfQZvekDlxonf/SQxcllp9X8rgEAtIOWegAAACBzBPUA\nAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHOPUA2jb/A/ulUxffvysZPqC\nJzeoTBs2Pd3W0L0gmazQkR5LvqN6WHGFzvSyyXHkJXXXjGPf253eN0sMRd+zbs2Y5jV5WzEsvXxI\nD4Mv66pefsy4l5PL7rTBjPTKt0snj+peUpnWZTVj/2+RTn5xyahk+rih6QI3e9mIyrRpi9ZLLjt8\n2sJkOgC0g5Z6AAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgc\n49QDaNvoyc8k06fsuU0yfdzOL1WmbfXmOf3KU8OS5d3J9OmLRlamzZyzbnLZ5XOHJNO7X+5Mpvd2\n14wVnxhrPozpSS672zZ/S6aPHZYeb32b4TOT6StCdRvQaRs+kVz27FnbJ9Nvmr5TMv2cHa6rTBvT\nOTS57IpQM75/jUUhfdx/s2jLyrSnlmyUXPbO0Zv1K08A0Awt9QAAAEDmCOoBAACAzBHUAwAAAJkj\nqAcAAAAyR1APAAAAZI6gHgAAAMichQEO9wXgtefgjqNetYqjc/31k+kvv32HZPqcHdLDSnbtWT1k\n5rZj0sM6brlOerjNzYam0zuVPmwrVD2mZU9vegTiRxdskky/55nxyfT1bxuWTB975UOVab0LFyaX\nHaje325RmXbg2CnJZR+anx428sWFo5LpsxaOSKYvX15d3nqWpc/ZDp9KDw174+yLEoOcAkBftNQD\nAAAAmSOoBwAAADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYYpx5A217NceoB\nuJt7r2acegAto6UeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmbMQwprO\nAwAAAIABoKUeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADL3\n/wEBR2EX21X4vwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "!pip install -q requests\n",
+    "\n",
+    "import requests\n",
+    "headers = {\"content-type\": \"application/json\"}\n",
+    "json_response = requests.post('http://localhost:8501/v1/models/fashion_model:predict', data=data, headers=headers)\n",
+    "predictions = json.loads(json_response.text)['predictions']\n",
+    "\n",
+    "show(0, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(\n",
+    "  class_names[np.argmax(predictions[0])], test_labels[0], class_names[test_images[0]], test_labels[0]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "YJH8LtM4XELp"
+   },
+   "source": [
+    "#### A particular version of the servable\n",
+    "\n",
+    "Now let's specify a particular version of our servable.  Since we only have one, let's select version 1.  We'll also look at all three results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 920
+    },
+    "colab_type": "code",
+    "id": "zRftRxeR1tZx",
+    "outputId": "c04d6187-9f67-40df-b43b-08819bc20110"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAvUAAAEtCAYAAACIx59SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3Xm8HUWd9/Hv7y7ZCCEEEvYlrAIq\nMCgCDpuC8oALIijKFleGcYNH53HAEQLjhijojIIoMoEBgUFRFBABISwCiiOrLGExCgQSspI9N7n1\n/PGrQ/p2Tlefc+8lscLn/XrldXO6eqnurq7+nerqOhZCEAAAAIB8dazpDAAAAAAYGIJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQOYJ6AAAAIHME\n9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0AAACQuWRQb2ahhX9T\n47yTzOy51ZLrNcDMDoj7e0A/lp1qZpNq5tnNzCaa2ZgmacHMvtLudleXmO9gZl0181XuY2K9b2sy\nvaWyZmYTYr62bmV7rzVm9tZ4fGbUnbsW1jXVzC6rmWeimYWBbKe0vtV+XbRbhuMy65jZNDM7ss1t\n1dYbq5OZdZrZl83sL2a21MyeNLOTm8z3CzM7f03ksR2t1g9mNtnMJhc+t10G1lZVdfSrtJ1QmhbM\nbOKrve1WmdlwM5sX87XrANdVe48bSExSsb7JZnbXYKyrjW2Ojuf2H9pc7pdm9r02l5nUiFf/XpjZ\nkWZ2v5ktMbMXzex7ZrZuaZ6TzexhM2upEb5upr1L/16U9JvStPe1uyNoajdJZ0ham28U7e7jGZIG\ncsO4Xl5GXxjAOtZmJ8S/YyX9nzWZkYz05zr9vKSZkn72quRo9Tlf0r9J+rGkd0m6WtK3zOzfSvOd\nKekTZrbDas7fq+Wf47+G10Jd3aqB1tFrk/dJGhX/f/yazEhGRsvLUMtBvZntJ+kdkr7+amVqdTCz\nD8nr0AclvVfSREkfknRNadYL5ffoE9SCZOtcCOHeUiaWSppZng78PQohvCTppTWdj79HZjZM0gck\nTZa0p7zC+NWazNPayMyGSvqMpIkhhEF7SrG6mdmWkj4u6d9DCI2nIzeb2ShJXzKz80MIsyUphHC/\nmd0v6WT1DYazFEJ4dE3nAVk4QdJsSU9KOsbMvhhCWL6G87Q2+hdJvwohPL+mMzJA/y7p9hDChMYE\nM5sp6WozOzSEcIMkhRAWm9mlkr4g6b/qVjroferNbHczu9PMFsXHs//UZJ7xZna5mb0UH+M+YGa1\nLf6Fx6X7mNn/mNl8M5tuZqfG9EPio4yFZnafme1RWt7M7BQze8LMlpnZC/Fxx6jSfGPN7Cdm9rKZ\nzY0HdHRFno4ws3vj/s41s6vjDbCdYzZBK0/Wk7aya9PWpfk+Gx99zzez281sl3b3z8y2juueUFp2\nlUd55o/bvxLXs8jMbjWz1yUee443s+vNbIGZ/dXMTm88Mmp1HwvbbgRAXyrMO7E0T7KsWZPH62b2\n4VhGFsTz+7CZndgsD3H+PeI6/rEw7TNW6vphZtvHaYfFz2PN7EIzmxLz92wsU5uV1r+Dmf3cvAvM\nEjP7WyxDdV2ZzjSzP8V9mBnPzV6pZUoOl7SevPX155LebWbrl7bRKCsnmtlZsRzMNbNfmdnmNfnr\nNLMfxvwdlJivy8xONbPHzeuCaWb2bfMvHa0wM/uSmT1nZovN7A4z2608Q911EecbFadPi3l5Ii5n\nMX2C2ijD0eHyFt2rmmR8fzO72fyR/UIze9DMPpbY0UEpU2Y20sz+M05fGue7xcxel9iPPeX3i1+X\npt8oaZhWfdJzpTywGZ5YZ9V+DjOz88zskXidvhjL3OtK8zWu773M7ycvx3P3H+XyY2bbmNdNi8zv\nO9+VNLTF/LzS/abdMhCP81Olaf8bl9muMO2r5veyRll7h5ndYCvr3kfM7PNm1llaV1v1WVxmOzP7\nb/N7yWIze8bMLrDS9R/nrSyjlqijrdRlqbC+Pl3KWi3Tdczs/VbR7SXmJdkQaWZHm9ehL8Vjeb+Z\ntdQyGpffTNJB8nJ/kaSNJL2zyXxTzeyyuL3H4jH9oxXuL4ltfMS8/vrXmvkGFJOY2XtjeVtqXi9/\noMk8h5jZPbH8zDPvcrdjaR6zRL0br5m/xNl/VChDExJ521Re1/ykSdr4WK5fjHl/Jl7nqX0902ru\no9ZCfWlmn4vnc7GZzYnntDKmNbMNJW2r5vWptGoPmCsl7Wxm+6T2Rxr8oH6U/GBfJn+ccJ+kC8zs\nwMYMZraFpN9L2lXSKZLeI+lPkn5mZu9pcTuXSHpYvuO/kPQ1Mztb0jmSzpb0QUnrSPqFmQ0pLPdV\nSedKulnSuyV9U9IESddb3/5K18gfL58W17Vc0n+WM2EeRP5M0qOSjpR0oqTXS7rdSv2ialwvqREg\nHqWVXZuK3UaOlXSYpM9J+oikLSVda32Dv1b3r1Vnyo/BpfLzeZOkXybm/7mkW+WBzC/i8o2KsZV9\nLNo7/p1UmPeiQnptWSuLFedlkm6PeTxS0o9U8YUtul/SXPV9xPw2SYubTFsu6Y74eYykJZJOlXSI\nvHVhe0m/s74Bx/WSNpN0kvwm8K+Slqr+2txM0nnyfZ8gaYakO8zsDTXLNZwQ9+uX8vM7RNLRFfOe\nKmk7SR+Vl7+95cexKfNA7mcxbweEEG5J5OMyeZeOn8jL99clfUzS5S3ux/GSDpX0aflx2EjSb61v\nf+fa6yL+vV5+bX07zndjXO6rcT3tlmHJz/1jIYSZxYlm9l5Jv5Uf9xPlx+piSVsl1jVYZeo8+VOa\nMyUdHLf/gNLXwYr4d1lp+tL49/Wl6XfIr9G91b6hktaVH+vD5PsxTNI9ZrZxk/n/W9LTko6QdIGk\nT8mPkSQp3gNulrR7TJsgaby83LWr3TJwm6RtG0GVeeC8m5rXH5MLT3O2kZePj8qPwSXyx/ONstjf\n+kySNpX0rPxJyjslnSXp7ZJuKM7UQhmtq6Nb0WqZrnOtpGkxn8V9eJ2k/SX9oGb5bST9VNIx8mP5\nK0kXWZNGyQrHyq+vS+VdKpaougvOvvIueV+Wxxedkq4zs8rzZmanybthfDKE8I3EfAONSbaT9B/y\nOvAISU9JurIUwx0ivw4WxPyfFLdxV+nLWF29+0LchuT1fqMMXZ/I38Hy43Vnab/HS/qDpP0knS4v\nS2dK2rBmf1u5jybrSzM7Rn68rpDfi46Rl6VU97yq+rRHUtCq9ekDkubH/UoLIbT8T9JUSZdVpE2K\nmTmwMG2opFmSfliY9mN5l4gNSsvfLOmBmu1PiNs4vTCtS34ieiSNL0x/T5x3//h5jPwGNKm0zmPj\nfO+Jnw+On48uzffrOP2A+HmkpHmSLi7NNz6eqJNLx21Si/u2XZO0IH+k112YdmScvk+b+7d1/Dyh\nNN8Bpf1bX37Rnl+a7//G+SYWpk2M0z5SmvdhSTe1so8VxyRI+soAylpje1vHz1+QNLudMh+Xu1bS\nbfH/HfJHrN+OZW5knH6lpHsT6+iUtEXMz/vitA2L56a//+K6uyQ9Iem7Lcy/ifwLyIWFfXqunP9C\nWZlcmv6FOH3TUhm/LJabu+RB1ral5SZKCoXP+8b1HF+a75g4fbcWysdMSeuU8twj7yYitX5dvEvN\nr4uL4vIb9rMMPybp8tI0i8frj5I6EstOLed7MMqUpEckndtmGds5rvek0vTT4/QLS9O75Teu0wZS\ntgv7OUJ+UzulML1xLs4szX+dpCmFz5+I8+1VmNYh6c8q1A+J7U8uXgPtlIFY/nolnRA/Hy5pjvw+\neEWcNjKW2X+qWIfJr+8vxWU7Ctdh2/VZk/V3SfrHuE+7t1lGq+roPsdsIGU6Tp+oQt1R2PbE0jzz\n1Lc+ODces+FtHI+OeEx+JOnBFpd5VNLjhc9XyL+4jW6y/3MkrV+Y9qa4Lx8uTJskr5M75A2KCyUd\nVlrXAepnTJIo5+XrpFPS45LuLEz7ozwe6Spto0exXlH78cjHWzzOF0h6vsn0S+XxyqaJZSdJmlpT\n9la5j6qmvpT0PUl/aueai8vNkHRVadp+8Xg80WT+O1WIp6r+DXZL/aIQwm2NDyGEpZKmyFuVGw6R\ntwjMM3/03hVbm38jaVcrPRKv8Moji+B91p6SV+J/KczzePy7Rfy7l7zFodzCeKU8wNk/ft5bfjMq\nv9R2Zenz3vKWqMtL+/Fs3PZ+LexHO24OIfQUPj8c/zaObav716o3yJ92XF2a/tPEMuVv2I+o77kf\nTK2UtbL7JK0fH3++K9UyUnKrpL1jy9Fu8m/o35RXWvvGeQ6Ut8q9wsxOMn9cvUB+Dv4WkxqPKWdJ\nekbSN8zsE2a2fYv5kZkdZGa3mdmsuO4eSTsU1p1yrLwCu1SSQgi98nLzlvIj1OiG0udy2WvYVB7Q\nj5B/2Xy6Jh+HyG82Py1dQzfF9FauoRtCCAsbH0IIUyXdq5WtiK1eF/vJg6/yY93L4vL9aXGW/JiU\n3+vYUd7aeVE89i0bpDJ1n6QJZnaamb3JSl06mgner/wWSWea2TvNR614n7y1V/JjV5y/Rx5gbNrO\n/jWY2QfM7PdmNle+nwvlQUuz8lmudx5W37K5t6RnQ+FdsHjc/6c/eWtH8PcMHtTKVvm3yVvWb5HX\nGZKXvS4V6g8z28S8W8pf5ddIj/wJwWhJ4+Js/arPzGxIPPePm9niuO5Gy+eOhb/9KqPtaqFMt+qH\n8rrnQ3G9w+RPJC8NISyuycP2ZnaFmT0vPx498ndIavNgZm+WtJP8iVHDJfKnSx9sssg9IYQ5hc9V\n9WmXvJ76sKSDQgipFmxpcGKS8nWyQh4D7GlmHWa2jvyl1qtC4X2BGHv9Tivr08GORxqa1aeSvzh7\nXQhhWjsra/E+Wldf3idpt9hF5yAzG9Hi5r8r6Ugz+7SZjTHvLn6BPP5sds29pBbq08EO6uc0mbZU\nXrgbxskfS/WU/p0T0zfox3aWVUxTYduNRyF9HpPGgjmrkL6JpDmlAFqSppc+NyrWW7TqvrxBre1H\nO2aXPjcee7e7f63aJP6dUZpePg51eWznEWo7WilrfYQQbpc/Mt9C3lXopdg37o0127pN/iRgH/mN\n+MEQwnR5AHug+bsN4+TBvyTvdy/vr36L/BHjnvKKTo08Bv/6fbC85ePrkqaY9wM8KZUZ8+G/bpC3\nTHwsrvfN8uChleN9gvzG+ecYnI2WP42Qmj8yrit7DW+Ut+heFY9PnXHyin+h+l4/jTLXyjXUbDvT\n5Y9VpdavizHyVs/y49AXS+tp1zCtPF4Njf1qawjgQSxTn5E/yv+o/IY0w7wPe93NaIK8RfJG+fU3\nSSu7uTTrfrJYUn/61L9b/g7CY/KA5i3y8v2SmpfvZuWz2F9+E1WXk9XhNq0M4Btf/m+TtJGZ7Ryn\nTQshPCG90hXsl/KnR1+RfxF4s1Z2vWmc6/7WZ1+Xt2pfJu/as6dWdoNoHN9+ldF2tVKmWxUDumsl\nNbrMHCW/bi+sycNIeU+BXeVd1faVH++L1dp7FyfEv78q1Kf3yctrbX0aG6SkVfd3lPz83C3vWlJn\nMGKSqutkiHwElvXlT3GaXe8vqm99qvJ8A4hHGprVp5LvW7v1aav30br68lJ5F6S3yBunZ5vZNVY/\nlPY58ifB35Efk3sVe6xoAPXpgMam7qdZ8laBsyvS2/qm1YbGhbSx/LGrJH9RT14gGukvyFs/ukuB\n/Ual9c2KfycU11cwf6AZblOr+7ck/i2+ayCtesE3CtU49d2/8nHISgjhp/KW4ZHyx5dnS7rRzDZP\ntEg9LO/m8TZ5v9xG8H6rvK/ds/Ivkb8rLHO0pN+GED7fmBD7/ZXz84yk483M5DeVT0s638ymhhDK\nL9E0vF/eqnBEsYya99edm9h9xdaAxgvWzb4YHWdmX+5n69yN8grxbDNbEkJIvqQkv4aWaOXTjrJW\n6oJm5XEjSY2REVq9LmZLGmNmQ0qB/caF9P6YJb8RFjX617f1MqAGqUyFEBbIg/FTzWwreVe+b8jL\n8BerNh58tIkDzF9WGyPvYtUIIJuNbz1GK/e1HUdLeir0HRWiW/0PBF7QyjJftLrqstsknWL+ktsu\nkm4NIbxoZo/J65S3qe9Tvm3lXTKOCyG80tIZv+z00c/67Gh563XxRf+RpXn6W0Yblmjl8I5F5XPY\nUpluw/nyd2r2kPd9vjPUj160t/ypxL4hhFfKsbXw2x3m72t8KH58sMksY81s+xDCky3lvq/Z8qeq\n10n6iZkdE9Kj6QxGTFJVny6Tf0kZLu8e0uzdlo3Vtz5tTEvVu+2aJe/qUzZT7ZfVlu6jdfVlbEi5\nUNKFcdl3yLvnXiUP9JuK95kTzeyL8qc0z8nP0Ux5K35ZS/XpmvhF2RvlN4I/hxD+2ORfs29hg+Fe\n+Ukovwz4QfmXm8nx8z3yrgnvL81XXu5u+QnYrmI/nmgzf439brtlK2p1/6bHbZVfxDis9PlheQvq\nUaXp5c/taHcfl7Uxb1tCCAtCCNfJL8ZNlGjFiBftZHkL6L7qG9TvLn9h+w8hhEWFxUbIW0iKPpLa\nRgjhAfk7C9Kq56dohPwRXWhMMP8BmFa6Op0Ql3u/vIWw+O8b8la/ypeN64QQzpH39f2OmZ1SM3tj\n5JT1Kq6hVoL6Q+MjYUmvjKiwl/w6llq/Lm6X14fl8n1MXL6xvnbL8OPyl/CKpsj71n48Bt6tGvQy\nFUL4awjh2/LrPVXmistMCyE8Ig/cTpbv4+TiPOYvtA6T909t1wj5zbboOHm93B/3SNrCCqNaxNbw\nVUb1aFG7ZeB2+fV6lvym/Eicfqu8dXo39Q3qGy2AxUCjW14Wm2qnPlNr5ajVMlpVR/9V0g5WGKjC\nfHzx8suabZXpOiGEW+Xl8VxJb1X9C7KNPEh9j/f68pcn67xLHmydqVXr00ad0+8x60MIk+WjvRwq\n6YqaLxqDEZOUr5NOeZ34hxBCb+zq+L+Sjip2Q4nB7j5aWQ+0Wu/2pz7doslxuEnSu8xskybLVGn7\nPlpXX4YQ5oQQrpJ37Wu1Pp0bQngodtX7mPzp0MVNZh2vFurTNdFSf7r8UdId5r8INlXekvV6SduE\nED76amw0hDDbzL4t/7a1UP7YZSf54827FPtlhhBuNv9VtQvNhx16Ul4QX19a38tm9i+Svm9mY+X9\n/OfJvy3uL39JaJVhlxIarQmfMrNL5BXMQ026Awx0/4KZXSXpY2Y2RV5IDpO38hTXN8fMviPpNDOb\nL3+k9w/yQic17/M12Pv4qKTDzKzxuH9au33miszsLHmrw23yVuDNJX1W/oJ23Xj2t0n6vrwSaPQ/\nvV9eiR4ov2EX3Sjpi+ajFvxB3hrX5xdF42Py78q/0T8lD1omyAOaW1XtRnkwNcnM/kveB/DLWtk6\n3VQMDD4kHxu3/AMXMrMH4nqPl4960S8hhHPNbIWk88ysI1aCzeabbGZXyFsaz5Ufp175y1OHyltB\nptRsbrGkm8zsHHlleKakl+UjFrR8Xciv37sk/SBez3+Oefi4pK+HlaPXtFuG75B0cjwOvTFPwfyX\nWK+RdKuZ/UDeCraTpHEhhDMq1jUoZcrM7pF373hY/uh5f3mL/iUV222s+yR5IP8XeQvcCfIXLN/e\npFW40UJ1R2H5reOyZ4YQJiY2daOkw83sPHkr5Zvkj8CTT6ESLpF3q7gmHrsZ8i4arby/1UxbZSDe\nK/4kH2Hm6thIIHmd8qn4/+L1/pg8KP5qvI565CPF9TGA+uxGSSeY2cPyMnKEPCAr5rnVMlpVR18p\n6ZOSLjYfwnK8/MvlvCZ5SZbpfrhAfg20+oNvd8vrjO+b2Rnyd8n+LS6/Xs2yJ8ivoW/FFt0+YsPG\nsWZ2euG8tyWEcKf5iDO/lnSVmR0dVu0ePFgxyfS4jTPk5/sk+f2l2H3vy/J68zrzX44eKa9358lb\nqNupd6fLW9+PNrOH5A2JfwkhzFJzd8RtvVE+amLDGfL6+m4z+5q8XG8m6ZAQwrEV62rpPlpXX5rZ\nD+VxwD3yumUHeSPETUows4PlceUj8gaQd8h/1+Mzwd8NK847Oq73W6l1Shr00W+eazJ9slYdPWNz\neV+i5+Xf5l6Q9yU6tmb7E9Rk1IG4jbtK07ZW6a1qeV+wU+SBbGO735c0qrTsWPnb6/PlN5LGkI6v\nvGlemPdQeaX6sqRF8i8BF0vauXTcJrVwfM+Ix6Tx7XHrOH2VEQbUZBSbNvZvtPylnpnyx2A/kAf2\nffZPHhB8Vd5XbnE8zvvE+T5XmG9inNZV2s4kld42r9rHiuPxVnmrwBIVRjpotaxp1dFvDpP3eXtB\n3kLwrHwUiso35gvr2imuqzxCzLUV5WK4/ObyUixH18lvbMX9GCevGKbEsjNb3qr3zhby8xl5gLRY\n3s/voPL+N1nm8Lj94xLzXC6vuEaqYmQClUZdqKob5AFLr6T/VywnpXk65MNkPhjP87z4/2/KW/BT\nxyDE8nma/NHlEvkXrt1K87V6XYySj2TwQpxvSlzOBlCGG+Vm/yZpjW4XC+K/B1UYQUqlemOwypS8\ni8b98VgvlN+sPttCmft0PIZL4nqvkbRLxbw/kvTH0rRdYl6bjvJSKhNfkQeqi2L+d29yPCao+f2g\nWTnbRh5YLIrH77vy7hnJ89esXmm3DBSOeZ9918qRcaY2mX83efCzSF62z5J/wRxwfSYfIelKeRA+\nR37Nv1nNR3+qK6NN6+iYdqL8frhYHjjv0eQc1pbpxDntM09h+iYx7Zy6Ml3az/tjXp+WfzlaZZul\nZcbK64kfJ+ZpjLx0QOGaXiWGarK/k1S6x8m7Cc2TDxc9RE3q4ThfbUySKOd3yUcOfCSWqSckfbDJ\nvIfIg9jFMU/XStqxNE+r9e7h8i+HjeEcJyTy2Cm/7s5okratPG6bGcvj0yqMWqPm8UjtfVQ19aX8\ni91keUC/NK7vvPJ+Nsnv/nGb8+N6fyfp3RXzHhP3aYPUOkMIfrMCWmVmR8rfht8vhHBn3fzAa535\nj/A8FUL4+JrOy+pgPurIC5K+EEL4cWH6J+VfwrYKfbuqAYPGzD4h74a0Qwjhqbr5kRfzHzg7Rn5+\nXxMBrJn9WtLMEMJxtfO+Ro4J+sHM3iJvDfq9/FviHvLH2E/Ihyyk8AA1zOyt8u5r24X8f9q8lpl9\nTv4YeZdQeLHPzC6Xv0v1tTWWOay1zEcS2lYe0N8bQjiiZhFkyMzWk3evOSn4i+JrNfNfSP+9vD6t\n/ZK6JvrUIx8L5GPbfkreNWGG/AWQUwnogdaEEH4X+9ZupZr3HtYSS+WP0Pu87BpCqHzRExgE58u7\nh94t7yqGtVAIYZ6ZHaf+j4aVm43l9WlLT51oqQcAAAAytyaGtAQAAAAwiOh+A6BtB3ccxSM+4FV2\nc+/V7fyOAYDXOFrqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHEE9AAAAkDmCegAA\nACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIXNeazgAA4LXNutK3\norBiRSIxDGjbHSNGJNN7Fy1Kptvuu1Smhfv/3K88AUB/0FIPAAAAZI6gHgAAAMgcQT0AAACQOYJ6\nAAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJljnHoAWBuY1aTXtOH0JsaCl9S5/TaVaTMO2Ci57Lir\nH02mr5g7L5n+aqobh77OMx8YVZk2/v4BrRoA2kJLPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDM\nEdQDAAAAmSOoBwAAADJHUA8AAABkjnHqAeC1oGYc+jovHlQ9Fv2cN/Ukl124yS7J9C3PurtfeRoM\nXVttkUx//r3p9O75g5kbAOg/WuoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgcQT0A\nAACQOYJ6AAAAIHOMUw8AawHr6k6mh55lyfSeg/ZIps/bMVSmdb+U3vbSbZek02/aOpn+4tx1K9NG\nDEvv15zn1kumd6+/NJm+3rozk+nzpqXXDwCrCy31AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5xqkHgBx0dCaT68ah7xydHk99ypHp9VtiOPcVQ6vHsJek4SPT\nY8GbpZfv6KhOr1t2ux1fSKY/M23DZPqceesk09WV3j4ArC601AMAAACZI6gHAAAAMkdQDwAAAGSO\noB4AAADIHEE9AAAAkDmCegAAACBzDGkJ4LXFrDot1AxPWDOspEJvTXp6/dZVXSWH5cvT667x9Od3\nTqYPnZFevnNJ9XFbtGU6byOG9iTTn3tp/WR6R2f1ce3tTbdNzV40PJneuyx9Toeumx6Os3tI9b7X\nDSO6Yu68ZDoAtIOWegAAACBzBPUAAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4A\nAADIHOPUA8hLapx5qX6s+bpO3uh9AAAIJklEQVT0lN4V/V9W6XHopYGNRT/jn/dJpi8blx4rfvRD\n3cn03kTWu0YtSy47e846yfQwZ0g6fYPq9Xd3pc9Jd+fAzllHR7q8jBxePY59z67bpNd9+/39yhMA\nNENLPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJHUA8AAABkjnHqAeRl\nIOPMS1JHZ2WSdVanSVJYnh7rvS5vAxmH/oXPp8ehn79det3Dnk+PQ790THr7IfHzAMOGp8epX/DC\nyPTKR6bHkg+9iXUvHppcdvjQdN5U+7MHNTMk/PWQYcn08bf3e9UAsApa6gEAAIDMEdQDAAAAmSOo\nBwAAADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgc4xTD2D1S4wVXys1aLkkWU1bRW/1mOgh\nkTYYOrcbn0yfevQmlWkrhqfHwB/5dLo6X75OMlkrhqbXv2xM9bEZsiy9basZ671reM34/wkrVqTP\n95Jl6fH5tSKdt6WL0sv39lYvv9Wez6W3DQCDiJZ6AAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJkj\nqAcAAAAyR1APAAAAZI6gHgAAAMgc49QDaJt1pauOsHx5egWv5njwof/r7tpi82T64h03SqbP3mlo\nevmN02PBdyyrTuuenx5Pfdl66XUvXzedHrrT6RpS/fsAITFWuyStt/m8ZPrQ7nR5mT2vepD9FcvT\nv3lQlzd11ByXxTXj/3dWLz9zQfrHAcbuvWsyHQDaQUs9AAAAkDmCegAAACBzBPUAAABA5gjqAQAA\ngMwR1AMAAACZI6gHAAAAMseQlgDaVjtkZY2urbesTFu8w7jksj0j00MYLlsn3VaxfHh12vytk4tq\nxfCaISl70uldC9PDK4ZE1peNSq97xbB0utWNMjq8eshKSbLF1ce9Z1n6mC8bkt743OnrJtO7Ry2t\nTBs2PDEOqKSFcxMnXFL3Ounlx45ekEyft6h6/TttOD257HPjtk+mA0A7aKkHAAAAMkdQDwAAAGSO\noB4AAADIHEE9AAAAkDmCegAAACBzBPUAAABA5gjqAQAAgMwxTj2AQbfgqLek0zetHvO8o2Y89SUb\nptNDZ8147Suqx4rvWF6z7IL0OPPL10kvv2SjFcl0pVY/JD2OfOfcdHWeGgNfkjpHpg98R0f19nsW\ndSeXXbxwaHrbL6d/e2Do2IH9LkJKz9xhyfQZvekDlxonf/SQxcllp9X8rgEAtIOWegAAACBzBPUA\nAABA5gjqAQAAgMwR1AMAAACZI6gHAAAAMkdQDwAAAGSOoB4AAADIHOPUA2jb/A/ulUxffvysZPqC\nJzeoTBs2Pd3W0L0gmazQkR5LvqN6WHGFzvSyyXHkJXXXjGPf253eN0sMRd+zbs2Y5jV5WzEsvXxI\nD4Mv66pefsy4l5PL7rTBjPTKt0snj+peUpnWZTVj/2+RTn5xyahk+rih6QI3e9mIyrRpi9ZLLjt8\n2sJkOgC0g5Z6AAAAIHME9QAAAEDmCOoBAACAzBHUAwAAAJkjqAcAAAAyR1APAAAAZI6gHgAAAMgc\n49QDaNvoyc8k06fsuU0yfdzOL1WmbfXmOf3KU8OS5d3J9OmLRlamzZyzbnLZ5XOHJNO7X+5Mpvd2\n14wVnxhrPozpSS672zZ/S6aPHZYeb32b4TOT6StCdRvQaRs+kVz27FnbJ9Nvmr5TMv2cHa6rTBvT\nOTS57IpQM75/jUUhfdx/s2jLyrSnlmyUXPbO0Zv1K08A0Awt9QAAAEDmCOoBAACAzBHUAwAAAJkj\nqAcAAAAyR1APAAAAZI6gHgAAAMichQEO9wXgtefgjqNetYqjc/31k+kvv32HZPqcHdLDSnbtWT1k\n5rZj0sM6brlOerjNzYam0zuVPmwrVD2mZU9vegTiRxdskky/55nxyfT1bxuWTB975UOVab0LFyaX\nHaje325RmXbg2CnJZR+anx428sWFo5LpsxaOSKYvX15d3nqWpc/ZDp9KDw174+yLEoOcAkBftNQD\nAAAAmSOoBwAAADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYYpx5A217NceoB\nuJt7r2acegAto6UeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAA\nADJHUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmbMQwprO\nAwAAAIABoKUeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADJH\nUA8AAABkjqAeAAAAyBxBPQAAAJA5gnoAAAAgcwT1AAAAQOYI6gEAAIDMEdQDAAAAmSOoBwAAADL3\n/wEBR2EX21X4vwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsoAAAEtCAYAAAARP0bnAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3XmcHVWZ//Hv051OOgshEAg7hB1H\nRURlc0BgFFCQQQYHRsFf3AaXAUfn5w8BFXR0FB1cEUVQIqKgoOIoEomQgIhIGFZBEvYtLCEhIVt3\nejm/P55zSaX61Kl7e6FZPu/Xi1e49dR+T5167qlTpy2EIAAAAADrahvtHQAAAABeiEiUAQAAgAQS\nZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAA\nACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCB\nRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkA\nAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABI\nIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAErKJspmFJv57MM4708wefV72ehSY2f7x\nePcfxLIPmtnMmnl2M7PTzWzDRCyY2Rda3e7zJe53MLMxNfNVHmNmvQcmpjdV1sxsRtyv6c1s7+Wi\ndP32mtkDZna+mW05iHUNuC7MbK6ZzR3OfX6+mNmRZvakmU1oYZlB1w0jwcxeb2bfN7O7zWyVmT1s\nZj8xs21L820W43uM1r42q5kyZWbT4/cwozBthpm9b6T374Wu1bp3iNta5373QqmHC+Wj8d8aM1tg\nZl83sw0Gsb4Bx9XMvf6Fysw+YWa3m5m1sMwL4rttMLN/MLMLzew+M1sd//2umU0rzffaWPdt3cx6\n61qU9y7994Sk35emvaPVg0HSbpJOkzTiFdkoavUYT5M0IFFuweXyMvr4ENbxUjVTfm72l3SmpMMl\nXWVm40dxn0ZV/KH3JUlfDSGsGu39GYJjJL1S0rckvVXSpyTtLukmM9uqMVMI4XFJ50r66mjs5Ah4\nXF6mLy9MmyHpZZ8o6+Vxf2nWl+Tl5C3yevB4Sb9qJUF8qTGzKZJOlfT5EEIY7f0Zgg9JmirpC5IO\nkX/Xh0u6wcwmNWYKIdwiabak/2xmpdkWwBDCDcXPZtYt6enydOCFKISwSNKi0d6PF6jHCtfxdWa2\nXH7TeKukX47aXo0gM+uQ1Ju5EfyjpOmSfvi87dTIOCOW/eeY2Z8kPSDpg5I+WwidI+lOM9sjhHDj\n87iPwy6E0C2JexPq3F+o+66J9cLpkl4r6eZR26sRZGbj4vVR5f2S1kj61fO0SyPlI6W67xozWyDp\nGkn/rHXr9nMk/drMTg4hLMytdNj7KMcm7T/GZu17zOxDiXm2jY8CF5lZt5ndama1LdOFZv59zOzn\nZrY8PiY9OcYPMbNbzGylmc0zs9eVljcz+7iZzY+PXR43s7PMbHJpvo3N7Kdm9qyZLTWzCyRNqdin\nI83shni8S83skmab84vHJen8+PGewqOh6aX5TjR/TL7czK4xs1e2enypx5NxeuoReruZfSGuZ5WZ\nXW1mu8T5Tk8cyrZmdrmZrTCzh8zss2bW1soxFrbdSGZOLcx7emmebFmz9KOxd8UysiJ+v3eY2fGp\nfYjzvy6u4+8L006wUncYM9sxTjs0ft7YzM4xf7S3ysweiWVqi9L6dzKzX5nZU2bWZf6Y/BKr78by\nOTO7OR7D0/G72Su3TI158d8d4vpnWuxWVdruoLpVmNnO8TiXmj8Su8HMDinE3xnP366JZX9nZrcV\nPo8xs5PNuxZ0m9lCMzvTzDoL8zTK+UfM7CtmtlBStyqu4+gDkmaFEJaUtj/GzE4ys7vid7TIzGaZ\n2S6Z4z0o7nfj2vmrmf2HmbWX5suWRzN7g5nNNrPF8bzdb2ZnZ45B5SQ5TntI/qNxi9L0uyTdEY+9\nZXH/LjWzR+P+zTez/7LSk4lYbq4zszfHcts4JwPqfTM7pvDd3pmap2Jf1qnbYjl9k6Q3FuqQuRXL\ntsey+enCtFfHZa4rzfuomX218Ln2WjSzSWb27Xh9d8fr/Q+5MlQ4F1fHMrcilpX/k5ivsoxapu4t\nn7PC+lL3g6bKdB0z+42Z3ZKYvq2Z9VsiZyjM02neVeKv8Xw8EdeXPY81ynVfso6zQXarMLM94ne9\nwjw3ucoK3Z3M7JPm9+upiWXvMrNfFz5PMLMzzPOANfHfUy3eZ+M8je/uSDM718wWSXqyZjc/IOnn\nIYS+0vYnmtmXzbswdMfz/Qsz2yRzvM2W2Y+Z2d/M641nzOym4rVuZgeb2fVmtiyuZ76Zfba8nqJU\n3ae13+8WpelXSnpW/tQpa7gT5cmSfirpQnnrzDxJ3zWzAxozmD/6+4uk10j6uLxZ/GZJvzCzw5vc\nzo/klfs7JF0m6b/M7Az5I8QzJB0taaKky8xsbGG5L0r6mrzJ/e2SviI/SZcXC5q8Re0wSafEdfVK\n+nZ5J+IF/QtJd0k6Sv4I51XyXzHrNXkskj8qbCRd79Tabi3FLgPHSjpU0sckvVfS1vJfQ8WEqtnj\na9bn5OfgAvn3eaWk/8nM/ytJV0s6Qv69fE5S4wJp5hiL9o7/zizMe14hXlvWysyT3Qvlvy6PkH9n\n5yqfPN0iaanW7QJyoKTViWm9kq6NnzeU1CXpZPkjoE9K2lHSn6yQ0MnPyxaSPizpYPlj8m7VX5tb\nSPq6/NhnSHpK0rVm9uqa5ao0+q8uHeTylcxsc0nXya/5f5P/sl8qL5dvjbP9RtIyeTkvLruJpIPk\nZbDhQkmfln//h8ofr71f0k8Smz9V0k6S/lVeX3RV7OM4eTeUPybCF8uvrd/Jy80H5df8ZpUHLW0n\n6Sr5Y/9D5XXW6XE9jW1my6P5o8LfS+qTf8dvlfR51TwJrDi+V0iaJulvifC18rI3GFtLulX+yPMQ\nSd+UH/P5iXm3j/GvSTpSfu1fYmY7FPbzzfLv9Z44z1fjMjsPYt8+Ir9+b9faOuQjqRljgnCt0tf5\nHmY2Me7fzvJr7+rCfM1ci1+Xl/vPyR/5Hy8/b7m6R/JydKmkd8vLyG8knZdIJnNltNW6N7cv2TLd\npO9K2s0G9o3/V0krlb6OG8ZJWk9+PIfK681OSX82s01b3I+Gkaz7dpVf3xvIy8Z75Peua8zsNXG2\nn0pql+caxWVfJ+kVinVfvNf/Xp7UflNeH5wn6TNKd5/6tiSTdJwyyaCZbSNpF5Xqvpg7zZZ0gvw+\nfJi8/l4Sj6dKbZk1s3fLu/xdJOltcd5LFbsGmdl28lzjAfl5OVxeb0zMbLfKm+K/69R9IYReSX+W\n11t5IYSm/5P0oKQLK2IzJQVJBxSmjZO0WNL3C9N+IG/ZmFpafrakW2u2PyNu47OFaWPkFVOPpG0L\n0w+P874pft5QnoDMLK3z2Djf4fHzW+LnY0rzXRGn7x8/T5Lf2H9Ymm9b+SOMfy+dt5lNHtsOiViQ\n3zg6CtOOitP3afH4psfPM0rz7V86vg0krZB0dmm+T8T5Ti9MOz1Oe29p3jskXdnMMVackyDpC0Mo\na43tTY+f/6+kJa2U+bjcryXNif/fJq8ozoxlblKcfrGkGzLraJe0Vdyfd8RpGxW/m8H+F9c9RtJ8\nSd9s8rx+MS7TKWkveSWyUtLmhXP8YGLZuZLmVpWbinn+W/4jYofSPs+XdHNh2rmSHpXUVpj273HZ\nzeLnfeP23lPar3fH6buVyvnNkqyJc7JnnP8tpekHxuknZpYdcA5KcYvn+lRJzzSOr648Snp9XO+u\nQywfY+Q366ckbZCIvz9uZ/MhbqdxnMdK6lehjo9lokfSjoVp0+Q/Ak4pTPuTPMErloG94v7Nrdl+\n4zufUdrudU3u/8flifG4+PkyeVK3UtLBcdqHVLjum70WJf1V0teGeH7b4rrPlXRbi2V0hhJ1b+qc\nDaVMx9iDKtyHNLAebpN0n6QfFObpkL8D9b0Wz0m7pAmSlkv6eJPl41/jvk+Q3+8fl7RQ0vhCmRlQ\n1uqOq2KeS+UJ+JTCtMnye8gvC9NmS/pzaXvfiOe2UR6Pi9vbrzTfqfKcY1rpu/tVk+fw6Dj/jqXp\n71PN/Sl1Dposs2epUPcnlmvkN5OHeM2sJ+lueZ0yJhH/T3njSVtuPcPdorwqhDCn8SF4n5gF8laH\nhkPkv3qXmT8uGlP4pfQaK3WDqHBFYRu9ku6VtCCE8EBhnrvjv42XV/aSNFbeglN0sfxG/Kb4eW95\n5f2LxHxFe8sL/E9Kx/FI3PZ+TRxHK2aHEHoKn++I/zbObbPH16xXy3+9XVKafmlmmctLn/+qdb/7\n4dRMWSubJ2kD87diDzN/gaEZV0vaO7YE7yZvBfqK/IfJvnGeAyTNKS5kZh82s9vMbIX8O3g4hhqt\nY4sl3S/py2b2QTPbscn9kfkj7Dlmtjiuu0fectpsy9spcZnV8l/VPZLeFmr6ag3SfvIfEfc2JgRv\nwbtI3rLUuOYvkLfOFVv1jpN0VfAXzySvP9ZIurR03V1Z2FbRZSHWiDU2j/+WH90dJK+wz21iHc8x\nH1HiHDN7KO5vj7wVbIo8QZTqy+M98pvsOWZ2rBVexGvRWZL2kXRsCOGZRLxxzJsnYllmNjk+Cr5P\nfj30SPqxPJEql+d7Qgj3ND6EEJ6SJ+9bx3W1S3qDpEtDCP2F+W6QJyAj7Wr5D8d94hO4N8nvS9dp\nbZk8UNJNIYQVjYWavBbnSZphZqeYj0rSVHcF8y5dF5nZY3G9PfIWxeK6B1VGW9Vkma4Vv9tzJB1j\nZuvHyUdI2iROr9uPfzazv5jZUvn5XilvuGq27jsn7vtKeb1xr6RDQgirmz2GFuwn6bchhOdaq0MI\nz8pbS4v35Ask7dV4uhLrtH+Rd4do9C0+RNJDkq5P1H0d8hygqNn+xrm674kQQu4p8gBNltl58rr/\n2/H6KY8ydGtc7mIzO8pKo1Y0uR9j5PeYLeQNn72J2RbJG9myL7kOd6KcqoS75ZVPwzT544ee0n+N\nRwcD+uk0sZ01FdNU2HbjRKzzuCmevMWF+GaSniklpdLAPj6NL+4PGngsr1Zzx9GKJaXPjYun1eNr\nVuOx8lOl6bm+Tql97EzNOAyaKWvrCCFcI3/0uJW8Ellk3ndsQL/Ykjnyi2kfeUJ8WwjhSfkN9ADz\nvuLTVHgca2YnSDpbXj6OlLSH1lZknXF/grxF4yZ594EF5n1QP5zbGTPbXf5jc4W8NXAveYJxW+74\nS34Yl3mtpI1CCLvG8zMSNlT6Me8T8oSq8RjvOnlCdJz0XHeB3bVut4tp8h+EK7XuNdcop+XrrtnH\ny43zVn7hZaq81bfpm2hMsv5H/qjyC/Lk6g1a+4i68f1ny2MIYZm8vC2Ul6WHzftm/lML+/JleQva\n+0IIV1bM1ji2wYx4cr68lfVb8rL8BkkfjbFyWSzXD9K61+xG8ht+qo6p62M5HG6X15UHyK+LyfKW\n+Dny69zkrXXF67zZa/EEeYL2PnmS8JR5X9vKYQhj15vZ8i5Ln5L/KH+D/NodV5i15TLaqmbLdAt+\nIG8NPi5+/pCkG4OPRpDbj7dL+pn8Cdi75E+C3iBPeJrdhy/EZXaVt/TuG0K4vcX9b1au7it2X/il\nvE5rnI+D5HVdue7bRgPzjcZLuCNR9z3W5DoktVRmL5B3m9lT/mN0iZn90uL7RLFR5WB5jvpjSU+Y\nv9fSVINfLK8/kvRmSUdkvt+m6r6W+7oNg8XyvjBnVMRHokVLWltJbyrpzsbE+KtjaiH+uLyVp6OU\nLJc7ry+O/84orq9g+VB3uEXNHl+jj2ax77ZUfZFN07rHV9mJ/8UghHCpvDVykvymd4akWWa2ZbEV\nq+QOSU/Lbw6v1dob5dXyfoePyH+Y/amwzDHyltD/aEyw0ji2cX/ul/SeeBNu9OE928weDCFcUZ4/\n+id5S8qRxTJqPhZos/3sHg8h3JSJd2lgGZG8nCxOTM9ZIi+XZZvKW8KekfyHg5ldKOnf44+F4+QJ\nSLFlZHHct32VVq4/mmlNbqxXGtj37mlJG5rZ+BYSke3l3SaOCyE894Qn3uTX3bma8hhCuFXSP8Xr\n+PXyPu8/N7PXhBD+mtsJMztV0kmSTggh/Dgza+NH9NNNHl9j/Z3yfrmnhxC+WZg+2H7yT8tv/Kk6\nZhN5a9qIieXvGvl1vlzeFfAZM7tanly9UdLGWvfJUVPXYmyBPlnSybFP6FGSviyvN06q2KW95YnR\nviGE514otIEv+g6mjDY0ez9oukw3I4Sw2Mx+Lul4M/u9/MdJMy+UHiPp3hDCjMI+dKi1hqCHmqj7\nUk+2BzO0Xq7ue66xJ4Sw0sx+Je9Cdpq8+9L9IYTiPWWxvM/uP1ds68HS58HUfcXy87T8natWNFVm\nYyPROfKnZRvIfxicKf8RtGecZ46kOebvj7xR/n7G5WY2PYRQV1d9T96l5KgQwlWZ+Zqq+0bjL/PN\nkv+SuzOEcFPiv9wQJkNxg7xSOqY0/Wj5D4a58fOf5b90y6025eWul1emO1Qcx/wW969x3IMdx7bZ\n43sybqt8ARxa+nyH/BfuO0vTy59b0eoxrmlh3paEEFaEEH4rv1g3U+YJQLyo58pbzPbVuonya+Uv\nid0Y1h17d4L8pl/03tw2YlL0iTgpV0FNkHcPeq4iNP/DLMPZzeUhSZuY2caFbWyvwb1UdY38seL0\nwroaL6/cEh9FNvxY/hj1SPlN45el8zpL3gKyfsV1N9gf2o2uWtuVpl8pb/VuZVSIRithMXHqkB9P\nUl15DCH0xi4In5HX26/I7YCZnShP7k4NIZxVs7+N9yoeqJmvbJy8riyX8xktrkfSc91x5kk6ytZ9\ni39Pef/SwehWa3XI1fKnP4dp7XX+v/K68HQN/EHc8rUYQngohHCmvI6tu86ldcvRBvIfJ0XNlNGq\nurfZ+0HLZboJZ8ftnid/36fcvTFlgvyHSdFx8nI4XB6StJMVBgIws/3k/V1bdY2kt1nh5f74/2/X\n2ntywwWStjezg+VdUcrdKGfJnz6tqKj7WvqhW5Cr+zZt8cdQs2X2OSGEZ0IIP5P0cyWuhxBCdwjh\nanl3x4la+/JlkpmdKb8W3htCuKxmf7eV9EjdD8zRaFH+rPxRwbVmdpb8V9AG8hO0XQhhRAaHDyEs\niSfwZDNbKX9c9gr5zeQ6xf61IYTZ5sMBnWNmG8n7CR6t0hcYQnjWzD4p6TsxmbhCfrFvIe97NDeE\n8NMWdvGu+O9HzexH8oJ2ewhhTWaZwRxfMLOfSXq/+fiC8+WV4v6l9T1jZt+QdIr5GLt/kD8Gf3+c\npar1dTiP8S5Jh5rZLPmv74VDSIRkZp+Xt0zNkbc8binpRHnLUd14y3MkfUd+U2y8HXyL/MfSAfJf\nu0WzJJ1kZqfIy/uB8lak4v7sKn97+WfyfnLt8iSjV+u+VV82S/6S20wzO1/eH/IzavExWY1L5C86\nXGhmX5M/Fj9ZLbY6Rl+XH9dsMztNPiTPR+T7vc4NOYSwwMz+Im9t20LrPnpUCGGumV0kb4X9mvzc\n9ssTqbdJOimEsKDVHQwhPGze93IPFW5QIYQ5ZvYLSV8z7yN8tbx7wH6SLg8hzE2s7m/ym+0XzaxP\nXs4/Xp6prjya2WHybhOXyZPYiTG+XP6DPsnMjpG/CDRLUnmosmeDDwlXtKekeSGErsI6Tpe3bG0b\nQngwtZ0QwjIzu0HSf5jZ4/Ky8T4NHIapFafJb9CXmdk58hbcz8kfVQ/GXZI+YmZHy18gW17TiDFH\na7/fMyRP4M3sWnnyfG3pptrUtWhmf5Z3XbhD/pTkTfInSD/K7Mv18mvlO/G6mSgf7eVpSY2+vc2W\n0cq6t5n7gZos060IIdxgPkzcfpK+HZr7Iz+zJB1hZl+X9Ft5K/cJGt4RKy6WX3c/NB8Oblt5A8ay\nQazrP+Xl5irzkbmC/AnCBA28Z1wlrwd+IP9BU34K9BN5Y8tV8V5/m/xJwPbywQuOaPIclt0o/7G0\nhzxXaLhQPnrKRWb2JfloZevJu0R8I4Rwd3lFarLMmtn3tbYee0p+3Ryn+K6J+QgZ+8nzmEe09v6z\nUP7uU5KZnST/rn4oHwqxWPctCiHcV1pkT60dqapaaO0NwgeVH/Xi0cT0uSq9QSq/IZwnr0zWyB/z\nz5a/bJLb/gyl39ydq9KbzVr7husHCtNMfnHPL2z3Oyq9WSmvnC+Sf5FLtXZ4tAFvActvznPkhWOV\nPLH+oaS/K523mU2c39PiOWm0UEyP04NKoz8o/YZ3s8c3RX4RPi1/NPQ9eeW4zvHJE7cvym9Sq+N5\n3ifO97HCfKfHaWNK25mp0sgJVcdYcT7eKG/N6VJhpI1my5oGvm19qLw/1OPyiuEReaVU+7a//EdH\nUGlkC/mIGKlyMV7+xvyiWI5+K69wi8cxTX6jXBDLzhJ5C8TBTezPCfLkabW8Fe7N5ePPLDugPFXM\nd4S8Ulotr5QPSpzj/RPlZsB+yFuiL5PfbLrkT0AOqdjuR+M61xkBoxBvkw+TeFtc17L4/1+RtzRL\nieu/ieM9Q/64szy98Xb/Avl1tUhege+cOQe7yW86q+JxfF7eytF0eYzn7Gfxe+4qbHfPmuOYGbeT\n+q/8vYyX113/Vpr+1bjNKTXbmi5vJFguv+GdpXRdMleJ0SeUqBvlLzHNj+fkTvkTmwFlqmJfynXi\npvGcLU8df8V6nlBpZAt5vfrctdvqtRjL1i2xrK6UJ8yVo1QUljswLrdanuifqFjftlJG4zxV95dm\n7we1ZTr1nSozMoI8+QmSXtnkNdomb/xZGPfjGvlTvQHlKFM+ausE+fB998Tzfr2k1zVzXKn9kCdj\nf5D/QFopT4j3qNjuV+M6r6+Id8bv/2759bEklrnTFe+/WlsfvbmZcxqX+ZniyE6l6ZPiPjVe4Hxc\n/kL/tMw5qC2z8mFj58rrjG759fN1xVxF3oXj1/I6sTtu9xIVynPFccxVdd1X/l62kjeyHFZ3fiwu\nADTFzI6SF9j9QgipMWeBF6XYtWS+PDm4rm7+l4LY0nqepC2DvzzYmH69vGU7Oe4wMBzM/2Jkfwih\n6p0DPA/M/7DM1fKE9+Ga2V8SYuvzhyVtH0p/aGXAvCTKqBL7Bh4qf+TSJf9V/Sl5MrFPoPDgJcbM\nzpWP2XzYaO/L88HMbpYPoff5wrQJ8hbJvwv+F/2AYRNfztpd3vL+eUn/GFocggzDz8xmS5ofQvi3\n0d6XkRZfRL5f0qdCCBfUzT8afZTx4rFC3k/oo/K3gJ+Sd7g/mSQZL1Gfkb+JPyEMrr/fi4b5XzL7\ntfwPwjwnHvdg/gIW0IzN5N0Zlkr6L5LkF4wT5P2/7WVwf58ufz8oNxrQc2hRBgAAABJGY3g4AAAA\n4AWPrhfAS9xb2t7JY6NBaJ+a//sCzx5Q/RfHJ176l+HenZb0HbB7ZWzMs/mh6sP/pv5+EurM7r/E\nRnsfAAw/WpQBAACABBJlAAAAIIFEGQAAAEggUQYAAAASSJQBAACABBJlAAAAIIFEGQAAAEhgHGUA\nL0ptE/N/Zfm+z+yajb//0D9k468af3c2vue431TGFv53e3bZXcd2ZuND9XTfnypjT/bl20e6Qn7f\nT5x/TDbe/6NplbHJF92QXRYAXmhoUQYAAAASSJQBAACABBJlAAAAIIFEGQAAAEggUQYAAAASSJQB\nAACABBJlAAAAIMFCCKO9DwBG0Fva3vmivcgXfG+PytjvDvlGdtntOjqy8Sf7urPxJ/rGZePL+6vH\nQt60fUV22fXb+rLxsWbZ+NL+bFgLe9erjHVYb3bZDdu6svFN88Msa5xVD8//sccOyC778J4r8yt/\nAZvdf0n+SwPwokSLMgAAAJBAogwAAAAkkCgDAAAACSTKAAAAQAKJMgAAAJBAogwAAAAkVI/jAwAj\n7LGT9snGHzj87MrYtV0Tsss+sjo/PFy/JmXjbcqPwTY5M4zaor6J2WUX5UeHU5/yI431hXwbx8S2\n/NB3OYv68+f1od78sHldofq8n7Xl3Oyyh1/1jmxc//BoPg4Aw4wWZQAAACCBRBkAAABIIFEGAAAA\nEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEhhHGcCoOe/4b2fj9/Wsroz1hPWzy3a29WTj+3Vm\nw7XuXLOmMramvz277Kr+/FjEW41Zmo1v3J4f4/nW7imVsbGWH8Q5Nw6yJG3YviIbb1eojF3XNT67\n7Nk7XJyNn7jl0dl476OPZeMA0CpalAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAEEmUA\nAAAggUQZAAAASGAcZQCjZueO7mx8SWa44I6a8YDrxkne/qr3ZuPbfT+//G8vrp7hsdX5sYgPmZA/\n7gd68sd22YqdsvE3jr+vMra0Zgzn/cfnx2i+ctWEbHxR3+TK2I5jn8guu0l7/pa0+u82y8Y7GEcZ\nwDCjRRkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgATGUQYwajZo\nrxmTt39lZaxd+fF+69oBdv7Eo9l436JF2fg4qx4redMxy7PLvuehg7LxJ/d+Nhuv03NXe2Xso1Me\nyS77tlcfmI3fc9LO+fix362M3ZgfPlodVr3fkrTw7/PjU29zZX79ANAqWpQBAACABBJlAAAAIIFE\nGQAAAEggUQYAAAASSJQBAACABBJlAAAAIIHh4QCMmLbOziEt3xOqf8tv2NZVs3R+6Lnui8Zn42Pe\nXLP6jF3H5o+7bvi3e765Vzbesdyy8cuOrz43F288Nrvs+J3y53X7i2qGrju2OjS2Zki/rpCPd7x6\nWX7bADDMaFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBcZQB\njBjbfpuaOW7IRnPjKG/S3jOIPVpr740eyMbnqX3Q6379aR/Oxqfqz9n4TjOXZ+NtK2vGkB5Tve9t\nf7wlv+h207PxsKxmHOUR9A94BuiSAAAK7ElEQVRbL8jG//Y87QeAlw9alAEAAIAEEmUAAAAggUQZ\nAAAASCBRBgAAABJIlAEAAIAEEmUAAAAggUQZAAAASGAcZQAjpmuzSSO27vXa8tXXiv78WMMHTb4j\nG5/X9rqW96lhk1mPZOO9NcvPuPh32fgx6z2Tjd/a3V0Z+8TxH80uO/O8b2TjX3rqgGz84d4VlbEO\ny49Nvaq/Lxvfd726cZS3y8YBoFW0KAMAAAAJJMoAAABAAokyAAAAkECiDAAAACSQKAMAAAAJJMoA\nAABAAokyAAAAkMA4ygBGzPKtxg5p+TYLg152YV9+TN79OvPLf7FmTN+DN9+tMmavn5Jd9qEzN8jG\nz985G9b52iYbf8ddiypji1+R/04+sM/R2fj8j2+VjX/rX+ZVxm5fkx/beml/vu3m4AlPZePfZxxl\nAMOMFmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABIYRxnAiOna\n2Ia0fE+o/i0/ztqzy06w3mz84d4V2fg9Z+2ZjYcx1WM8f3Cfa7LLztpofjb+yZtfm41P73w6G//Q\nlMcqY7uc+L3ssmecu1c2vvmrBj82dqflx6bOfd+SNKmtZvBrABhmtCgDAAAACSTKAAAAQAKJMgAA\nAJBAogwAAAAkkCgDAAAACSTKAAAAQALDwwEYMas36R/S8j2hegi4jprh4SZavh1gfs+4bPz+I8/J\nxnMW9KzMxv/UNT4bP2GjPw5625J0bdekytge47qyy15x7/VD2nZfqP7OO616SD1J6smHa9mY/C0t\n9OaHDASAMlqUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIYBxl\nACOmf6M1I7buZf2rs/F333tUNv697X+ejc9aNTUb7wodlbEpbfk2iAlt3dn4/T2Ts/E667VVj5V8\nXdfE7LJT2/NjQN/Xs3E2vqBrs8rYpze6O7vsrd3581LHXrljNh5u+9uQ1g/g5YcWZQAAACCBRBkA\nAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIIFEGAAAAEhhHGcCImbR+fqzjOtuMqV7+ipVb\nZZd98uJtsvGtT5uUjS/sXZWN53RYXzberpBfQc04y3X6ZJWxiTXr3rAtP/b1yjHLsvFTrvyXytin\n35UfR3moujbNjxE99rYR3TyAlyBalAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAEEmUA\nAAAggUQZAAAASGAcZQAjZsv182Pu9oX+bHyzMdVjHc9bsW122c5nasYqrvFsf2c2nhuPuC0zjvHz\noT9Ut4F0Wm9+2Zp1T2nrysanzcsE35Vfd278Z0l6qm9lNh7aRve8A3jpoUUZAAAASCBRBgAAABJI\nlAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAExlEGMGK2m7Q4G3+mf3U2vlH7xMrYY11T\nsssu2WVo7QCrwrhsfLLy4wnn1I0XPFRtVj0act226+Kv6OjIxm0Iw1e3K79wR82+rd44f0vLf6MA\nMBAtygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkkygAAAEACiTIAAACQwPBwAEbMuLaebLx6ELN6\n8+7fJr/ubbuHsHapL+TbETqsr3rZmmHM6oZBG6rc9jsz+y1JS/o6s/GdOtqz8QmPD/68j6vZtzar\nGx4uH88PKAgAA9GiDAAAACSQKAMAAAAJJMoAAABAAokyAAAAkECiDAAAACSQKAMAAAAJJMoAAABA\nAuMoAxgx49vz4yh3hcGPJzz23vHZ+NS9nxj0uiVpYtvgxwOuGye5Ll43DvNQtt9RM3r1yjC2Zu35\nsY7H3v9kZWzWqnHZZXcft7Jm2/nz0jOxZnEAaBEtygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkk\nygAAAEACiTIAAACQQKIMAAAAJDCOMoARs6RmYNuuMPjxgi0/HLCO3up/s/EV/V3ZeIe1t7pLz5uO\nmoPvz5zXnpr2ka7QUbP1/DjKq161eWXs2uU7Z5fdr/OmbHxZ/5psvG/C4MflBoAUWpQBAACABBJl\nAAAAIIFEGQAAAEggUQYAAAASSJQBAACABBJlAAAAIIFEGQAAAEhgHGUAI2Z1X35M3k4b/Li3/R35\nZXcf/0A2vrAvPx5wp/W0vE/DpU/58aXrRjrO6Qn59pGhHvdDh1ePP931xI7ZZU+blh/7Ov+NST1T\n6uYAgNbQogwAAAAkkCgDAAAACSTKAAAAQAKJMgAAAJBAogwAAAAkkCgDAAAACQwPB2DEdPflq5iN\n2sYOet39O67Kxqe0dWfjS/o6s/GJNcOkrcm0M7Rr8MPeNbN8Xby/Zni5nPrh4fLtK1O2WloZW3Tn\nxtllx70mP/Bdv/Lfqcb05+MA0CJalAEAAIAEEmUAAAAggUQZAAAASCBRBgAAABJIlAEAAIAEEmUA\nAAAggUQZAAAASGAcZQAjZkXvuGy83QY/3u/UKSuy8U3a82PqLu3Pbzs3TnKdntCej9cs31czDnJd\nvD9U73ub5c9L3RjNC3pWZuOn7nJFZez/3feu7LJ1+mqGp24f3zek9QNAGS3KAAAAQAKJMgAAAJBA\nogwAAAAkkCgDAAAACSTKAAAAQAKJMgAAAJBAogwAAAAkMI4ygBGzurcjG3+yrzsb33pM9fLjvrVh\nft3fzbcDbNq+KhvvqhkLOatmeOj6cZDz8TarGVDYqscT7szEpPrj3n7M+Gz8+AUHVMam/7ZmBOmj\n8+GuzPjQkjSmoze/AgBoES3KAAAAQAKJMgAAAJBAogwAAAAkkCgDAAAACSTKAAAAQAKJMgAAAJBA\nogwAAAAkMI4ygBEztXNlNt5VM17wiv6uylj/2Pyy87q2ycZnTH4qG//J8qnZeIeN3Ji97aoZJ7lu\neeuvjK2pGSd5Vf+4bHzXsfnz9tjTUypjOzyxIrtsne6afd9ti8ey8WeGtHUAL0e0KAMAAAAJJMoA\nAABAAokyAAAAkECiDAAAACSQKAMAAAAJJMoAAABAAokyAAAAkMA4ygBGzI037ZSNr7dVfrzgRX3V\nYxWvd/uT2WUv2mXzfFz5ONLqztu2uq0yFnbdJbvsAz35cZY3yg+jrL/ctkM2vpNuzK8AAEpoUQYA\nAAASSJQBAACABBJlAAAAIIFEGQAAAEggUQYAAAASSJQBAACABIaHAzBiNr7JsvHN3jkpG1/Wv7o6\n2N8/mF3CKApj87ecDdvz47+t3zY+Gx+zomb8OABoES3KAAAAQAKJMgAAAJBAogwAAAAkkCgDAAAA\nCSTKAAAAQAKJMgAAAJBAogwAAAAkMI4ygBGz3iPd2fhpi16ZjS9eUz3Oclj27KD2qcE6xmbjoben\nZgUvz3YGa8uPjR16e6uDt96dXfbtd74rG99y0tJsfJMbGVsbwPB6edb0AAAAQA0SZQAAACCBRBkA\nAABIIFEGAAAAEkiUAQAAgAQSZQAAACCBRBkAAABIsBDCaO8DAAAA8IJDizIAAACQQKIMAAAAJJAo\nAwAAAAkkygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkkygAAAEACiTIAAACQQKIMAAAAJJAoAwAA\nAAkkygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkkygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAkk\nygAAAEACiTIAAACQQKIMAAAAJJAoAwAAAAn/H/LwGtpeIZShAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsQAAAEtCAYAAAAP9nZUAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3XmcHUW99/HvbybLkJAQCAQCAYKI\nLAqCIpuILKJccAEB5VFEuLghihuoXL0sssgFvaIXUUSvKAgR5BHUQAQewipBQLaAbLInJGQjZJvJ\nJFPPH786mZ7OOXXOmcmQZOrzfr3ySk5XdZ/uPtXVv66qrlgIQQAAAECuWlb3DgAAAACrEwExAAAA\nskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZA\nDAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAA\ngKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwR\nEAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMA\nACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIWjIgNrPQwJ/nY97LzOzlN2SvVwMz\n2zce7769WPd5M7usTp6dzewMM9ugSlows7Ob/d43StzvYGaD6uSreYyJ7e5fZXlDZc3Mjo37Nb6R\n7xvo4nlr5Jred3Xv6xvJzH5hZn9ocp3zzKy9v/apWWY23swuMrMpZrYk/o6bVMm3h5ktNLOxq2M/\nm2FmM8zs53XyHBSPdY/CspPN7MP9v4drNjN7n5md9gZ8T1v8Db5dWLbar49YfurVdWvMNfxGMLPB\nZvaMmX2myfUeMrPr+mu/mhXL9uVm9k8zW25mD9XId4aZ3d3oduu1EO9Z+jND0l9Lyw5r9MuQtLOk\n0yU1FCyupZo9xtMlrRQQN2GivIy+0odtDCRnqee1+6u4fO/S8n+slr1bDcxse0nHSTpzde9LH20n\n6XBJsyXVvAGEEKbE9DPemN3qd/fIy+zUwrKTJWUfEEt6n6R+D4jXYAerZ732mKT7Ssv2WW17t3qc\nIKlV0m9W94700cGSdpP0oKRnE/kulPQ2M2soTk226MXKcwUz65A0u7wcWBOFEGZJmrW692NNEUL4\nl6R/VT6b2UHxn/eGEJbVW9/MhoYQOvpr//pDA/v8dUlTQgiPvlH71E9uCiGMlSQz+5KkAxJ5L5F0\nlZl9J4Qw+w3Zu34SQpgvifsRVhJC6PFgb2YLJS1sNH4ZaPWdmbXI67tLQwidb+yerXInhxC+Lklm\n9hdJ46plCiG8Zma/l3SKpD/W2+gqH0NsZruY2Z1mttjMnjazL1TJs5WZ/c7MZplZR2yOrxvBF7rA\n9zKzq81sgZnNNLNTY/pBZvagmS0ys/vM7J2l9c3MvmZmT5rZUjN7JXYzjizl28jMrjSz183sNTP7\nraRRNfbpo7GbcnHMe42ZbdHkOTtW0q/jx6cL3TnjS/lOMrPn4nHfbmZvbfb4YtdqiN9ZXHelISFm\n1mpmZ8ftLDazW81su5jvjCqHspWZTTTvkn3BzE6LF2HDx1j47hD/+Z1C3jNKeZJlzaoMmTCzT8Qy\nsjD+vo+a2eer7UPM/864jb0Ly75spWEsZrZNXHZI/LyRmV1iZk/F/XsplqnNStt/i5n90cxeNbN2\nM3sxlqF6w0/ONLN/xGOYHX+bPVLrNMO6u6I/ZD7UYo6kFwrpHzKzv5t3z88zs2vNbOvSNlbq8rbq\n3as7mNmfzOuDyjn4fWm9jc3s0lgWO8zscTM7rpTnC3Hbe8ZzOl/S7YljHC7pKElXVknbJP5+L8fv\nezGeh9bE9r5mXhfMM68L7jaz95fyDDaz75vZs/FYZ8cyvHshz7Fm9rB5PTY//vvfa32vJIUQulLp\nJRMldUg6pol1isdwsJlNir/vongNnVS51gv5ZpjZL83sGPM6aZGZ3Vs81kLek+M5bo95GirLVhoy\nYWYzJG0s6XjrrjeqDrsws81i+hGFZUfGZb8sLFvPzJaZ2fHx83Az+0ksg4vMbLqZXWdm21TZ/u8K\nZXZ6LOfr1zmmuuUo5hthZj+IZakjfs81ZjbazM6T9C1JrVYaHlA+Z4XtVa6fTQrLjjG/18wyv+88\nYGafSO1/lf0083rwqipplX3ZN7H+2HjtP2Ne37xoZr+1KkOCesvMLjS/J+xsZreZ2SJJv4hprWb2\nnfj9S2Od8EMzW6ew/s7xOA4tbffQuHzn0rK/x/O5IJajb5TW2z1eY/PN7x+TzexdpTzXmdlUMzvA\nPN5pl/QficM8UNKWql7f7W5+754Xv+8xMzspcb5GmscW/4zXwDTze8CbSvm2NLMJ5nVBR8x3nZmN\niOlDzewC82GlHbGc3W5m70gcR7P13QRJe5rZDvUyJm+6vTBSfrIvlPQ9eVfkz8zsyRDCZEkys80l\n3SvpVUlfk7fgfVzStWZ2aAjhTw18z28k/VZeYI+UdK6ZjZI3o58jaaGk8yVdZ2ZbhxCWxvXOkXSq\npJ9K+rOkHeTdyG83s/cWTvL/lfR2eeF6Ou7f/5R3wjwA+5k80PuepBHyrsjbzWynEMKCBo5F8hvU\n2ZK+G4+nMj622NV/tKQnJX1F0hBJF0i63sy2K7TuNXp8jTpTfg4ukHSLpHdKSv0+f5Sfix9J+lBc\n/6W4rJFjLNpT3h16mbxFS4V1pAbKWpl5UHuFpJ/Inxhb5F3NVR92ogclvSYfunFXXLa/pCXqOZxj\nf0nLJN0RP28gqV3+e8yStKmkb0i6O/5mlbFrEyXNk3dlzZa0mbwc13tY3Ux+nl+WNFxePu4ws3eu\n4tbOn8vL0v+R1CZJZvYR+W89SdLHJK0n/23vMrO3hxBebXTjZmaSbozH8XlJc+RP+4cU8qwvLwuS\nl58XY/qvzGxQCOHS0mYnSPqdpIvk3YO17C1pXUl3lvZpQ3mr47B4XFMlbSIfHtYqaXmN7W0pL6sv\nyK/RwyRNMrMDCmXyNEknysvFVPm5201xGJGZHSC/Xn4ob80ZJL+OU2W0KSGEDjP7u6SDJP13Lzbx\nJvlvf6GkpfL9P09+DGeU8r5P0lvlx7tMXkdNNLPxIYSFkmRmJ8rrmEslXSu/Jq+R/zbNOljSzfJr\n9ftx2cxqGUMI08zsafm1WxlDXu3a3lf+u98aPw+TNFR+rDMlbSjpS5LuMbNtQwhzYr4JkkbLf8dp\n8jJ0oOJ1lFC3HJlZm6TJ8nN1rqS/S1pf0r/J68afyuucT8jLuSQ1W/9L0lbxOJ6Jn/eTdLmZDQkh\nXNbIBkIIlYeS75vZRrHnruLzkp4IIdyW2MSGkhZI+qa8jhwnr7/vMLO3rsLWziHyeu0i+b2rst3/\nkfQF+TV5s6R3yH/77eXlrWFmtpO8rP1aXpd1SdpW0phCnn3i99whv691yu/7t8X6/YnCJjeV9L/y\nMvCk/DzVcpCkaSGE50r7tL/8en5IXo5nyMvV+MS2RsjvUafJY7kxkk6S9Ld4DcyP+f4gv1a+Ir/X\nj5X0Afm5lrx+/Yy8fvinvJ7bQ16WV5V75HXPQZIeT+YMITT8R9Lzkq6okXaZpCBpv8KyofIb3C8K\ny34lDxBGl9a/WdJDdb7/2PgdpxWWDZL/IJ2Stios/3DM+974eQN5q8hlpW0eHfN9OH4+MH4+qpTv\nxrh83/h5XUnzJf1vKd9W8pvEV0vn7bIGj+3NVdKCPDAfXFh2RFy+V5PHNz5+PraUb9/S8a0vf7C4\nuJTv6zHfGYVlZ8Rlx5XyPirvyq17jDXOSZB0dh/KWuX7xsfPJ0ua20yZj+tdL2ly/HeLpLnyyrFT\n0rpx+QR513utbbRK2jzuz2Fx2YbF36a3f+K2B8krxB83sV7ldxtUJe2gmHZVlbSp8vF4LYVl28oD\nxXMLy2ZI+nlp3ba43W/Hz+Pi5/cn9vMcSYsqv2Nh+eWSplf2Q37TCpK+3+Dxny6/VltLy8+XV6A7\nJNY9T1J7Ir0l/iZ3SPp9Yfktkq5MrPddSdP7WB6+FM/DJok8F0h6vS/fE7dj8TjPkjSzlDZDXteP\nLCzbO+7bR+PnwTHfdaV1Px3z/bzO91fK6R6l7/1lg/t/iaR/Fj4/Ea/tIGnLuOxCSc8nttEqDxDa\nJZ1QOC9LJX2uj+e3Vjn6YgPXzXmSljVyzuLyyvVTtdwU9uVy+TCrqtd0tetDfj9ZLOmUwrJN5XXo\nV2sdQ439GCRpm/id/9bEelMk3VIj7cK4vU+Xlm8hr9cuLC2vXGP7xM87x8+HlvIdGpfvHD9/Jh5z\na2I/H5CPdW4tLGuTNwRcVlh2nQoxTgPHf4+kiVWWPxLL/eDEug+Vr9Eq18D68nrzuLhssDzgPyax\n3l0qxVC9uEb+ovqx46OSrq63rVU9ZGJxKLTOBR/L8pS8UFUcJOkGSfPNbFDlj/xlvbdbafhCDTcW\nvmOZ/On1qdDzyafyFLV5/HsP+VPJFaVtTZD/iO+Nn/eUXwDXVslXtKf8Sfx3peN4KX73qh6sf3Po\n+SRcaQWsnNtGj69RO8pbHq8pLU+9jT+x9Hmqev72q1IjZa3sPknrm9kVZvbB2KvQiFvlXS5t8opv\nlDxo6pD0nphnP3mLzQpmdoJ5d/dC+W/wYkzaNv49R/5CwHlm9lkrdbmmmL9lO9l8KMMyeSX7lsK2\nV5Ue467MZwh5qzxQXtHiFEJ4Un5+my1nM+Stwz8ws+OtNOwiOkhecb5cpc4YK+nNqX1O2FT+gFRu\n8X2/pLtCCOnWhJLY7Xijmb0qr0M65eWj+JvcJ+lQM/ue+dCvwaXN3CdprPnwjIMbrA97Y5akEWbW\ndCusmY0zs1+Z2YvyY+yUB/JjqlxTd4YQXi98LtdbW8mHOFxdWu/38pt9f7tV0nbm3fKbyn+rS+XX\naqWVeH+tfG1/MnZTz5dff6/LH8q3lbxVVB7Y/IeZfclKw9tSGixH75f0QgjhpqaPuAnmQ+SuNrPp\n6q5njlaT9UwIYZ78XvS52CskScfHbSZf8DJ3kvnQnIVxH56Kyf1a38kf4Fq08n218rnZ+u6BuL2r\nzYdO9HjB3Mw2krdAX+UfV9R1y+TDv8pxxbwQQs1hYSWbqvROjfmwkx3lgXZTLe3mQ7seMLPX4/7N\nlQfGlWugU9LDkk43sy+av8Bcdp+kI83sdPMZcFb1qIWKSi9t0qoOiOdVWdahnl1EY+Rj1zpLfy6I\n6aN78T1LayxT4bsrBa9HF30MqOcU0sfKC1m5cJS73SpdHLdo5WPZUY0dRzPmlj5XBs43e3yNqkzL\nVO7+rtr9mNjHet2DvdVIWeshVhxHyh+S/ihplpndEruxUibLb3Z7yQPfh0MIM+VB2n7xZjdG3V2q\nMrMvS7pYXj4+Ku9WrozZa4v7E+Q9EvfLu3efMh8PeEJqZ+L4qhvkLfjHx+2+S175rOrzXR7SUrWc\nRTPUZDmL5XN/eSvFBZKeMR+rd3wh2xh5AFC+zi6P6eVrrdFZRdrUfR0VjVbP4Tl1mY+du0Xenf5F\n+QPzu+RlovibnCFv8T5CPtvDbPPxketLUgjhr/LhKVvLeybmmNlfmwmoGrQk/r1OMldJvGFNlA+F\nOFPes/Quddff5fJXr96q1DM96pXgQ4qKgXR/uS3+vV/880rwLunJ8mt7Q0lvU89r+0h5QPSQfAz6\n7vJzMF89j/8weVf0dyRNNR97emohIFxJE+Wo6TLarPhwc4u8+/wUeXD4LvlwpN7UMxfLH14PMB9v\n/hl5q121urzoZHkL7kT5Od1N3YHoqqzvFpce3qTa99XX5GW52fruQflwwlHyh75ZZnaHdY+rr8QV\nlR7I4p+j1fu6Tqpe31W212x99yn5sI975cPmKtdAu3r+Jh+Ul93TJD1uPv775EL6qZJ+IK/z7pHX\nhz/rh4aAJWqgruuvaDxljnzM3n/VSJ/eT99bqZg3kXf3SlpRwY8upL8ib0UcXAqKNy5trzJO7Nji\n9goaHT+8qjR6fJWxq0PUU60LbYx6Hl/5PKxVQgh/kPSH2DK2r7wcTjKzcaH2GOtH5WPX9pe0i7pv\njrfKK4OX5A9gxemujpL0/0IIK16WMLOtquzPs5KOiTfJt8u74i42s+dDCDeW80eHy5/IP1osozGo\nei1x+L1RbqUrlrOyTdQzAGpX/XKmEMLTko6ON8mdJX1V0i/N7NnYCzBH3gt0So19fKL0udGWxTmq\nPlatMpa7GYfIh1EdHgozN5RbYGNPxjmSzjGfC/jD8pvfEPkwAYUQJkiaYP7iyf7y3oiJSo/pa9YG\n8vNUDljr2V7STpKOjNeSpBVBYm9U6pke9Ursjemv1vEVQggzzexx+Xk2dbcE3yr/nfYrLZf82p4a\nQvhsYX+HyceDF7c9Qz4M4QvmL/QcJx/rOUPdLxiXNVSO5GV0Z/VOo/eA98ivg0NDCPcX9qXcq9GQ\nEML9ZnaffNxwm7yX4JL0WpL8fN8QQii+iFuttbGvqtUbxfpuWuH7R8kbSZq9ryqEcIOkG8xfyttH\nXiZuNLNx6o4rzlX1nq5yb1YzvSjV6rtKGWu2vjtK0gMhhC9WFsT7T48HlBDCNEmfjelvi/++wMym\nhRCuig++Z0o60/yF80PlAXKLvJysKhuo+1hrWh3/U90keYX6WAjh/ip/+muakynyoOWo0vKPyx8M\nbouf75E3+x9eylde72/yoPfNNY7jySb3r3LcTbXYFDR6fDPjd72tlO+Q0udH5eM2yze63t74pOaP\ncWkTeZsSQlgYQviLvEIeq0SLfmzJvU3emvse9QyId5G3Wvw9hLC4sNowdb+UUXGcagjuIfkYbWnl\n36domLxiXFEZmr8Y0V/DU1YIIcyVD4X5WLGly3y4x67qLmeSvxRUr5wVt90VfKqkSgtCZd1J8kDs\n2RrX2sJeHs4T8mEDG5aW3yRp7yZvusPi3yumr4s3gF1rrRBCeCWEcIl8fOhKv3cIYUEI4Xr5exdb\nruJWk60kPVNluEg9leMsPogNlbfw9MZz8jrpY6XlH5cHor3RoebqjVvV3UJcvLbHyW/Kz4QQii1o\nw1T4naNjU18QQng8hHCKfBxtvWtbql+ObpI03swOTGyrQz7LRDmArcwWU96P8gti1X7rMVXyNeNi\nSR+Rv6z9SAjhbw2s01RduordJR8HW76vfjL+fVv8uzIcrpn6bknsEfqxPFDdLD5EPSxpxxp13YN9\nOJYn5C/EFvdhprx37rgmH3Sa/k1CCFPlEyksU/X6bloI4afyGCx1jfTGVvJ3bJJWRwvxafI3Yu8w\ns4vkL5ytLz8BbwohJKcX6q0Qwlwz+6GkU82nVLlBfpM9W17oJ8Z8N5vZXZIuiTfKyiwTbytt73Uz\nO0XST+O4nxvlXWabybtzbgshrDS9SUJlvOKJZvYbeWF7JHTPkLGqji+YT2l1vJk9JS8kh8hbS4vb\nm2dmF8rHwC2Qd529Q95FL/XujeVmj/FxSYeY2ST5EInpIYRe9yCY2ffkLVGT5T0R4+Rvxj4Uer75\nXM1k+Zvby9U9K8GD8oei/eQzXRRNkvQtM/sPeXnfX95NXtyfneSV4e/lLaCt8hvrMhW6aKuYJG9F\nvczMfi0fO/yfKrRg9LPvylsvrjezS+Tdf2fJx2n9uJBvgry1+7/kN/B3KLaCVpjZbvLWkKvlcyQP\nlnelLlX3zeZ8+bm7K5bJp+QvMW0vafcQQvnhtVGVGUF2k18vFefLr/nJ5lPrPSbvKTlM/oJItfJ6\nUzyOK8zsx/Kydaa6b5SV471R3s1Ymb1kV3nZ+FFMP0/eMnq7vPV0C3nX+ZQq3bnF7bbIh+ZI3S2H\nHzSz1yTNCCHcVVpl98LxV7YxQd4amOqGfkR+7Zxv3dOsfUPdQ9SaEkLoNLOzJF0Uy9K18t/1ZPkD\neW88Lh/ucLB8yNerIYQXE/kny3tmKv9WCOFlM3tGPp/zL0r5J0m6sFCud5e3BK94MDOzjeVDXq6U\n17HL5WV4HfkL5LU0VI7kLczHy2dnOlc+FnM9+SwT5wZ/n6ZS355iZrfIX7D7RwjhOTO7V9Jp5mOg\n58rrnXIr4Z3y3+CSWHeOlN+/Z6rGvK8NmCDvEdlTPttKIyZJ+rKZfVP+nwZ9QN6S2O9CCC/Gcvl1\nM6vUy7vIf5MbQwh3xnyLzexPkr5iZi/Jf6/DY94VYszwVvnvPE1+P/qmvO6rzBF/kqSb4vYuV/cs\nDrvJX4Q9q5eHc4f8um0L3bMcSX4v+aukO83sJ/J65y2Stg4hfLPGtibJ3305W37NvFvSv6u7pVxm\ntqW8/F8lr7O75A/OrfJ4QrFc3i5/CJgvH/63t7x3pibz8f57xY+bSFrPuqdPfCiE8Ewh75by83yH\n6gnNvc33vNKzTLxcZflt8uCwuGycpF/KC8RS+Q9ws6Sj63z/saoyS0H8jrtKy8bHvJ8pLDP5E8qT\nhe/9qQpvQcd8G8l/xAXym9Zv5U+1QXEWhkLeg+UF4nX50//T8mlQdijkeV51ZpmI+U6P56TS+jc+\nLg8qzbagKrNFNHF8o+QX2mx5ZfhzeVDc4/jkBfcceRffknie94r5vlLId4aqzFYQy8TzjRxjjfPx\nbvlLCO0qzGzRaFnTyrNMHCK/8F+Rt568JG9927SB32b7uK0ppeXX1ygX68in5JsVy9Ff5E+pxeMY\nI3+h5KlYdubKK4cPNLA/X5a3ri2R3wzfVz7+BrZR9XeLaZU30feuse6H5IF+u/wauVZegRbztMoD\n5RflN9aJ8hcuVryRLr8JXy6/bhbLu/UmSzqgtK3R8unyXpCX7ZnxXH2xkKfylvy4Js7Bw5J+VmX5\n2Fg2ZsSy8qL8um6N6SvNMiEf4/dUPCePym+IE+TTSlXynCoPiOfG431C/oBR2e6h8rqw+L2/kLRx\nneOovOlf7c+kUt6t4/L3lZb/WYnZFAr5dpW34iyWX0P/qe5ZDzYp5FtptgdVmZEgLj8lbqs9np/d\nVWWWkkQ5Lc4ysaN8+NJiNTZTxQbym3W5rrpE1WccapUPtXollutb43eu2F/5C8mXyoPShfKb/RT5\nUJN657duOYr5RsofpF6UXxPT5Q/XG8T0QbHszI7HV5z1YUvFl9vjcZwpD1DLv+EH5NfIEvk1eoJW\nnkGi7iwTpf3+TTwnI+udi5h/3XguZ8nvs9fJA7aVylGd7dSbZWJhjbRW+Tjwf8Xz/LI8qF+nlG+M\n/KXzufGc/0j+YB3UPcvE/vJ6cJr8+p4mH48+vrStXeTTv85Wdz1wraT9C3mukw/dafT4x8kbWz5S\nJW1P+b2xEsdMlfSlQnqPWSbkDRf/Hcv8Inmdtb38XnBhzLOevA79Z8zzmrxn/bDCdk6T37/mxe99\nXD5/dkudY6nM3lHtz1dLeU+M5XxYvXNkcQWgIfEp7Br5dDN31ssPrMnM5xI/R/5QtFb9r1S9ZWan\ny7t8tw3xBhCHv8yS9L0Qwk9W5/5h4DKzIfIGoomhMAYbbwwzu07eU3BE3cwDhJndI+n+EMKX6+Yl\nIEYt8c3XQ+QtNu3y/5jj2/IW6L0ChQdruXiDflzeqnHR6t6f/hZfznpO0okhhKsLy3eUt/JsFUJY\nUmt9oDfMbD35sMNPy7vWdwpNTmuIvovX+QPyMcrNvue01jGz98pb5LcJIdSdkWN1jCHG2mOh/C3Y\nE+Xdc6/Kx3qeSjCMgSCEsNT8vxWv+996DhDjJZ1fDIYlKfj/brjK/itcoGRP+Xs2M+TDnAiGV4MQ\nwqNm9jn5ULUBHxDL30/7VCPBsEQLMQAAADK3OqZdAwAAANYYDJkABqADW47Ms+un9n8C5ur0iC06\nYvdk+tAv1O55e35q+n8GbRnTnk5/Lj117rLh6X0Po2r/z6uhM932seWW6VkHh77/+WR6rm7uuqa3\ncyUDWMPQQgwAAICsERADAAAgawTEAAAAyBoBMQAAALJGQAwAAICsERADAAAgawTEAAAAyBrzEAMY\nOKzOM35Ynkze6VsPJ9Mv3mxK7cQ+/ufP/3r3wmT62NYhyfRhLbXTX1lWZ9uD1k2m7/6pE5Lpoy6/\nJ5kOAGs6WogBAACQNQJiAAAAZI2AGAAAAFkjIAYAAEDWCIgBAACQNQJiAAAAZI2AGAAAAFljHmIA\nA0dXep7her698S3J9EeW1q4y71syPrnu5oPnJNPbWtJzAT/QsV4yfXHX0JppLdowue4xI2cn01/b\nNpmsUelkAFjj0UIMAACArBEQAwAAIGsExAAAAMgaATEAAACyRkAMAACArBEQAwAAIGtMuwYA0RaD\n0lOfzepYWjNtm6EzkusOUXpKuDldw5PpbdaZTB89eGHtbS9PH1c9SzerfdwAMBDQQgwAAICsERAD\nAAAgawTEAAAAyBoBMQAAALJGQAwAAICsERADAAAgawTEAAAAyBrzEAPIxqDxW9TJ8VAydUFXW820\n5bLkukMsPQ9xvXmGF4WhyfTOULs67wrpto9/ddaew1iSNthwQTIdANZ2tBADAAAgawTEAAAAyBoB\nMQAAALJGQAwAAICsERADAAAgawTEAAAAyBoBMQAAALLGPMQAsjF/17F9Wv/1xDzEmwyan1y3PQzu\nU3q9eYxb1FUzra0lPcfxnK70HMdbrz8nmZ4+cgBY89FCDAAAgKwREAMAACBrBMQAAADIGgExAAAA\nskZADAAAgKwREAMAACBrBMQAAADIGvMQA8jG7J3SbQDzu5Yk02ct26Rm2maDXkuuO7olve1tBi1M\npj+8dHQyvSvRvpGao1iSRrd0JNNnLVk3mT5E6XmKAWBNRwsxAAAAskZADAAAgKwREAMAACBrBMQA\nAADIGgExAAAAskZADAAAgKwx7RqAbAzfJT09WGdIT0+22eB5NdMWhSHJdbcd3J5MP33mPsn07465\nK5n+aOewmmnty9PTpo1tTe/7C9PTU75toxeS6QCwpqOFGAAAAFkjIAYAAEDWCIgBAACQNQJiAAAA\nZI2AGAAAAFkjIAYAAEDWCIgBAACQNeYhBpCNw7d8OJm+oCsk05eG1pppOwxamFz31iVjkulT35me\nA3n96bXnGZakIZ3La6YNtmW7cytFAAAIRElEQVTJdYe1pOchtnnpdABY29FCDAAAgKwREAMAACBr\nBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGvMQA8jGtm2vJNMXJ+YZlqTOULvK3GLQ\nusl1D77/sGT6ZnosmV5PW2Ku4fauevMItydTu4ak50gGgLUdLcQAAADIGgExAAAAskZADAAAgKwR\nEAMAACBrBMQAAADIGgExAAAAskZADAAAgKwxDzGAbOzVNj2ZPn15er7e5bJef/eIa0b0el1Jmrd8\ncTJ9xyFtNdMeaB9WZ+uvp5PXWV5nfQBYu9FCDAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAA\ngKwREAMAACBrBMQAAADIGvMQA8jG2EHrJtNfWJaeb3d4S0evv3vU9Y8k07vqrP+Vlw9Kpv943KSa\naW0tnXW2ntY6d3Cf1geANR0txAAAAMgaATEAAACyRkAMAACArBEQAwAAIGsExAAAAMgaATEAAACy\nxrRrANCgES3tNdMWdy1Nrtu1eHGfvvv+aVsk04duXrs6b607qVva4NdpOwEwsFHLAQAAIGsExAAA\nAMgaATEAAACyRkAMAACArBEQAwAAIGsExAAAAMgaATEAAACyxjzEABAtlyXTR1pHzbQrFmy1qnen\nh/bpw5Ppg621Ztpy2j4AIIlaEgAAAFkjIAYAAEDWCIgBAACQNQJiAAAAZI2AGAAAAFkjIAYAAEDW\nCIgBAACQNeYhBoBoUdfQZPrmQxbXTPvNC3sk111Xz/Zqnyq2uLErmb74o0trpg22ZX36bgAY6Ggh\nBgAAQNYIiAEAAJA1AmIAAABkjYAYAAAAWSMgBgAAQNYIiAEAAJA1AmIAAABkjXmIASAaYsuT6akW\nhOkvjE6u+5Y+zkM87O4nk+nrtaxTM21kS3ufvntQ7emXAWBAoIUYAAAAWSMgBgAAQNYIiAEAAJA1\nAmIAAABkjYAYAAAAWSMgBgAAQNYIiAEAAJA15iEGkI1Ji4cm0zcdND+Z3hlqpw2dMbg3u9SwsHRp\nr9dts84+ffegRX1aHQDWeLQQAwAAIGsExAAAAMgaATEAAACyRkAMAACArBEQAwAAIGsExAAAAMga\n064ByMZdC9+STP/kqHuT6W1WO23Zm5f0Zpca1tXe3ut120O9KeE6kqnLhvX6qwFgrUALMQAAALJG\nQAwAAICsERADAAAgawTEAAAAyBoBMQAAALJGQAwAAICsERADAAAga8xDDCAbEx7bNZl+4nvuSabP\n7WqtmXbwtlOT6z6ZTO1fG7QurJMjPU9xa3qaYgBY69FCDAAAgKwREAMAACBrBMQAAADIGgExAAAA\nskZADAAAgKwREAMAACBrBMQAAADIGvMQA8jGiLvXSaa37ZNuI1jQNaRm2pkb355c9yjtlUzvq47Q\nWTOtzZbXWTs9D7F19WKHAGAtQgsxAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAAskZADAAA\ngKwREAMAACBrzEMMIBtjb5udTJ/1rZBMXxRqz0P8t47hvdqnVeXZztrzELfK+rTtQNMJgAGOag4A\nAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgAAABZIyAGAABA1ph2DUA2lj/+VDL96c7RyfTRLYtq\npm3UWjtNklp22i6Z3vXIE8n0ehaEwTXThtuyPm07tPZpdQBY49FCDAAAgKwREAMAACBrBMQAAADI\nGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGvMQA0CUmmdYktoS8/lu0JKe6/f1bddLpq/7SDK5\nrskLd6iZdsTIB5PrPrK0PZnOPMQABjpaiAEAAJA1AmIAAABkjYAYAAAAWSMgBgAAQNYIiAEAAJA1\nAmIAAABkjYAYAAAAWWMeYgADh1k6PYRk8tFTjk+m3/zui2qm1Zuqd8Ze6X178zV1NlDHtI5RvV63\nVenzMnReOh0A1na0EAMAACBrBMQAAADIGgExAAAAskZADAAAgKwREAMAACBrBMQAAADIGgExAAAA\nssY8xAAGDqvzjB+WJ5M3+ktbMn34e2rPJbygKz1X74kH3pRM/6tGJtPrWae1s2bacqXnQK6X3trB\nPMQABjZaiAEAAJA1AmIAAABkjYAYAAAAWSMgBgAAQNYIiAEAAJA1AmIAAABkjYAYAAAAWWMeYgAD\nhrW2JtNDV3oe4pFXTkmmP3pW7bmCR7csTq7bGdL71ld/embHmmmn7HF3ct2Zy9PzDC8am247WS+Z\nCgBrPlqIAQAAkDUCYgAAAGSNgBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSNadcADBhhWWe/bv/P\nr+1SM+3Csfcn1x036KFk+o0HfzWZPvSG+5Lpra1dNdM2bB2eXHdES/q8dYxOT8sGAGs7WogBAACQ\nNQJiAAAAZI2AGAAAAFkjIAYAAEDWCIgBAACQNQJiAAAAZI2AGAAAAFljHmIAA0fo3/lyb71yt5pp\nO+y5XXLdUX9YN5k+4oYpvdqnivWuqr39/UZ8JLnu3EXDkumb3rmsV/sEAGsLWogBAACQNQJiAAAA\nZI2AGAAAAFkjIAYAAEDWCIgBAACQNQJiAAAAZI2AGAAAAFmz0M/zdgIAAABrMlqIAQAAkDUCYgAA\nAGSNgBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSN\ngBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgAAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgA\nAABZIyAGAABA1giIAQAAkDUCYgAAAGSNgBgAAABZ+/8QwCyVXUs1XAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "headers = {\"content-type\": \"application/json\"}\n",
+    "json_response = requests.post('http://localhost:8501/v1/models/fashion_model/versions/1:predict', data=data, headers=headers)\n",
+    "predictions = json.loads(json_response.text)['predictions']\n",
+    "\n",
+    "for i in range(0,3):\n",
+    "  show(i, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(\n",
+    "    class_names[np.argmax(predictions[i])], test_labels[i], class_names[test_images[i]], test_labels[i]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "rest_simple.ipynb",
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 2",
+   "name": "python2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
In the rest_simple.ipynb notebook (https://www.tensorflow.org/tfx/tutorials/serving/rest_simple) there is a piece of code which show the comparison between the prediction and the actual one. But the comparison is done to same prediction vs prediction. But actually it should be between prediction vs test_image.

This is the wrong code which is show in the tutorial:
show(0, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(
**class_names[np.argmax(predictions[0])]**, test_labels[0], **class_names[np.argmax(predictions[0])]**, test_labels[0]))

But the code should be like below:
show(0, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(
**class_names[np.argmax(predictions[0])]**, test_labels[0], **class_names[test_images[0]]**, test_labels[0]))

show(i, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(
    **class_names[np.argmax(predictions[i])]**, test_labels[i], **class_names[test_images[i]]**, test_labels[i]))