### PR TITLE
Fix typo in schemagen docs

### DIFF
--- a/docs/guide/schemagen.md
+++ b/docs/guide/schemagen.md
@@ -9,7 +9,7 @@ whether a feature has to be present in all examples, allowed value ranges, and
 other properties.  A SchemaGen pipeline component will automatically generate a
 schema by inferring types, categories, and ranges from the training data.
 
-* Consumes: statistics from an StatisticsGen component
+* Consumes: statistics from a StatisticsGen component
 * Emits: Data schema proto
 
 Here's an excerpt from a schema proto:


### PR DESCRIPTION
I spotted a small typo when reading the SatisticsGen Documentation 🙏 