### PR TITLE
Typo: deplopying --> deploying

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -573,7 +573,7 @@ for details
 
 Kubeflow requires a Kubernetes cluster to run the pipelines at scale. See the
 Kubeflow deployment guideline that guide through the options for
-[deplopying the Kubeflow cluster.](https://www.kubeflow.org/docs/started/getting-started-gke/)
+[deploying the Kubeflow cluster.](https://www.kubeflow.org/docs/started/getting-started-gke/)
 
 ### Configure and run TFX pipeline
 


### PR DESCRIPTION
Creating a TFX Pipeline With Kubeflow contained a typo in the url-text: deplopying the Kubeflow cluster.