### PR TITLE
Update Metadata gRPC env in default kubeflow metadata config

### DIFF
--- a/tfx/orchestration/kubeflow/container_entrypoint_test.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint_test.py
@@ -61,13 +61,13 @@ class MLMDConfigTest(tf.test.TestCase):
 
   def testGrpcMetadataConnectionConfig(self):
     self._set_required_env_vars({
-        'METADATA_GRPC_SERVICE_HOST': 'metadata-grpc',
-        'METADATA_GRPC_SERVICE_PORT': '8080',
+        'METADATA_GRPC_SERVICE_SERVICE_HOST': 'metadata-grpc-service',
+        'METADATA_GRPC_SERVICE_SERVICE_PORT': '8080',
     })
 
     grpc_config = kubeflow_pb2.KubeflowGrpcMetadataConfig()
-    grpc_config.grpc_service_host.environment_variable = 'METADATA_GRPC_SERVICE_HOST'
-    grpc_config.grpc_service_port.environment_variable = 'METADATA_GRPC_SERVICE_PORT'
+    grpc_config.grpc_service_host.environment_variable = 'METADATA_GRPC_SERVICE_SERVICE_HOST'
+    grpc_config.grpc_service_port.environment_variable = 'METADATA_GRPC_SERVICE_SERVICE_PORT'
     metadata_config = kubeflow_pb2.KubeflowMetadataConfig()
     metadata_config.grpc_config.CopyFrom(grpc_config)
 
@@ -75,7 +75,7 @@ class MLMDConfigTest(tf.test.TestCase):
         metadata_config)
     self.assertIsInstance(ml_metadata_config,
                           metadata_store_pb2.MetadataStoreClientConfig)
-    self.assertEqual(ml_metadata_config.host, 'metadata-grpc')
+    self.assertEqual(ml_metadata_config.host, 'metadata-grpc-service')
     self.assertEqual(ml_metadata_config.port, 8080)
 
 

--- a/tfx/orchestration/kubeflow/kubeflow_dag_runner.py
+++ b/tfx/orchestration/kubeflow/kubeflow_dag_runner.py
@@ -139,10 +139,10 @@ def get_default_kubeflow_metadata_config(
   # The environment variable to use to obtain the Metadata gRPC service host in
   # the cluster that is backing Kubeflow Metadata. Note that the key in the
   # config map and therefore environment variable used, are lower-cased.
-  config.grpc_config.grpc_service_host.environment_variable = 'METADATA_GRPC_SERVICE_HOST'
+  config.grpc_config.grpc_service_host.environment_variable = 'METADATA_GRPC_SERVICE_SERVICE_HOST'
   # The environment variable to use to obtain the Metadata grpc service port in
   # the cluster that is backing Kubeflow Metadata.
-  config.grpc_config.grpc_service_port.environment_variable = 'METADATA_GRPC_SERVICE_PORT'
+  config.grpc_config.grpc_service_port.environment_variable = 'METADATA_GRPC_SERVICE_SERVICE_PORT'
 
   return config
 


### PR DESCRIPTION
Kubernetes by default inject service host and port as environment variables into pod container. 

```
$ kubectl get svc                                      
NAME                                                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                               AGE
metadata-envoy-service                              ClusterIP   10.100.80.21     <none>        9090/TCP                              4d18h
metadata-grpc-service                               ClusterIP   10.100.30.11     <none>        8080/TCP                              4d18h
```

The naming convention is  
-`SERVICE_NAME` + `_SERVICE_HOST` 
-`SERVICE_NAME` + `_SERVICE_PORT`

In this case, it should be `METADATA_GRPC_SERVICE_SERVICE_HOST ` and `METADATA_GRPC_SERVICE_SERVICE_PORT `

User can override this for sure. I think it's better to make it consistent as kubeflow setup. `get_default_kubeflow_metadata_config ()` will help populate the right environment.

Upstream manifest:
- Kubeflow https://github.com/kubeflow/manifests/blob/master/pipeline/upstream/base/metadata/metadata-grpc-service.yaml#L6
- Kubeflow Pipeline Standalone https://github.com/kubeflow/pipelines/blob/514120167e2e255d6c35cb564fd57ee75b452f56/manifests/kustomize/base/metadata/metadata-grpc-service.yaml#L6


