### PR TITLE
Support BOOLEAN row values by casting to integer

### DIFF
--- a/tfx/components/example_gen/big_query_example_gen/executor.py
+++ b/tfx/components/example_gen/big_query_example_gen/executor.py
@@ -47,7 +47,7 @@ class _BigQueryConverter(object):
       data_type = self._type_map[key]
       if value is None:
         feature[key] = tf.train.Feature()
-      elif data_type == 'INTEGER':
+      elif data_type in ('INTEGER', 'BOOLEAN'):
         feature[key] = tf.train.Feature(
             int64_list=tf.train.Int64List(value=[value]))
       elif data_type == 'FLOAT':


### PR DESCRIPTION
Boolean types can be coerced to an Int64List according to docs [here](https://www.tensorflow.org/tutorials/load_data/tfrecord#data_types_for_tfexample).