### PR TITLE
Modified ExampleGen and StatisticsGen executors to implement FuseableBeamExecutor class

### DIFF
--- a/tfx/components/base/base_executor.py
+++ b/tfx/components/base/base_executor.py
@@ -163,13 +163,33 @@ class EmptyExecutor(BaseExecutor):
 
 
 class BeamExecutor(BaseExecutor):
-  """ TFX executor class for handling Beam-related logic."""
+  """ Abstract TFX executor class for handling Beam-related logic."""
 
   @abc.abstractmethod
   def beam_io_signature(self, input_dict: Dict[Text, List[types.Artifact]],
                         output_dict: Dict[Text, List[types.Artifact]],
                         exec_properties: Dict[Text, Any]
                         ) -> List[Dict[Text, Any]]:
+    """Provides input and output signatures for the input_dict and output_dict
+       of the underlying component.
+
+    Args:
+      input_dict: Input dict from input key to a list of Artifacts. These are
+        often outputs of another component in the pipeline and passed to the
+        component by the orchestration system.
+      output_dict: Output dict from output key to a list of Artifacts. These are
+        often consumed by a dependent component.
+      exec_properties: A dict of execution properties. These are inputs to
+        pipeline with primitive types (int, string, float) and fully
+        materialized when a pipeline is constructed. No dependency to other
+        component or later injection from orchestration systems is necessary or
+        possible on these values.
+
+    Returns:
+      A first dict from input artifact name/split key to the return type of
+      reading the inputs. A second dict from output artifact name/split key to
+      the return type of executing underlying component logic.
+    """
     pass
 
   @abc.abstractmethod
@@ -178,6 +198,24 @@ class BeamExecutor(BaseExecutor):
                   output_dict: Dict[Text, List[types.Artifact]],
                   exec_properties: Dict[Text, Any]
                   ) -> Dict[Text, beam.pvalue.PCollection]:
+    """Executes reads for underlying component implementation.
+
+    Args:
+      input_dict: Input dict from input key to a list of Artifacts. These are
+        often outputs of another component in the pipeline and passed to the
+        component by the orchestration system.
+      output_dict: Output dict from output key to a list of Artifacts. These are
+        often consumed by a dependent component.
+      exec_properties: A dict of execution properties. These are inputs to
+        pipeline with primitive types (int, string, float) and fully
+        materialized when a pipeline is constructed. No dependency to other
+        component or later injection from orchestration systems is necessary or
+        possible on these values.
+
+    Returns:
+      A dict from input artifact name/split key to PCollections from reads for
+      underlying component execution logic.
+    """
     pass
 
   @abc.abstractmethod
@@ -187,6 +225,26 @@ class BeamExecutor(BaseExecutor):
                            output_dict: Dict[Text, List[types.Artifact]],
                            exec_properties: Dict[Text, Any]
                            ) -> Dict[Text, beam.pvalue.PCollection]:
+    """Executes underlying component implementation, except for reads/writes.
+
+    Args:
+      beam_inputs: A Beam input dict from input key to PCollections. Output
+        of self.read_inputs().
+      input_dict: Input dict from input key to a list of Artifacts. These are
+        often outputs of another component in the pipeline and passed to the
+        component by the orchestration system.
+      output_dict: Output dict from output key to a list of Artifacts. These are
+        often consumed by a dependent component.
+      exec_properties: A dict of execution properties. These are inputs to
+        pipeline with primitive types (int, string, float) and fully
+        materialized when a pipeline is constructed. No dependency to other
+        component or later injection from orchestration systems is necessary or
+        possible on these values.
+
+    Returns:
+      A dict from output artifact name/split key to PCollections from underlying
+      component execution logic (not including reads/writes).
+    """
     pass
 
   @abc.abstractmethod
@@ -195,4 +253,23 @@ class BeamExecutor(BaseExecutor):
                     input_dict: Dict[Text, List[types.Artifact]],
                     output_dict: Dict[Text, List[types.Artifact]],
                     exec_properties: Dict[Text, Any]) -> None:
+    """Executes writes for underlying component implementation.
+
+    Args:
+      beam_outputs: A Beam output dict from input key to PCollections. Output
+        of self.construct_beam_graph().
+      input_dict: Input dict from input key to a list of Artifacts. These are
+        often outputs of another component in the pipeline and passed to the
+        component by the orchestration system.
+      output_dict: Output dict from output key to a list of Artifacts. These are
+        often consumed by a dependent component.
+      exec_properties: A dict of execution properties. These are inputs to
+        pipeline with primitive types (int, string, float) and fully
+        materialized when a pipeline is constructed. No dependency to other
+        component or later injection from orchestration systems is necessary or
+        possible on these values.
+
+    Returns:
+      None
+    """
     pass

