### PR TITLE
Fix the issue about tutorial notebooks won't run in Colab.

### DIFF
--- a/docs/tutorials/data_validation/tfdv_basic.ipynb
+++ b/docs/tutorials/data_validation/tfdv_basic.ipynb
@@ -180,7 +180,19 @@
         "colab": {}
       },
       "source": [
-        "!pip install tensorflow_data_validation\n",
+        "!pip install tensorflow_data_validation"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-Ok8jaAp5aKk",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
         "import tensorflow as tf\n",
         "import tensorflow_data_validation as tfdv\n",
         "\n",

--- a/docs/tutorials/data_validation/tfdv_basic.ipynb
+++ b/docs/tutorials/data_validation/tfdv_basic.ipynb
@@ -1,4 +1,21 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "chicago_taxi.ipynb",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [
+        "tghWegsjhpkt"
+      ],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -7,18 +24,16 @@
         "id": "tghWegsjhpkt"
       },
       "source": [
-        "##### Copyright \u0026copy; 2019 The TensorFlow Authors."
+        "##### Copyright &copy; 2019 The TensorFlow Authors."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "rSGJWC5biBiG"
+        "id": "rSGJWC5biBiG",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -31,7 +46,9 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -53,14 +70,14 @@
       "source": [
         "Note: You can run this example right now in a Jupyter-style notebook, no setup required!  Just click \"Run in Google Colab\"\n",
         "\n",
-        "\u003cdiv class=\"devsite-table-wrapper\"\u003e\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/data_validation/tfdv_basic\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://colab.sandbox.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/data_validation/tfdv_basic.ipynb\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\"\u003eRun in Google Colab\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://github.com/tensorflow/tfx/blob/master/docs/tutorials/data_validation/tfdv_basic.ipynb\"\u003e\n",
-        "\u003cimg width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\"\u003eView source on GitHub\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003c/table\u003e\u003c/div\u003e"
+        "<div class=\"devsite-table-wrapper\"><table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "<td><a target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/data_validation/tfdv_basic\">\n",
+        "<img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a></td>\n",
+        "<td><a target=\"_blank\" href=\"https://colab.sandbox.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/data_validation/tfdv_basic.ipynb\">\n",
+        "<img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\">Run in Google Colab</a></td>\n",
+        "<td><a target=\"_blank\" href=\"https://github.com/tensorflow/tfx/blob/master/docs/tutorials/data_validation/tfdv_basic.ipynb\">\n",
+        "<img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\">View source on GitHub</a></td>\n",
+        "</table></div>"
       ]
     },
     {
@@ -89,15 +106,15 @@
       },
       "source": [
         "The columns in the dataset are:\n",
-        "\u003ctable\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003epickup_community_area\u003c/td\u003e\u003ctd\u003efare\u003c/td\u003e\u003ctd\u003etrip_start_month\u003c/td\u003e\u003c/tr\u003e\n",
+        "<table>\n",
+        "<tr><td>pickup_community_area</td><td>fare</td><td>trip_start_month</td></tr>\n",
         "\n",
-        "\u003ctr\u003e\u003ctd\u003etrip_start_hour\u003c/td\u003e\u003ctd\u003etrip_start_day\u003c/td\u003e\u003ctd\u003etrip_start_timestamp\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003epickup_latitude\u003c/td\u003e\u003ctd\u003epickup_longitude\u003c/td\u003e\u003ctd\u003edropoff_latitude\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003edropoff_longitude\u003c/td\u003e\u003ctd\u003etrip_miles\u003c/td\u003e\u003ctd\u003epickup_census_tract\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003edropoff_census_tract\u003c/td\u003e\u003ctd\u003epayment_type\u003c/td\u003e\u003ctd\u003ecompany\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003etrip_seconds\u003c/td\u003e\u003ctd\u003edropoff_community_area\u003c/td\u003e\u003ctd\u003etips\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003c/table\u003e"
+        "<tr><td>trip_start_hour</td><td>trip_start_day</td><td>trip_start_timestamp</td></tr>\n",
+        "<tr><td>pickup_latitude</td><td>pickup_longitude</td><td>dropoff_latitude</td></tr>\n",
+        "<tr><td>dropoff_longitude</td><td>trip_miles</td><td>pickup_census_tract</td></tr>\n",
+        "<tr><td>dropoff_census_tract</td><td>payment_type</td><td>company</td></tr>\n",
+        "<tr><td>trip_seconds</td><td>dropoff_community_area</td><td>tips</td></tr>\n",
+        "</table>"
       ]
     },
     {
@@ -113,18 +130,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "K4QXVIM7iglN"
+        "id": "K4QXVIM7iglN",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import sys, os\n",
         "import tempfile, urllib, zipfile\n",
         "# Confirm that we're using Python 3\n",
-        "assert sys.version_info.major is 3, 'Oops, not running Python 3. Use Runtime \u003e Change runtime type'\n",
+        "assert sys.version_info.major is 3, 'Oops, not running Python 3. Use Runtime > Change runtime type'\n",
         "\n",
         "# Set up some globals for our file paths\n",
         "BASE_DIR = tempfile.mkdtemp()\n",
@@ -141,7 +156,9 @@
         "\n",
         "print(\"Here's what we downloaded:\")\n",
         "!ls -R {os.path.join(BASE_DIR, 'data')}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -157,21 +174,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "gE-J0fCb431_"
+        "id": "gE-J0fCb431_",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "!pip install -q tensorflow_data_validation\n",
+        "!pip install tensorflow_data_validation\n",
         "import tensorflow as tf\n",
         "import tensorflow_data_validation as tfdv\n",
         "\n",
         "tf.logging.set_verbosity(tf.logging.ERROR)\n",
         "print('TFDV version: {}'.format(tfdv.version.__version__))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -191,16 +208,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "EE481oMbT-H0"
+        "id": "EE481oMbT-H0",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "train_stats = tfdv.generate_statistics_from_csv(data_location=TRAIN_DATA)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -222,16 +239,16 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "U3tUKgh7Up3x"
+        "id": "U3tUKgh7Up3x",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "tfdv.visualize_statistics(train_stats)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -249,17 +266,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "6LLkRJThVr9m"
+        "id": "6LLkRJThVr9m",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "schema = tfdv.infer_schema(statistics=train_stats)\n",
         "tfdv.display_schema(schema=schema)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -282,13 +299,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "j_P0RLYlV6XG"
+        "id": "j_P0RLYlV6XG",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Compute stats for evaluation data\n",
         "eval_stats = tfdv.generate_statistics_from_csv(data_location=EVAL_DATA)\n",
@@ -296,7 +311,9 @@
         "# Compare evaluation data with training data\n",
         "tfdv.visualize_statistics(lhs_statistics=eval_stats, rhs_statistics=train_stats,\n",
         "                          lhs_name='EVAL_DATASET', rhs_name='TRAIN_DATASET')"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -314,18 +331,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "T7uGVeL2WOam"
+        "id": "T7uGVeL2WOam",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Check eval data for errors by validating the eval data stats using the previously inferred schema.\n",
         "anomalies = tfdv.validate_statistics(statistics=eval_stats, schema=schema)\n",
         "tfdv.display_anomalies(anomalies)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -347,13 +364,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "legN2nXLWZAc"
+        "id": "legN2nXLWZAc",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Relax the minimum fraction of values that must come from the domain for feature company.\n",
         "company = tfdv.get_feature(schema, 'company')\n",
@@ -366,7 +381,9 @@
         "# Validate eval stats after updating the schema \n",
         "updated_anomalies = tfdv.validate_statistics(eval_stats, schema)\n",
         "tfdv.display_anomalies(updated_anomalies)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -404,19 +421,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "wSZfbnifJuTA"
+        "id": "wSZfbnifJuTA",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "serving_stats = tfdv.generate_statistics_from_csv(SERVING_DATA)\n",
         "serving_anomalies = tfdv.validate_statistics(serving_stats, schema)\n",
         "\n",
         "tfdv.display_anomalies(serving_anomalies)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -432,20 +449,20 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "OhtYF8aAczpd"
+        "id": "OhtYF8aAczpd",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "options = tfdv.StatsOptions(schema=schema, infer_type_from_schema=True)\n",
         "serving_stats = tfdv.generate_statistics_from_csv(SERVING_DATA, stats_options=options)\n",
         "serving_anomalies = tfdv.validate_statistics(serving_stats, schema)\n",
         "\n",
         "tfdv.display_anomalies(serving_anomalies)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -459,13 +476,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "bnbnw8H6Lp2M"
+        "id": "bnbnw8H6Lp2M",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# All features are by default in both TRAINING and SERVING environments.\n",
         "schema.default_environment.append('TRAINING')\n",
@@ -478,7 +493,9 @@
         "    serving_stats, schema, environment='SERVING')\n",
         "\n",
         "tfdv.display_anomalies(serving_anomalies_with_env)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -533,13 +550,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "wEUsZm_rOd1Q"
+        "id": "wEUsZm_rOd1Q",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Add skew comparator for 'payment_type' feature.\n",
         "payment_type = tfdv.get_feature(schema, 'payment_type')\n",
@@ -554,7 +569,9 @@
         "                                          serving_statistics=serving_stats)\n",
         "\n",
         "tfdv.display_anomalies(skew_anomalies)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -580,13 +597,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "ydkL4DkIWn18"
+        "id": "ydkL4DkIWn18",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from tensorflow.python.lib.io import file_io\n",
         "from google.protobuf import text_format\n",
@@ -596,7 +611,9 @@
         "tfdv.write_schema_text(schema, schema_file)\n",
         "\n",
         "!cat {schema_file}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -614,23 +631,5 @@
         "* Validating our data after we've transformed it and done feature engineering (probably using [TensorFlow Transform](https://www.tensorflow.org/tfx/transform/)) to make sure we haven't done something wrong"
       ]
     }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [
-        "tghWegsjhpkt"
-      ],
-      "name": "chicago_taxi.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/docs/tutorials/model_analysis/tfma_basic.ipynb
+++ b/docs/tutorials/model_analysis/tfma_basic.ipynb
@@ -1,4 +1,22 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "chicago_taxi.ipynb",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [
+        "tghWegsjhpkt"
+      ],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -7,18 +25,16 @@
         "id": "tghWegsjhpkt"
       },
       "source": [
-        "##### Copyright \u0026copy; 2019 The TensorFlow Authors."
+        "##### Copyright &copy; 2019 The TensorFlow Authors."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "rSGJWC5biBiG"
+        "id": "rSGJWC5biBiG",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -31,7 +47,9 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -53,14 +71,14 @@
       "source": [
         "Note: You can run this example right now in a Jupyter-style notebook, no setup required!  Just click \"Run in Google Colab\"\n",
         "\n",
-        "\u003cdiv class=\"devsite-table-wrapper\"\u003e\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/model_analysis/tfma_basic\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://colab.sandbox.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/model_analysis/tfma_basic.ipynb\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\"\u003eRun in Google Colab\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://github.com/tensorflow/tfx/blob/master/docs/tutorials/model_analysis/tfma_basic.ipynb\"\u003e\n",
-        "\u003cimg width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\"\u003eView source on GitHub\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003c/table\u003e\u003c/div\u003e"
+        "<div class=\"devsite-table-wrapper\"><table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "<td><a target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/model_analysis/tfma_basic\">\n",
+        "<img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a></td>\n",
+        "<td><a target=\"_blank\" href=\"https://colab.sandbox.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/model_analysis/tfma_basic.ipynb\">\n",
+        "<img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\">Run in Google Colab</a></td>\n",
+        "<td><a target=\"_blank\" href=\"https://github.com/tensorflow/tfx/blob/master/docs/tutorials/model_analysis/tfma_basic.ipynb\">\n",
+        "<img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\">View source on GitHub</a></td>\n",
+        "</table></div>"
       ]
     },
     {
@@ -80,9 +98,9 @@
         "\n",
         "[Read more](https://cloud.google.com/bigquery/public-data/chicago-taxi) about the dataset in [Google BigQuery](https://cloud.google.com/bigquery/). Explore the full dataset in the [BigQuery UI](https://bigquery.cloud.google.com/dataset/bigquery-public-data:chicago_taxi_trips).\n",
         "\n",
-        "Key Point: As a modeler and developer, think about how this data is used and the potential benefits and harm a model's predictions can cause. A model like this could reinforce societal biases and disparities. Is a feature relevant to the problem you want to solve or will it introduce bias? For more information, read about \u003ca target='_blank' href='https://developers.google.com/machine-learning/fairness-overview/'\u003eML fairness\u003c/a\u003e.\n",
+        "Key Point: As a modeler and developer, think about how this data is used and the potential benefits and harm a model's predictions can cause. A model like this could reinforce societal biases and disparities. Is a feature relevant to the problem you want to solve or will it introduce bias? For more information, read about <a target='_blank' href='https://developers.google.com/machine-learning/fairness-overview/'>ML fairness</a>.\n",
         "\n",
-        "Key Point: In order to understand `TFMA` and how it works with Apache Beam, you'll need to know a little bit about Apache Beam itself.  The \u003ca target='_blank' href='https://beam.apache.org/documentation/programming-guide/'\u003eBeam Programming Guide\u003c/a\u003e is a great place to start."
+        "Key Point: In order to understand `TFMA` and how it works with Apache Beam, you'll need to know a little bit about Apache Beam itself.  The <a target='_blank' href='https://beam.apache.org/documentation/programming-guide/'>Beam Programming Guide</a> is a great place to start."
       ]
     },
     {
@@ -93,15 +111,15 @@
       },
       "source": [
         "The columns in the dataset are:\n",
-        "\u003ctable\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003epickup_community_area\u003c/td\u003e\u003ctd\u003efare\u003c/td\u003e\u003ctd\u003etrip_start_month\u003c/td\u003e\u003c/tr\u003e\n",
+        "<table>\n",
+        "<tr><td>pickup_community_area</td><td>fare</td><td>trip_start_month</td></tr>\n",
         "\n",
-        "\u003ctr\u003e\u003ctd\u003etrip_start_hour\u003c/td\u003e\u003ctd\u003etrip_start_day\u003c/td\u003e\u003ctd\u003etrip_start_timestamp\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003epickup_latitude\u003c/td\u003e\u003ctd\u003epickup_longitude\u003c/td\u003e\u003ctd\u003edropoff_latitude\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003edropoff_longitude\u003c/td\u003e\u003ctd\u003etrip_miles\u003c/td\u003e\u003ctd\u003epickup_census_tract\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003edropoff_census_tract\u003c/td\u003e\u003ctd\u003epayment_type\u003c/td\u003e\u003ctd\u003ecompany\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003ctr\u003e\u003ctd\u003etrip_seconds\u003c/td\u003e\u003ctd\u003edropoff_community_area\u003c/td\u003e\u003ctd\u003etips\u003c/td\u003e\u003c/tr\u003e\n",
-        "\u003c/table\u003e"
+        "<tr><td>trip_start_hour</td><td>trip_start_day</td><td>trip_start_timestamp</td></tr>\n",
+        "<tr><td>pickup_latitude</td><td>pickup_longitude</td><td>dropoff_latitude</td></tr>\n",
+        "<tr><td>dropoff_longitude</td><td>trip_miles</td><td>pickup_census_tract</td></tr>\n",
+        "<tr><td>dropoff_census_tract</td><td>payment_type</td><td>company</td></tr>\n",
+        "<tr><td>trip_seconds</td><td>dropoff_community_area</td><td>tips</td></tr>\n",
+        "</table>"
       ]
     },
     {
@@ -135,29 +153,41 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
+        "id": "UkyhQZv_6uYd",
         "colab_type": "code",
-        "id": "SA2E343NAMRF"
+        "colab": {}
       },
