### PR TITLE
Support for multiple artifact input for Tuner component

### DIFF
--- a/tfx/components/tuner/executor_test.py
+++ b/tfx/components/tuner/executor_test.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import copy
 import json
 import os
 from kerastuner import HyperParameters
@@ -48,14 +49,20 @@ class ExecutorTest(tf.test.TestCase):
         tmp_dir=self._output_data_dir, unique_id='1')
 
     # Create input dict.
-    examples = standard_artifacts.Examples()
-    examples.uri = os.path.join(self._testdata_dir, 'iris', 'data')
-    examples.split_names = artifact_utils.encode_split_names(['train', 'eval'])
+    e1 = standard_artifacts.Examples()
+    e1.uri = os.path.join(self._testdata_dir, 'iris', 'data')
+    e1.split_names = artifact_utils.encode_split_names(['train', 'eval'])
+
+    e2 = copy.deepcopy(e1)
+
+    self._single_artifact = [e1]
+    self._multiple_artifacts = [e1, e2]
+
     schema = standard_artifacts.Schema()
     schema.uri = os.path.join(self._testdata_dir, 'iris', 'schema')
 
     self._input_dict = {
-        'examples': [examples],
+        'examples': self._single_artifact,
         'schema': [schema],
     }
 
@@ -160,6 +167,19 @@ class ExecutorTest(tf.test.TestCase):
 
     self._verify_output()
 
+  def testMultipleArtifacts(self):
+    self._input_dict['examples'] = self._multiple_artifacts
+    self._exec_properties['module_file'] = os.path.join(self._testdata_dir,
+                                                        'module_file',
+                                                        'tuner_module.py')
+
+    tuner = executor.Executor(self._context)
+    tuner.Do(
+        input_dict=self._input_dict,
+        output_dict=self._output_dict,
+        exec_properties=self._exec_properties)
+
+    self._verify_output()
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
Recently, support for multiple artifact input for Trainer component was merged, and since Tuner shares the same `get_common_fn_args()` as used in Trainer, Tuner also now has support for multiple artifact input. This CL contains a test to verify that Tuner supports multiple artifact input.