### PR TITLE
Added CAIP support for regional endpoints and VPC-SC

### DIFF
--- a/tfx/extensions/google_cloud_ai_platform/runner.py
+++ b/tfx/extensions/google_cloud_ai_platform/runner.py
@@ -24,6 +24,7 @@ import time
 from typing import Any, Dict, List, Optional, Text
 
 from absl import logging
+from google.api_core.client_options import ClientOptions
 from googleapiclient import discovery
 from googleapiclient import errors
 import tensorflow as tf
@@ -256,12 +257,36 @@ def deploy_model_for_aip_prediction(
   model_name = ai_platform_serving_args['model_name']
   project_id = ai_platform_serving_args['project_id']
   regions = ai_platform_serving_args.get('regions', [])
+  use_regional_endpoint = ai_platform_serving_args.get('use_regional_endpoint',False)
+  machine_type = ai_platform_serving_args.get('machine_type','n1-standard-2')
   default_runtime_version = _get_tf_runtime_version(tf.__version__)
   runtime_version = ai_platform_serving_args.get('runtime_version',
                                                  default_runtime_version)
   python_version = _get_caip_python_version(runtime_version)
-
+  
   api = discovery.build('ml', 'v1')
+  
+  # Insure regions was passed as a list and not a string. The API passes a list of str
+  if isinstance(regions, str):
+    if ',' in regions:
+      regions = regions.replace(" ","").split(',')
+    else:
+      regions = [regions]
+  
+  # Support regional endpoints in order to support VPC Service Controls
+  if use_regional_endpoint:
+    if len(regions) == 0:
+      logging.warning('Regional endpoints requires a region to be specified. Defaulting to us-central1.')
+      regions = ["us-central1"]
+    if len(regions) > 1:
+      # Regional endpoints requries requests to go to a specific endpoint
+      logging.warning('More than one specified region not supported with regional endpoints. Using first region in regions list.')
+
+    endpoint = 'https://{region}-ml.googleapis.com'.format(region=regions[0])
+    client_options = ClientOptions(api_endpoint=endpoint)
+    api = discovery.build('ml', 'v1', client_options=client_options)
+    logging.info('Using regional endpoint: {endpoint}'.format(endpoint=endpoint))
+    
   body = {'name': model_name, 'regions': regions}
   parent = 'projects/{}'.format(project_id)
   try:
@@ -283,6 +308,9 @@ def deploy_model_for_aip_prediction(
       'python_version': python_version,
       'labels': job_labels,
   }
+  # Add machine_type to body if regional endpoints.
+  if use_regional_endpoint:
+    body["machine_type"] = machine_type
 
   # Push to AIP, and record the operation name so we can poll for its state.
   model_name = 'projects/{}/models/{}'.format(project_id, model_name)

--- a/tfx/extensions/google_cloud_ai_platform/runner.py
+++ b/tfx/extensions/google_cloud_ai_platform/runner.py
@@ -257,36 +257,40 @@ def deploy_model_for_aip_prediction(
   model_name = ai_platform_serving_args['model_name']
   project_id = ai_platform_serving_args['project_id']
   regions = ai_platform_serving_args.get('regions', [])
-  use_regional_endpoint = ai_platform_serving_args.get('use_regional_endpoint',False)
-  machine_type = ai_platform_serving_args.get('machine_type','n1-standard-2')
+  use_regional_endpoint = ai_platform_serving_args.get(
+      'use_regional_endpoint', False)
+  machine_type = ai_platform_serving_args.get('machine_type', 'n1-standard-2')
   default_runtime_version = _get_tf_runtime_version(tf.__version__)
   runtime_version = ai_platform_serving_args.get('runtime_version',
                                                  default_runtime_version)
   python_version = _get_caip_python_version(runtime_version)
   
   api = discovery.build('ml', 'v1')
-  
-  # Insure regions was passed as a list and not a string. The API passes a list of str
+  # Insure regions was passed as a list and not a string.
+  # The API passes a list of str
   if isinstance(regions, str):
     if ',' in regions:
-      regions = regions.replace(" ","").split(',')
+      regions = regions.replace(" ", "").split(',')
     else:
       regions = [regions]
-  
+
   # Support regional endpoints in order to support VPC Service Controls
   if use_regional_endpoint:
     if len(regions) == 0:
-      logging.warning('Regional endpoints requires a region to be specified. Defaulting to us-central1.')
+      logging.warning('Regional endpoints requires a region to be specified.\
+        Defaulting to us-central1.')
       regions = ["us-central1"]
     if len(regions) > 1:
       # Regional endpoints requries requests to go to a specific endpoint
-      logging.warning('More than one specified region not supported with regional endpoints. Using first region in regions list.')
+      logging.warning('More than one specified region not supported with \
+        regional endpoints. Using first region in regions list.')
 
     endpoint = 'https://{region}-ml.googleapis.com'.format(region=regions[0])
     client_options = ClientOptions(api_endpoint=endpoint)
     api = discovery.build('ml', 'v1', client_options=client_options)
-    logging.info('Using regional endpoint: {endpoint}'.format(endpoint=endpoint))
-    
+    logging.info('Using regional endpoint: {endpoint}'
+                 .format(endpoint=endpoint))
+
   body = {'name': model_name, 'regions': regions}
   parent = 'projects/{}'.format(project_id)
   try:

--- a/tfx/extensions/google_cloud_ai_platform/runner_test.py
+++ b/tfx/extensions/google_cloud_ai_platform/runner_test.py
@@ -297,11 +297,11 @@ class RunnerTest(tf.test.TestCase):
         expected_models_create_body=expected_models_create_body)
 
   @mock.patch('tfx.extensions.google_cloud_ai_platform.runner.discovery')
-  def testDeployModelForAIPPredictionWithCustomRegionsList(self, mock_discovery):
+  def testDeployModelForAIPPWithCustomRegionsList(self, mock_discovery):
     mock_discovery.build.return_value = self._mock_api_client
     self._setUpPredictionMocks()
 
-    self._ai_platform_serving_args['regions'] = ['custom-region','other-custom-region']
+    self._ai_platform_serving_args['regions'] = ['custom-region', 'other-reg']
     runner.deploy_model_for_aip_prediction(self._serving_path,
                                            self._model_version,
                                            self._ai_platform_serving_args,
@@ -309,17 +309,17 @@ class RunnerTest(tf.test.TestCase):
 
     expected_models_create_body = {
         'name': self._model_name,
-        'regions': ['custom-region','other-custom-region'],
+        'regions': ['custom-region','other-reg'],
     }
     self._assertDeployModelMockCalls(
         expected_models_create_body=expected_models_create_body)
 
   @mock.patch('tfx.extensions.google_cloud_ai_platform.runner.discovery')
-  def testDeployModelForAIPPredictionWithCustomRegionsString(self, mock_discovery):
+  def testDeployModelForAIPPWithCustomRegionsString(self, mock_discovery):
     mock_discovery.build.return_value = self._mock_api_client
     self._setUpPredictionMocks()
 
-    self._ai_platform_serving_args['regions'] = "custom-region, other-custom-region"
+    self._ai_platform_serving_args['regions'] = "custom-region, other-region"
     runner.deploy_model_for_aip_prediction(self._serving_path,
                                            self._model_version,
                                            self._ai_platform_serving_args,
@@ -327,7 +327,7 @@ class RunnerTest(tf.test.TestCase):
 
     expected_models_create_body = {
         'name': self._model_name,
-        'regions': ['custom-region','other-custom-region'],
+        'regions': ['custom-region', 'other-region'],
     }
     self._assertDeployModelMockCalls(
         expected_models_create_body=expected_models_create_body)
@@ -358,10 +358,10 @@ class RunnerTest(tf.test.TestCase):
         expected_versions_create_body=expected_versions_create_body)
 
   @mock.patch('tfx.extensions.google_cloud_ai_platform.runner.discovery')
-  def testDeployModelForAIPPredictionWithRegionalEndpoint(self, mock_discovery):
+  def testDeployModelForAIPPWithRegionalEndpoint(self, mock_discovery):
     mock_discovery.build.return_value = self._mock_api_client
     self._setUpPredictionMocks()
-    
+
     self._ai_platform_serving_args['runtime_version'] = '1.23.45'
     self._ai_platform_serving_args['use_regional_endpoint'] = True
     self._ai_platform_serving_args['machine_type'] = 'foo-machine'
@@ -373,12 +373,11 @@ class RunnerTest(tf.test.TestCase):
     with telemetry_utils.scoped_labels(
         {telemetry_utils.LABEL_TFX_EXECUTOR: self._executor_class_path}):
       labels = telemetry_utils.get_labels_dict()
-    
+
     expected_models_create_body = {
         'name': self._model_name,
         'regions': ['foo-region'],
     }
-    
     expected_versions_create_body = {
         'name': self._model_version,
         'deployment_uri': self._serving_path,
@@ -392,10 +391,10 @@ class RunnerTest(tf.test.TestCase):
         expected_models_create_body=expected_models_create_body)
 
   @mock.patch('tfx.extensions.google_cloud_ai_platform.runner.discovery')
-  def testDeployModelForAIPPredictionWithRegionalEndpointDefaults(self, mock_discovery):
+  def testDeployModelForAIPPWithRegionalEndpointDefaults(self, mock_discovery):
     mock_discovery.build.return_value = self._mock_api_client
     self._setUpPredictionMocks()
-    
+
     self._ai_platform_serving_args['runtime_version'] = '1.23.45'
     self._ai_platform_serving_args['use_regional_endpoint'] = True
     runner.deploy_model_for_aip_prediction(self._serving_path,
@@ -405,12 +404,11 @@ class RunnerTest(tf.test.TestCase):
     with telemetry_utils.scoped_labels(
         {telemetry_utils.LABEL_TFX_EXECUTOR: self._executor_class_path}):
       labels = telemetry_utils.get_labels_dict()
-    
+
     expected_models_create_body = {
         'name': self._model_name,
         'regions': ['us-central1'],
     }
-    
     expected_versions_create_body = {
         'name': self._model_version,
         'deployment_uri': self._serving_path,


### PR DESCRIPTION
ml.googleapis.com global endpoint does not support VPC Service Controls for CAIP Prediction but is currently the only way the models are deployed. Regional endpoints _does_ support VPC Service Controls, so this PR establish a way for users to choose one or the other. 

- Created a **use_regional_endpoint** parameter to toggle different endpoint paths (global vs regional). Global remains the default. 
- Added additional required parameter **machine_type** with a useful default for regional endpoints as outlined in the [regional endpoint docs](https://cloud.google.com/ai-platform/prediction/docs/regional-endpoints). I thought about making this a parameter that could be used for global deployments as well however I wanted to keep the scope of this change focused on regional endpoints for now. 
- Added a little more checking on **regions** parameter 