-      "outputs": [],
+      "source": [
+        "# Install TFMA\n",
+        "# This will pull in all the dependencies, and will take a minute\n",
+        "# Please ignore the warnings\n",
+        "# NOTE: In Colab, restarting runtime is required after installing TFMA \n",
+        "!pip install tensorflow\n",
+        "!pip install tensorflow_model_analysis=='0.14.0'"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "SA2E343NAMRF",
+        "colab": {}
+      },
       "source": [
         "import sys, os\n",
         "# Confirm that we're using Python 3\n",
         "assert sys.version_info.major is 3, 'Oops, not running Python 3'\n",
         "\n",
-        "# Install TFMA\n",
-        "# This will pull in all the dependencies, and will take a minute\n",
-        "# Please ignore the warnings\n",
-        "!pip install -q tensorflow\n",
-        "!pip install -q tensorflow_model_analysis=='0.14.0'\n",
-        "\n",
         "import tensorflow as tf\n",
         "import tensorflow_model_analysis as tfma\n",
         "tf.logging.set_verbosity(tf.logging.ERROR)\n",
         "print('TFMA version: {}'.format(tfma.version.VERSION_STRING))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -178,13 +208,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "K4QXVIM7iglN"
+        "id": "K4QXVIM7iglN",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Download the zip file from GCP and unzip it\n",
         "import tempfile, requests, zipfile, io\n",
@@ -199,7 +227,9 @@
         "\n",
         "print(\"Here's what we downloaded:\")\n",
         "!ls -R {TFMA_DIR}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -215,13 +245,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "uW5eB4TPcwFw"
+        "id": "uW5eB4TPcwFw",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "from google.protobuf import text_format\n",
         "from tensorflow.python.lib.io import file_io\n",
@@ -232,7 +260,9 @@
         "schema = schema_pb2.Schema()\n",
         "contents = file_io.read_file_to_string(SCHEMA)\n",
         "schema = text_format.Parse(contents, schema)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -248,13 +278,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "8-wud3fPczl6"
+        "id": "8-wud3fPczl6",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import csv\n",
         "\n",
@@ -265,7 +293,7 @@
         "  example = example_pb2.Example()\n",
         "  for feature in schema.feature:\n",
         "    key = feature.name\n",
-        "    if len(line[key]) \u003e 0:\n",
+        "    if len(line[key]) > 0:\n",
         "      if feature.type == schema_pb2.FLOAT:\n",
         "        example.features.feature[key].float_list.value[:] = [float(line[key])]\n",
         "      elif feature.type == schema_pb2.INT:\n",
@@ -289,7 +317,9 @@
         "  writer.close()\n",
         "\n",
         "!ls {TFRecord_file}"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -305,13 +335,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "H2wANNF_2dCR"
+        "id": "H2wANNF_2dCR",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def run_and_render(eval_model=None, slice_list=None, slice_idx=0):\n",
         "  \"\"\"Runs the model analysis and renders the slicing metrics\n",
@@ -331,7 +359,9 @@
         "                                          output_path='sample_data',\n",
         "                                          extractors=None)\n",
         "  return tfma.view.render_slicing_metrics(eval_result, slicing_spec=slices[slice_idx])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -362,13 +392,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "hJ5_UMnWYmaE"
+        "id": "hJ5_UMnWYmaE",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "# Load the TFMA results for the first training run\n",
         "# This will take a minute\n",
@@ -380,7 +408,9 @@
         "slices = [tfma.slicer.SingleSliceSpec(columns=['trip_start_hour'])]\n",
         "\n",
         "run_and_render(eval_model=eval_shared_model_0, slice_list=slices, slice_idx=0)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -434,19 +464,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "355wqvY3yBod"
+        "id": "355wqvY3yBod",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "slices = [tfma.slicer.SingleSliceSpec(columns=['trip_start_hour']),\n",
         "          tfma.slicer.SingleSliceSpec(columns=['trip_start_day']),\n",
         "          tfma.slicer.SingleSliceSpec(columns=['trip_start_month'])]\n",
         "run_and_render(eval_model=eval_shared_model_0, slice_list=slices, slice_idx=1)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -460,17 +490,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "k7vbFS1Me1SH"
+        "id": "k7vbFS1Me1SH",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "slices = [tfma.slicer.SingleSliceSpec(columns=['trip_start_day', 'trip_start_hour'])]\n",
         "run_and_render(eval_shared_model_0, slices, 0)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -484,17 +514,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "kdvBNfcHfRWg"
+        "id": "kdvBNfcHfRWg",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "slices = [tfma.slicer.SingleSliceSpec(columns=['trip_start_day'], features=[('trip_start_hour', 12)])]\n",
         "run_and_render(eval_shared_model_0, slices, 0)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -537,13 +567,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "zJYUOjmFfuPy"
+        "id": "zJYUOjmFfuPy",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def get_eval_result(base_dir, output_dir, data_loc, slice_spec):\n",
         "  eval_model_dir = os.path.join(base_dir, next(os.walk(base_dir))[1][0])\n",
@@ -566,7 +594,9 @@
         "output_dir_2 = os.path.join(TFMA_DIR, 'output', 'run_2')\n",
         "result_ts2 = get_eval_result(os.path.join(TFMA_DIR, 'run_2', 'eval_model_dir'),\n",
         "                             output_dir_2, TFRecord_file, slices)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -583,19 +613,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "KjEws8T0cDm9"
+        "id": "KjEws8T0cDm9",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "eval_results_from_disk = tfma.load_eval_results([output_dir_0, output_dir_1],\n",
         "                                                tfma.constants.MODEL_CENTRIC_MODE)\n",
         "\n",
         "tfma.view.render_time_series(eval_results_from_disk, slices[0])"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -609,41 +639,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "VjQmlXMmLwHf"
+        "id": "VjQmlXMmLwHf",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "eval_results_from_disk = tfma.load_eval_results([output_dir_0, output_dir_1, output_dir_2],\n",
         "                                                tfma.constants.MODEL_CENTRIC_MODE)\n",
         "\n",
         "tfma.view.render_time_series(eval_results_from_disk, slices[0])"
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [
-        "tghWegsjhpkt"
       ],
-      "last_runtime": {
-        "build_target": "//intelligence/datum/prensor/colab:prensor_notebook",
-        "kind": "shared"
-      },
-      "name": "chicago_taxi.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
+      "execution_count": 0,
+      "outputs": []
     }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/docs/tutorials/model_analysis/tfma_basic.ipynb
