### PR TITLE
CONTRIBUTING.md: Note on Python 3.8 and above

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,10 @@ https://opensource.google.com/conduct/).
 
 # Contributing Guidelines
 
-At this point, TFX only supports Python 3 on Linux and MacOS. Please use one of
+At this point, TFX only supports Python 3 (up to version 3.7) on Linux and MacOS. Please use one of
 these operation system for development and testing.
 
 If Python 3.5 is used, our usage of type hints requires at least 3.5.3.
-
-If Python 3.8 or above is used, note that this will likely introduce an [error when trying to install ml-metadata](https://github.com/google/ml-metadata/issues/37).
 
 ## Testing Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ these operation system for development and testing.
 
 If Python 3.5 is used, our usage of type hints requires at least 3.5.3.
 
+If Python 3.8 or above is used, note that this will likely introduce an [error when trying to install ml-metadata](https://github.com/google/ml-metadata/issues/37).
+
 ## Testing Conventions
 
 All python unit tests in this repo is based on Tensorflow's


### PR DESCRIPTION
I updated the contributing.md with my finding that Python 3.8 and above isn't really supported by ml-metadata for some reason