--- a/tfx/components/base/base_executor.py
+++ b/tfx/components/base/base_executor.py
@@ -160,3 +160,39 @@ class EmptyExecutor(BaseExecutor):
          output_dict: Dict[Text, List[types.Artifact]],
          exec_properties: Dict[Text, Any]) -> None:
     pass
+
+
+class BeamExecutor(BaseExecutor):
+  """ TFX executor class for handling Beam-related logic."""
+
+  @abc.abstractmethod
+  def beam_io_signature(self, input_dict: Dict[Text, List[types.Artifact]],
+                        output_dict: Dict[Text, List[types.Artifact]],
+                        exec_properties: Dict[Text, Any]
+                        ) -> List[Dict[Text, Any]]:
+    pass
+
+  @abc.abstractmethod
+  def read_inputs(self, pipeline: beam.Pipeline,
+                  input_dict: Dict[Text, List[types.Artifact]],
+                  output_dict: Dict[Text, List[types.Artifact]],
+                  exec_properties: Dict[Text, Any]
+                  ) -> Dict[Text, beam.pvalue.PCollection]:
+    pass
+
+  @abc.abstractmethod
+  def construct_beam_graph(self, pipeline: beam.Pipeline,
+                           beam_inputs: Dict[Text, beam.pvalue.PCollection],
+                           input_dict: Dict[Text, List[types.Artifact]],
+                           output_dict: Dict[Text, List[types.Artifact]],
+                           exec_properties: Dict[Text, Any]
+                           ) -> Dict[Text, beam.pvalue.PCollection]:
+    pass
+
+  @abc.abstractmethod
+  def write_outputs(self, pipeline: beam.Pipeline,
+                    beam_outputs: Dict[Text, beam.pvalue.PCollection],
+                    input_dict: Dict[Text, List[types.Artifact]],
+                    output_dict: Dict[Text, List[types.Artifact]],
+                    exec_properties: Dict[Text, Any]) -> None:
+    pass

--- a/tfx/components/base/base_executor_test.py
+++ b/tfx/components/base/base_executor_test.py
@@ -18,14 +18,21 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+import io
 from typing import Any, Dict, List, Text
 
+import apache_beam as beam
 from apache_beam.options.pipeline_options import DirectOptions
 from apache_beam.options.pipeline_options import StandardOptions
 import tensorflow as tf
 
 from tfx import types
 from tfx.components.base import base_executor
+
+_EXAMPLES = 'examples'
+_SHUFFLED_EXAMPLES = 'shuffled_examples'
+_NUM_LINES = 1000
 
 
 class _TestExecutor(base_executor.BaseExecutor):
@@ -37,21 +44,130 @@ class _TestExecutor(base_executor.BaseExecutor):
     pass
 
 
+class _BeamTestExecutor(base_executor.BeamExecutor):
+  """Fake BeamExecutor for testing purpose only."""
+
+  def beam_io_signature(self, input_dict: Dict[Text, List[types.Artifact]],
+                        output_dict: Dict[Text, List[types.Artifact]],
+                        exec_properties: Dict[Text, Any]
+                        ) -> List[Dict[Text, Any]]:
+    input_signature = {_EXAMPLES: io.TextIOBase}
+    output_signature = {_SHUFFLED_EXAMPLES: io.TextIOBase}
+    return input_signature, output_signature
+
+  def read_inputs(self, pipeline: beam.Pipeline,
+                  input_dict: Dict[Text, List[types.Artifact]],
+                  output_dict: Dict[Text, List[types.Artifact]],
+                  exec_properties: Dict[Text, Any]
+                  ) -> Dict[Text, beam.pvalue.PCollection]:
+    input_dir = input_dict[_EXAMPLES].uri
+    beam_inputs = ({_EXAMPLES: (pipeline
+                                | beam.io.textio.ReadFromText(input_dir))})
+    return beam_inputs
+
+  def construct_beam_graph(self, pipeline: beam.Pipeline,
+                           beam_inputs: Dict[Text, beam.pvalue.PCollection],
+                           input_dict: Dict[Text, List[types.Artifact]],
+                           output_dict: Dict[Text, List[types.Artifact]],
+                           exec_properties: Dict[Text, Any]
+                           ) -> Dict[Text, beam.pvalue.PCollection]:
+    beam_outputs = {_SHUFFLED_EXAMPLES: (beam_inputs[_EXAMPLES]
+                                         | beam.Map(str.strip)
+                                         | beam.Map(int)
+                                         | beam.CombineGlobally(sum))}
+    return beam_outputs
+
+  def write_outputs(self, pipeline: beam.Pipeline,
+                    beam_outputs: Dict[Text, beam.pvalue.PCollection],
+                    input_dict: Dict[Text, List[types.Artifact]],
+                    output_dict: Dict[Text, List[types.Artifact]],
+                    exec_properties: Dict[Text, Any]) -> None:
+    output_dir = output_dict[_SHUFFLED_EXAMPLES].uri
+    _ = (beam_outputs[_SHUFFLED_EXAMPLES]
+         | beam.io.textio.WriteToText(output_dir))
+
+  def Do(self, input_dict: Dict[Text, List[types.Artifact]],
+         output_dict: Dict[Text, List[types.Artifact]],
+         exec_properties: Dict[Text, Any]) -> None:
+    with beam.Pipeline(runner=beam.runners.create_runner('DirectRunner')) as p:
+      beam_inputs = self.read_inputs(p, input_dict, output_dict,
+                                     exec_properties)
+      beam_outputs = self.construct_beam_graph(p, beam_inputs, input_dict,
+                                               output_dict, exec_properties)
+      self.write_outputs(p, beam_outputs, input_dict, output_dict,
+                         exec_properties)
+
 class BaseExecutorTest(tf.test.TestCase):
 
   def testBeamSettings(self):
     executor_context = base_executor.BaseExecutor.Context(
         beam_pipeline_args=['--runner=DirectRunner'])
     executor = _TestExecutor(executor_context)
