### PR TITLE
Fix datatype of the BigQuery query

### DIFF
--- a/tfx/experimental/templates/taxi/pipeline/configs.py
+++ b/tfx/experimental/templates/taxi/pipeline/configs.py
@@ -79,7 +79,7 @@ _query_sample_rate = 0.0001  # Generate a 0.01% random sample.
 #           dropoff_latitude,
 #           dropoff_longitude,
 #           trip_miles,
-#           pickup_census_tract,
+#           SAFE_CAST(pickup_census_tract AS STRING) AS pickup_census_tract,
 #           dropoff_census_tract,
 #           payment_type,
 #           company,


### PR DESCRIPTION
This PR fixes the problem that [tfx/template.ipynb](https://github.com/tensorflow/tfx/blob/master/docs/tutorials/tfx/template.ipynb) fails at step 7 "Try BigQueryExampleGen".

Using `CsvExampleGen`, the data type of `pickup_sensus_tract` is nullable string. With `BigQueryExampleGen`, the datatype of `pickup_sensus_tract` should be nullable string too, however, it is INT with the original query.

This causes Invalid argument error at Step 7 of [tfx/template.ipynb](https://github.com/tensorflow/tfx/blob/master/docs/tutorials/tfx/template.ipynb). Full error message is below;

```
2020-03-20 12:00:48.705697: W tensorflow/core/framework/op_kernel.cc:1655] OP_REQUIRES failed at example_parsing_ops.cc:91 : Invalid argument: Name: <unknown>, Key: pickup_census_tract, Index: 90.  Data types don't match. Expected type: string, Actual type: int64
```

I made the query returns string value using safe cast function. 