### PR TITLE
[Airflow tutorial] Remove Step 1's checkout out of r0.21

### DIFF
--- a/docs/tutorials/tfx/airflow_workshop.md
+++ b/docs/tutorials/tfx/airflow_workshop.md
@@ -213,9 +213,6 @@ virtualenv -p python3 tfx-env
 source ~/tfx-env/bin/activate
 
 git clone https://github.com/tensorflow/tfx.git
-cd ~/tfx
-# These instructions are specific to the 0.21 release
-git checkout -f origin/r0.21
 cd ~/tfx/tfx/examples/airflow_workshop/setup
 ./setup_demo.sh
 ```


### PR DESCRIPTION
Because it causes Step 1's `setup_demo.sh` to fail. See #1497. It happened to me today as well.

```shell
$ python -V
Python 3.6.8
```