### PR TITLE
fixing bug: read utf8 format error : orchestration/experimental/interactive/interactive_context.py 

### DIFF
--- a/tfx/orchestration/experimental/interactive/interactive_context.py
+++ b/tfx/orchestration/experimental/interactive/interactive_context.py
@@ -68,7 +68,7 @@ def requires_ipython(fn):
       absl.logging.warning(
           'Method "%s" is a no-op when invoked outside of IPython.',
           fn.__name__)
-    return None
+      return None
   return run_if_ipython
 
 
@@ -188,8 +188,8 @@ class InteractiveContext(object):
     absl.logging.info('Exporting contents of %s to %s with %s runner.',
                       notebook_filepath, export_filepath, runner_type)
 
-    with open(notebook_filepath, encoding="utf-8") as notebook_f,\
-        open(export_filepath, 'w', encoding="utf-8") as export_f:
+    with open(notebook_filepath, encoding='utf-8') as notebook_f,\
+        open(export_filepath, 'w', encoding='utf-8') as export_f:
       notebook = nbformat.read(notebook_f, nbformat.NO_CONVERT)
       cells = notebook['cells']
       code_cells = (cell for cell in cells if cell['cell_type'] == 'code')

--- a/tfx/orchestration/experimental/interactive/interactive_context.py
+++ b/tfx/orchestration/experimental/interactive/interactive_context.py
@@ -68,7 +68,7 @@ def requires_ipython(fn):
       absl.logging.warning(
           'Method "%s" is a no-op when invoked outside of IPython.',
           fn.__name__)
-
+    return None
   return run_if_ipython
 
 
@@ -226,8 +226,8 @@ class InteractiveContext(object):
   @requires_ipython
   def show(self, item: object) -> None:
     """Show the given object in an IPython notebook display."""
-    from IPython.core.display import display  # pylint: disable=g-import-not-at-top
-    from IPython.core.display import HTML  # pylint: disable=g-import-not-at-top
+    from IPython.core.display import display  # pylint: disable=import-outside-toplevel
+    from IPython.core.display import HTML  # pylint: disable=import-outside-toplevel
     if isinstance(item, types.Channel):
       channel = item
       artifacts = channel.get()

--- a/tfx/orchestration/experimental/interactive/interactive_context.py
+++ b/tfx/orchestration/experimental/interactive/interactive_context.py
@@ -188,8 +188,8 @@ class InteractiveContext(object):
     absl.logging.info('Exporting contents of %s to %s with %s runner.',
                       notebook_filepath, export_filepath, runner_type)
 
-    with open(notebook_filepath) as notebook_f,\
-        open(export_filepath, 'w') as export_f:
+    with open(notebook_filepath,encoding="utf-8") as notebook_f,\
+        open(export_filepath, 'w',encoding="utf-8") as export_f:
       notebook = nbformat.read(notebook_f, nbformat.NO_CONVERT)
       cells = notebook['cells']
       code_cells = (cell for cell in cells if cell['cell_type'] == 'code')

--- a/tfx/orchestration/experimental/interactive/interactive_context.py
+++ b/tfx/orchestration/experimental/interactive/interactive_context.py
@@ -188,8 +188,8 @@ class InteractiveContext(object):
     absl.logging.info('Exporting contents of %s to %s with %s runner.',
                       notebook_filepath, export_filepath, runner_type)
 
-    with open(notebook_filepath,encoding="utf-8") as notebook_f,\
-        open(export_filepath, 'w',encoding="utf-8") as export_f:
+    with open(notebook_filepath, encoding="utf-8") as notebook_f,\
+        open(export_filepath, 'w', encoding="utf-8") as export_f:
       notebook = nbformat.read(notebook_f, nbformat.NO_CONVERT)
       cells = notebook['cells']
       code_cells = (cell for cell in cells if cell['cell_type'] == 'code')


### PR DESCRIPTION

## Error Occur
When I run 
`https://github.com/tensorflow/tfx/blob/master/docs/tutorials/tfx/components_keras.ipynb`

There raise a `UnicodeDecodeError`.

### Error Trace
![image](https://user-images.githubusercontent.com/16930652/83554687-c1226180-a53f-11ea-8641-cc5e65a89d40.png)

### Bug File Position

`tfx/orchestration/experimental/interactive/interactive_context.py``
Line 191-192
### Bug Fix Way
add `utf-8` support to `open()` method
