### PR TITLE
run_and_render method uses a global that is defined later

### DIFF
--- a/docs/tutorials/model_analysis/tfma_basic.ipynb
+++ b/docs/tutorials/model_analysis/tfma_basic.ipynb
@@ -355,7 +355,7 @@
         "                                          slice_spec=slice_list,\n",
         "                                          output_path='sample_data',\n",
         "                                          extractors=None)\n",
-        "  return tfma.view.render_slicing_metrics(eval_result, slicing_spec=slices[slice_idx])"
+        "  return tfma.view.render_slicing_metrics(eval_result, slicing_spec=slice_list[slice_idx])"
       ]
     },
     {


### PR DESCRIPTION
Due to the dynamic duck typing in Python, the method run_and_render parses fine though it uses `slices` variable that is defined later. Instead we could use the `slice_list` which is an argument to the function