+++ b/docs/tutorials/model_analysis/tfma_basic.ipynb
@@ -164,7 +164,8 @@
         "# Please ignore the warnings\n",
         "# NOTE: In Colab, restarting runtime is required after installing TFMA \n",
         "!pip install tensorflow\n",
-        "!pip install tensorflow_model_analysis=='0.14.0'"
+        "!pip install tensorflow_model_analysis=='0.14.0'\n",
+        "!pip install tensorflow_transform=='0.14.0'"
       ],
       "execution_count": 0,
       "outputs": []

--- a/docs/tutorials/transform/census.ipynb
+++ b/docs/tutorials/transform/census.ipynb
@@ -4,7 +4,6 @@
   "metadata": {
     "colab": {
       "name": "census.ipynb",
-      "version": "0.3.2",
       "provenance": [],
       "private_outputs": true,
       "collapsed_sections": [],
@@ -111,6 +110,33 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "2yZvxOa-FdEI",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Install TensorFlow Transforrm\n",
+        "\n",
+        "This will pull in all the dependencies, and will take a minute. Please ignore the warnings."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Yfhyv6cAF8O0",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Installing TensorFlow Transform and Apache Beam.  This will take a minute, ignore the warnings.\n",
+        "!pip install apache_beam\n",
+        "!pip install tensorflow_transform"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "colab_type": "text",
         "id": "RptgLn2RYuK3"
       },
@@ -159,10 +185,6 @@
         "train = os.path.join(temp, 'census/adult.data')\n",
         "test = os.path.join(temp, 'census/adult.test')\n",
         "\n",
-        "print('Installing TensorFlow Transform.  This will take a minute, ignore the warnings')\n",
-        "!pip install -q tensorflow_transform\n",
-        "print('Installing Apache Beam.  This will take a minute, ignore the warnings')\n",
-        "!pip install -q apache_beam\n",
         "import tensorflow_transform as tft\n",
         "import apache_beam as beam\n",
         "\n",

--- a/docs/tutorials/transform/census.ipynb
+++ b/docs/tutorials/transform/census.ipynb
@@ -142,7 +142,7 @@
       },
       "source": [
         "## Python check, imports, and globals\n",
-        "First we'll make sure that we're using Python 2, and then go ahead and install and import the stuff we need."
+        "First we'll make sure that we're using Python 3, and then go ahead and import the stuff we need."
       ]
     },
     {

--- a/docs/tutorials/transform/simple.ipynb
+++ b/docs/tutorials/transform/simple.ipynb
@@ -1,4 +1,21 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "simple.ipynb",
+      "provenance": [],
+      "private_outputs": true,
+      "collapsed_sections": [
+        "tghWegsjhpkt"
+      ],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -7,14 +24,14 @@
         "id": "Ifon2ScEAsJO"
       },
       "source": [
-        "\u003cdiv class=\"devsite-table-wrapper\"\u003e\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/transform/simple\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" /\u003eView on TensorFlow.org\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/transform/simple.ipynb\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\"\u003eRun in Google Colab\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://github.com/tensorflow/tfx/blob/master/docs/tutorials/transform/simple.ipynb\"\u003e\n",
-        "\u003cimg width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\"\u003eView source on GitHub\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003c/table\u003e\u003c/div\u003e"
+        "<div class=\"devsite-table-wrapper\"><table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "<td><a target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/transform/simple\">\n",
+        "<img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\" />View on TensorFlow.org</a></td>\n",
+        "<td><a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/transform/simple.ipynb\">\n",
+        "<img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\">Run in Google Colab</a></td>\n",
+        "<td><a target=\"_blank\" href=\"https://github.com/tensorflow/tfx/blob/master/docs/tutorials/transform/simple.ipynb\">\n",
+        "<img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\">View source on GitHub</a></td>\n",
+        "</table></div>"
       ]
     },
     {
@@ -24,18 +41,16 @@
         "id": "tghWegsjhpkt"
       },
       "source": [
-        "##### Copyright \u0026copy; 2019 Google Inc."
+        "##### Copyright &copy; 2019 Google Inc."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "rSGJWC5biBiG"
+        "id": "rSGJWC5biBiG",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
@@ -48,7 +63,9 @@
         "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
         "# See the License for the specific language governing permissions and\n",
         "# limitations under the License."
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -60,7 +77,7 @@
         "# Preprocess data with TensorFlow Transform\n",
         "***The Feature Engineering Component of TensorFlow Extended (TFX)***\n",
         "\n",
-        "This example colab notebook provides a very simple example of how \u003ca target='_blank' href='https://www.tensorflow.org/tfx/transform/'\u003eTensorFlow Transform (\u003ccode\u003etf.Transform\u003c/code\u003e)\u003c/a\u003e can be used to preprocess data using exactly the same code for both training a model and serving inferences in production.\n",
+        "This example colab notebook provides a very simple example of how <a target='_blank' href='https://www.tensorflow.org/tfx/transform/'>TensorFlow Transform (<code>tf.Transform</code>)</a> can be used to preprocess data using exactly the same code for both training a model and serving inferences in production.\n",
         "\n",
         "TensorFlow Transform is a library for preprocessing input data for TensorFlow, including creating features that require a full pass over the training dataset.  For example, using TensorFlow Transform you could:\n",
         "\n",
@@ -76,42 +93,64 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "qYotcTGEJYwQ",
+        "colab_type": "text"
+      },
+      "source": [
+        "# Install TensorFlow Transforrm\n",
+        "\n",
+        "This will pull in all the dependencies, and will take a minute. Please ignore the warnings."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "r9RLtKKWJz71",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Installing TensorFlow Transform. This will take a minute, ignore the warnings.\n",
+        "!pip install tensorflow_transform"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "colab_type": "text",
         "id": "RptgLn2RYuK3"
       },
       "source": [
         "## Python check and imports\n",
-        "First, we'll make sure that we're using Python 3. Then, we'll go ahead and install and import the stuff we need."
+        "First, we'll make sure that we're using Python 3. Then, we'll go ahead and import the stuff we need."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "tFcdSuXTidhH"
+        "id": "tFcdSuXTidhH",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "import sys, os\n",
         "# Confirm that we're using Python 3\n",
         "assert sys.version_info.major is 3, 'Oops, not running Python 3'\n",
         "print(sys.version_info)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "K4QXVIM7iglN"
+        "id": "K4QXVIM7iglN",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
-        "!pip install -q tensorflow-transform\n",
-        "\n",
         "import pprint\n",
         "import tempfile\n",
         "\n",
@@ -121,7 +160,9 @@
         "from tensorflow_transform.tf_metadata import dataset_metadata\n",
         "from tensorflow_transform.tf_metadata import dataset_schema\n",
         "tf.logging.set_verbosity(tf.logging.ERROR)"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -139,13 +180,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "-R236Tkf_ON3"
+        "id": "-R236Tkf_ON3",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "raw_data = [\n",
         "      {'x': 1, 'y': 1, 's': 'hello'},\n",
@@ -159,7 +198,9 @@
         "        'x': tf.FixedLenFeature([], tf.float32),\n",
         "        's': tf.FixedLenFeature([], tf.string),\n",
         "    }))"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -179,13 +220,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "H2wANNF_2dCR"
+        "id": "H2wANNF_2dCR",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def preprocessing_fn(inputs):\n",
         "    \"\"\"Preprocess input columns into transformed columns.\"\"\"\n",
@@ -202,7 +241,9 @@
         "        's_integerized': s_integerized,\n",
         "        'x_centered_times_y_normalized': x_centered_times_y_normalized,\n",
         "    }"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -217,28 +258,26 @@
         "2. `raw_data_metadata` - The schema for the raw data\n",
         "3. `preprocessing_fn` - The function that we created to do our transformation\n",
         "\n",
-        "\u003caside class=\"key-term\"\u003e\u003cb\u003eKey Term:\u003c/b\u003e \u003ca target='_blank' href='https://beam.apache.org/'\u003eApache Beam\u003c/a\u003e uses a \u003ca target='_blank' href='https://beam.apache.org/documentation/programming-guide/#applying-transforms'\u003especial syntax to define and invoke transforms\u003c/a\u003e.  For example, in this line:\n",
+        "<aside class=\"key-term\"><b>Key Term:</b> <a target='_blank' href='https://beam.apache.org/'>Apache Beam</a> uses a <a target='_blank' href='https://beam.apache.org/documentation/programming-guide/#applying-transforms'>special syntax to define and invoke transforms</a>.  For example, in this line:\n",
         "\n",
-        "\u003ccode\u003e\u003cblockquote\u003eresult = pass_this | 'name this step' \u003e\u003e to_this_call\u003c/blockquote\u003e\u003c/code\u003e\n",
+        "<code><blockquote>result = pass_this | 'name this step' >> to_this_call</blockquote></code>\n",
         "\n",
-        "The method \u003ccode\u003eto_this_call\u003c/code\u003e is being invoked and passed the object called \u003ccode\u003epass_this\u003c/code\u003e, and \u003ca target='_blank' href='https://stackoverflow.com/questions/50519662/what-does-the-redirection-mean-in-apache-beam-python'\u003ethis operation will be referred to as \u003ccode\u003ename this step\u003c/code\u003e in a stack trace\u003c/a\u003e.  The result of the call to \u003ccode\u003eto_this_call\u003c/code\u003e is returned in \u003ccode\u003eresult\u003c/code\u003e.  You will often see stages of a pipeline chained together like this:\n",
+        "The method <code>to_this_call</code> is being invoked and passed the object called <code>pass_this</code>, and <a target='_blank' href='https://stackoverflow.com/questions/50519662/what-does-the-redirection-mean-in-apache-beam-python'>this operation will be referred to as <code>name this step</code> in a stack trace</a>.  The result of the call to <code>to_this_call</code> is returned in <code>result</code>.  You will often see stages of a pipeline chained together like this:\n",
         "\n",
-        "\u003ccode\u003e\u003cblockquote\u003eresult = apache_beam.Pipeline() | 'first step' \u003e\u003e do_this_first() | 'second step' \u003e\u003e do_this_last()\u003c/blockquote\u003e\u003c/code\u003e\n",
+        "<code><blockquote>result = apache_beam.Pipeline() | 'first step' >> do_this_first() | 'second step' >> do_this_last()</blockquote></code>\n",
         "\n",
         "and since that started with a new pipeline, you can continue like this:\n",
         "\n",
-        "\u003ccode\u003e\u003cblockquote\u003enext_result = result | 'doing more stuff' \u003e\u003e another_function()\u003c/blockquote\u003e\u003c/code\u003e\u003c/aside\u003e"
+        "<code><blockquote>next_result = result | 'doing more stuff' >> another_function()</blockquote></code></aside>"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 0,
       "metadata": {
-        "colab": {},
         "colab_type": "code",
-        "id": "mAF9w7RTZU7c"
+        "id": "mAF9w7RTZU7c",
+        "colab": {}
       },
-      "outputs": [],
       "source": [
         "def main():\n",
         "  # Ignore the warnings\n",
@@ -254,7 +293,9 @@
         "\n",
         "if __name__ == '__main__':\n",
         "  main()"
-      ]
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -281,23 +322,5 @@
         "We wanted to create a new feature by crossing `x_centered` and `y_normalized` using multiplication.  Note that this multiplies the results, not the original values, and our new result of `[-0.0, 0.0, 1.0]` is correct."
       ]
     }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [
-        "tghWegsjhpkt"
-      ],
-      "name": "simple.ipynb",
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true,
-      "version": "0.3.2"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }


### PR DESCRIPTION
I fixed the issue of TFDV tutorial about that it raises an error in Colab environment.

In Colab environment, a user has to restart runtime after installing TFDV and Colab will show the "RESTART RUNTIME" button without pip -q option.
With pip -q option, however, running code cell contains pip command raises FileNotFoundError and Colab will not show the "RESTART RUNTIME" button. I think a user can easily miss the requirement to restart runtime (like me).

![image](https://user-images.githubusercontent.com/30427632/71312721-9ea8fa00-2471-11ea-8215-24320ff89118.png)

In this PR, I removed pip -q option and divide the code cell to show "RESTART RUNTIME" button at the bottom of the logs.