### PR TITLE
[Airflow tutorial] Update Airflow dependency to 1.10.10

### DIFF
--- a/tfx/examples/airflow_workshop/setup/setup_demo.sh
+++ b/tfx/examples/airflow_workshop/setup/setup_demo.sh
@@ -61,7 +61,7 @@ pip install docker
 printf "${GREEN}Preparing environment for Airflow${NORMAL}\n"
 export SLUGIFY_USES_TEXT_UNIDECODE=yes
 printf "${GREEN}Installing Airflow${NORMAL}\n"
-pip install -q apache-airflow==1.10.9 Flask==1.1.1 Werkzeug==0.15
+pip install -q apache-airflow==1.10.10 Flask==1.1.1 Werkzeug==0.15
 printf "${GREEN}Initializing Airflow database${NORMAL}\n"
 airflow initdb
 


### PR DESCRIPTION
Because Airflow 1.10.9 won't run in step 2, when running `airflow webserver -p 8080`.

Airflow 1.10.9 has a problem with its SQLAlchemy dependency. They fixed it in 1.10.10. See https://github.com/apache/airflow/issues/8211.