### PR TITLE
Fix plot title in serving tutorial.

### DIFF
--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -906,7 +906,7 @@
         "predictions = json.loads(json_response.text)['predictions']\n",
         "\n",
         "show(0, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(\n",
-        "  class_names[np.argmax(predictions[0])], test_labels[0], class_names[np.argmax(predictions[0])], test_labels[0]))"
+        "  class_names[np.argmax(predictions[0])], np.argmax(predictions[0]), class_names[test_labels[0]], test_labels[0]))"
       ],
       "execution_count": 14,
       "outputs": [
@@ -954,7 +954,7 @@
         "\n",
         "for i in range(0,3):\n",
         "  show(i, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(\n",
-        "    class_names[np.argmax(predictions[i])], test_labels[i], class_names[np.argmax(predictions[i])], test_labels[i]))"
+        "    class_names[np.argmax(predictions[i])], np.argmax(predictions[i]), class_names[test_labels[i]], test_labels[i]))"
       ],
       "execution_count": 15,
       "outputs": [


### PR DESCRIPTION
Fixed the plot title in the tutorial notebook of TensorFlow Serving, which used true label for predicted label, and used predicted class name for true class name.
