### PR TITLE
Add AWS SDK boto3 in Dockerfile

### DIFF
--- a/tfx/tools/docker/Dockerfile
+++ b/tfx/tools/docker/Dockerfile
@@ -27,7 +27,8 @@ RUN CFLAGS=$(/usr/bin/python-config --cflags) python -m pip install \
   "tensorflow>=1.15,<3" \
   "tensorflow-serving-api>=1.15,<3" \
   "google-api-python-client==1.8.0" \
-  "google-apitools==0.5.30"
+  "google-apitools==0.5.30" \
+  "boto3>=1.14.0"
 
 # docker build command should be run under root directory of github checkout.
 ENV TFX_SRC_DIR=/tfx-src


### PR DESCRIPTION
This PR helps users to leverage existing prebuilt TFX images to use S3. 

Errors with existing images: 
```
INFO:absl:Running driver for CsvExampleGen
INFO:absl:MetadataStore with gRPC connection initialized
INFO:absl:select span = None
INFO:absl:Adding KFP pod name parameterized-tfx-oss-jssk7-1105165278 to execution
INFO:absl:Adding KFP pod name parameterized-tfx-oss-jssk7-1105165278 to execution
INFO:absl:Running executor for CsvExampleGen
INFO:absl:Generating examples.
INFO:absl:Using 1 process(es) for Beam pipeline execution.
INFO:absl:Processing input csv data s3://xx-kubeflow-pipeline-data/taxi/pipeline/chicago_taxi_pipeline/data/* to TFExample.
Traceback (most recent call last):
    File "/tfx-src/tfx/orchestration/kubeflow/container_entrypoint.py", line 360, in <module>
       main()
    .....
 
    File "/opt/venv/lib/python3.6/site-packages/apache_beam/io/filesystems.py", line 204, in match
       return filesystem.match(patterns, limits)
    File "/opt/venv/lib/python3.6/site-packages/apache_beam/io/filesystem.py", line 765, in match
       raise BeamIOError("Match operation failed", exceptions)
                apache_beam.io.filesystem.BeamIOError: Match operation failed with exceptions {'s3://xx-kubeflow-pipeline-data/taxi/pipeline/chicago_taxi_pipeline/data/*': BeamIOError("List operation failed with exceptions {'s3://xx-kubeflow-pipeline-data/taxi/pipeline/chicago_taxi_pipeline/data/': AssertionError('Missing boto3 requirement',)}",)}
```

S3 file system for Python SDK has been implemented in [BEAM-2572](https://issues.apache.org/jira/browse/BEAM-2572). It has been released in [Apache Beam 2.19.0](https://beam.apache.org/blog/beam-2.19.0/).  TFX master supports >2.19.0 beam. We can bring boto3 dependency to address `Missing boto3 requirement` problem. 

boto3 size is not big. Here's the image differences between w/ and w/o boto3. 

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
seedjeffwan/tfx     0.22.0              6268c0aa2bfe        10 seconds ago      5.75GB
tensorflow/tfx      0.22.0              e032e569bc69        8 weeks ago         5.69GB
```

