### PR TITLE
Add support for arrays in BigQueryExampleGen

### DIFF
--- a/tfx/components/example_gen/big_query_example_gen/executor.py
+++ b/tfx/components/example_gen/big_query_example_gen/executor.py
@@ -60,7 +60,8 @@ class _BigQueryConverter(object):
             float_list=tf.train.FloatList(value=value_list))
       elif data_type == 'STRING':
         feature[key] = tf.train.Feature(
-            bytes_list=tf.train.BytesList(value=[tf.compat.as_bytes(elem) for elem in value_list]))
+            bytes_list=tf.train.BytesList(
+                value=[tf.compat.as_bytes(elem) for elem in value_list]))
       else:
         # TODO(jyzhao): support more types.
         raise RuntimeError(

--- a/tfx/components/example_gen/big_query_example_gen/executor.py
+++ b/tfx/components/example_gen/big_query_example_gen/executor.py
@@ -49,15 +49,18 @@ class _BigQueryConverter(object):
       data_type = self._type_map[key]
       if value is None:
         feature[key] = tf.train.Feature()
-      elif data_type in ('INTEGER', 'BOOLEAN'):
+        continue
+      # A repeated value will the data type as a single value
+      value_list = value if isinstance(value, list) else [value]
+      if data_type in ('INTEGER', 'BOOLEAN'):
         feature[key] = tf.train.Feature(
-            int64_list=tf.train.Int64List(value=[value]))
+            int64_list=tf.train.Int64List(value=value_list))
       elif data_type == 'FLOAT':
         feature[key] = tf.train.Feature(
-            float_list=tf.train.FloatList(value=[value]))
+            float_list=tf.train.FloatList(value=value_list))
       elif data_type == 'STRING':
         feature[key] = tf.train.Feature(
-            bytes_list=tf.train.BytesList(value=[tf.compat.as_bytes(value)]))
+            bytes_list=tf.train.BytesList(value=[tf.compat.as_bytes(elem) for elem in value_list]))
       else:
         # TODO(jyzhao): support more types.
         raise RuntimeError(

--- a/tfx/components/example_gen/big_query_example_gen/executor_test.py
+++ b/tfx/components/example_gen/big_query_example_gen/executor_test.py
@@ -83,7 +83,8 @@ class ExecutorTest(tf.test.TestCase):
   @mock.patch.object(bigquery, 'Client')
   def testBigQueryToExample(self, mock_client):
     # Mock query result schema for _BigQueryConverter.
-    mock_client.return_value.query.return_value.result.return_value.schema = self._schema
+    mock_client.return_value.query.return_value.result.return_value.schema =\
+        self._schema
 
     with beam.Pipeline() as pipeline:
       examples = (
@@ -119,7 +120,8 @@ class ExecutorTest(tf.test.TestCase):
   @mock.patch.object(bigquery, 'Client')
   def testDo(self, mock_client):
     # Mock query result schema for _BigQueryConverter.
-    mock_client.return_value.query.return_value.result.return_value.schema = self._schema
+    mock_client.return_value.query.return_value.result.return_value.schema =\
+        self._schema
 
     output_data_dir = os.path.join(
         os.environ.get('TEST_UNDECLARED_OUTPUTS_DIR', self.get_temp_dir()),

--- a/tfx/components/example_gen/big_query_example_gen/executor_test.py
+++ b/tfx/components/example_gen/big_query_example_gen/executor_test.py
@@ -51,9 +51,12 @@ def _MockReadFromBigQuery(pipeline, query, project, use_bigquery_source):  # pyl
 def _MockReadFromBigQuery2(pipeline, query, project, use_bigquery_source):  # pylint: disable=invalid-name, unused-argument
   mock_query_results = [{
       'i': 1,
+      'i2': [2, 3],
       'b': True,
       'f': 2.0,
+      'f2': [2.7, 3.8],
       's': 'abc',
+      's2': ['abc', 'def']
   }]
   return pipeline | beam.Create(mock_query_results)
 
@@ -64,9 +67,12 @@ class ExecutorTest(tf.test.TestCase):
     # Mock BigQuery result schema.
     self._schema = [
         bigquery.SchemaField('i', 'INTEGER', mode='REQUIRED'),
+        bigquery.SchemaField('i2', 'INTEGER', mode='REPEATED'),
         bigquery.SchemaField('b', 'BOOLEAN', mode='REQUIRED'),
         bigquery.SchemaField('f', 'FLOAT', mode='REQUIRED'),
+        bigquery.SchemaField('f2', 'FLOAT', mode='REPEATED'),
         bigquery.SchemaField('s', 'STRING', mode='REQUIRED'),
+        bigquery.SchemaField('s2', 'STRING', mode='REPEATED'),
     ]
     super(ExecutorTest, self).setUp()
 
@@ -86,15 +92,22 @@ class ExecutorTest(tf.test.TestCase):
               exec_properties={
                   '_beam_pipeline_args': ['--project=' + _test_project],
               },
-              split_pattern='SELECT i, b, f, s FROM `fake`'))
+              split_pattern='SELECT i, i2, b, f, f2, s, s2 FROM `fake`'))
 
       feature = {}
       feature['i'] = tf.train.Feature(int64_list=tf.train.Int64List(value=[1]))
+      feature['i2'] = tf.train.Feature(
+          int64_list=tf.train.Int64List(value=[2, 3]))
       feature['b'] = tf.train.Feature(int64_list=tf.train.Int64List(value=[1]))
       feature['f'] = tf.train.Feature(
           float_list=tf.train.FloatList(value=[2.0]))
+      feature['f2'] = tf.train.Feature(
+          float_list=tf.train.FloatList(value=[2.7, 3.8]))
       feature['s'] = tf.train.Feature(
           bytes_list=tf.train.BytesList(value=[tf.compat.as_bytes('abc')]))
+      feature['s2'] = tf.train.Feature(
+          bytes_list=tf.train.BytesList(
+              value=[tf.compat.as_bytes('abc'), tf.compat.as_bytes('def')]))
       example_proto = tf.train.Example(
           features=tf.train.Features(feature=feature))
       util.assert_that(examples, util.equal_to([example_proto]))


### PR DESCRIPTION
Addressing the lack of support for arrays/REPEATED as described in [this issue](https://github.com/tensorflow/tfx/issues/1738).

Last PR ended up in a CLA mess, this is not perfect either but at least looks better.

I guess we have to review it again @1025KB ?