-    options = executor._make_beam_pipeline().options.view_as(StandardOptions)
+    options = executor._make_beam_pipeline().options.view_as(StandardOptions) # pylint: disable=protected-access
     self.assertEqual('DirectRunner', options.runner)
 
     executor_context = base_executor.BaseExecutor.Context(
         beam_pipeline_args=['--direct_num_workers=2'])
     executor = _TestExecutor(executor_context)
-    options = executor._make_beam_pipeline().options.view_as(DirectOptions)
+    options = executor._make_beam_pipeline().options.view_as(DirectOptions) # pylint: disable=protected-access
     self.assertEqual(2, options.direct_num_workers)
 
+
+class BeamExecutorTest(tf.test.TestCase):
+
+  def setUp(self):
+    super(BeamExecutorTest, self).setUp()
+    self._input_data_path = (
+        os.path.join(os.environ.get(
+            'TEST_UNDECLARED_OUTPUTS_DIR', self.get_temp_dir()), 'input.txt'))
+    output_data_path = (
+        os.path.join(os.environ.get('TEST_UNDECLARED_OUTPUTS_DIR',
+                                    self.get_temp_dir()), 'output.txt'))
+    self._full_output_data_path = output_data_path + '-00000-of-00001'
+
+    self._generate_data(self._input_data_path)
+
+    # Create input dict
+    examples = types.standard_artifacts.Examples()
+    examples.uri = self._input_data_path
+    self._input_dict = {_EXAMPLES: examples}
+
+    # Create output dict
+    shuffled_examples = types.standard_artifacts.Examples()
+    shuffled_examples.uri = output_data_path
+    self._output_dict = {_SHUFFLED_EXAMPLES: shuffled_examples}
+
+    # Run Do() method
+    beam_test_executor = _BeamTestExecutor()
+    beam_test_executor.Do(self._input_dict, self._output_dict, {})
+
+  def _generate_data(self, file_path):
+    with open(file_path, "w+") as f:
+      for i in range(_NUM_LINES):
+        line = str(i) + '\n'
+        f.write(line)
+
+  def testBeamExecutorBeamIoSignature(self):
+    beam_test_executor = _BeamTestExecutor()
+    input_signature, output_signature = (
+        beam_test_executor.beam_io_signature(
+            self._input_dict, self._output_dict, {}))
+
+    with open(self._input_data_path) as f:
+      self.assertTrue(isinstance(f, input_signature[_EXAMPLES]))
+
+    with open(self._full_output_data_path) as f:
+      self.assertTrue(isinstance(f, output_signature[_SHUFFLED_EXAMPLES]))
+
+  def testBeamExecutorDo(self):
+    expected_sum = 0
+    for i in range(_NUM_LINES):
+      expected_sum += i
+
+    with open(self._full_output_data_path) as f:
+      actual_sum = int(f.read())
+
+    self.assertEqual(expected_sum, actual_sum)
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
This PR is for `tfx/components/statistics_gen/executor.py` and `tfx/components/example_gen/base_example_gen_executor.py`.  Please review these files.

This PR depends on [the PR](https://github.com/tensorflow/tfx/pull/2274) for `tfx/components/base/base_executor.py` and `tfx/components/base/base_executor_test.py`.  Please reference the dependent PR as needed for changes in those files. 