### PR TITLE
Adding SavedModel experiments for distributed inference

### DIFF
--- a/tfx/experimental/distributed_inference/savedmodel_experiments/beam_pipeline.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/beam_pipeline.py
@@ -1,0 +1,375 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Batch inference with Beam on partitioned subgraphs.
+
+There are two libraries representing two stages: graph_partition and
+beam_pipeline. After graph_partition produces lists of SavedModel directory
+paths that refers to the partitioned subgraphs, beam_pipeline constructs a
+Beam pipeline that executes the partitioned subgraphs. The results from the
+Beam pipeline should be the same as the results from the original model.
+
+  Typical usage example:
+  ```
+  # Obtained graph_name_to_partitioned_paths from the graph partition
+  remote_op_name_to_graph_name = {
+      remote_op_name: graph_name
+  }
+  graph_to_remote_op_input_name_mapping = {
+      graph_name:
+          {remote_op_name:
+              {remote_graph_placeholder_name: parent_graph_input_name}
+          }
+  }
+
+  with beam.Pipeline() as p:
+    # Get the input_pcoll
+    output_pcoll = input_pcoll | beam_pipeline.ExecuteOneGraph(
+        remote_op_name,
+        remote_op_name_to_graph_name,
+        graph_name_to_partitioned_paths,
+        graph_to_remote_op_input_name_mapping)
+    # Extract the outputs and store them somewhere.
+  ```
+"""
+
+import copy
+import os
+from typing import Any, Dict, Iterator, List, Mapping, Text
+import apache_beam as beam
+import tensorflow as tf
+
+
+@beam.ptransform_fn
+@beam.typehints.with_input_types(Dict[Text, Dict[Text, Any]])
+@beam.typehints.with_output_types(Dict[Text, Dict[Text, Any]])
+def ExecuteGraph(  # pylint: disable=invalid-name
+    pcoll: beam.pvalue.PCollection, remote_op_name: Text,
+    remote_op_name_to_graph_name: Mapping[Text, Text],
+    graph_name_to_partitioned_paths: Mapping[Text, List[Text]],
+    graph_to_remote_op_input_name_mapping: Mapping[Text, Mapping[Text,
+                                                                 Mapping[Text,
+                                                                         Text]]]
+) -> beam.pvalue.PCollection:
+  """A PTransform that executes a graph.
+
+  Each graph has a list of SavedModel directory paths, in which the order of
+  the list represents the order of execution. A SavedModel can either represent
+  a subgraph layer or a remote op in a remote op layer. When executing a
+  subgraph layer, we can load and execute the subgraph with a beam ParDo.
+  When executing a remote op (which represents another graph), we need to
+  load the remote graph inputs, call ExecuteGraph to recursively execute that
+  graph, and extract the remote graph output. When executing a remote op, we
+  call the current graph "parent" and the remote graph "child".
+
+  Here, each Beam element is a dictionary from remote op names to a dictionary
+  from tensor names to values, or {remote op name: {tensor name: value}}.
+  Note that at any time, PColl only stores input tensor values and computed
+  tensor values. The input PColl should have the input tensor names and values
+  for the graph ready. As we execute the partitioned subgraphs, we add the
+  intermediate output names and values to PColl.
+
+  Args:
+    pcoll: A PCollection of inputs to the graph. Each element is a dictionary
+           from remote op names to a dictionary from tensor names to values.
+           Here, element[remote_op_name] contains graph inputs.
+    remote_op_name: The remote op name of the current graph.
+    remote_op_name_to_graph_name:
+      A mapping from remote op names to graph names.
+    graph_name_to_partitioned_paths:
+      A mapping from graph names to a list of SavedModel directory paths, where
+      the order of the list represents the order of execution.
+    graph_to_remote_op_input_name_mapping:
+      A mapping from graph names to remote op names to remote graph placeholder
+      names to parent graph input names. We don't have this information since
+      it was stored in PyFunc's function.
+      {graph name: {remote op name: {placeholder name: input name}}}.
+
+  Returns:
+    A PCollection of results of this graph. Each element is a dictionary from
+    remote op names to a dictionary from tensor names to values. Here,
+    element[remote_op_name] stores graph inputs, intermediate results, and
+    graph outputs.
+  """
+  graph_name = remote_op_name_to_graph_name[remote_op_name]
+  paths = graph_name_to_partitioned_paths[graph_name]
+
+  for path in paths:
+    saved_model = _get_saved_model(path)
+    output_node_names = _get_output_node_names(saved_model)
+
+    # Construct Beam subgraph for a subgraph layer.
+    if not output_node_names[0] in remote_op_name_to_graph_name:
+      step_name = ("SubgraphLayerDoFn[Graph_%s][Outputs_%s]" %
+                   (remote_op_name, '_'.join(output_node_names)))
+      pcoll = pcoll | step_name >> beam.ParDo(_SubgraphLayerDoFn(), path,
+                                              remote_op_name)
+
+    # Construct Beam subgraph for a remote op.
+    else:
+      # ExecutionSpec stores one remote op.
+      child_remote_op_name = output_node_names[0]
+      step_descriptor = ("[Parent_%s][Child_%s]" %
+                         (remote_op_name, child_remote_op_name))
+
+      step_name = "LoadRemoteGraphInputs%s" % step_descriptor
+      pcoll = pcoll | step_name >> _LoadRemoteGraphInputs(  # pylint: disable=no-value-for-parameter
+          remote_op_name, child_remote_op_name, remote_op_name_to_graph_name,
+          graph_to_remote_op_input_name_mapping)
+
+      # A good place to add beam.Reshuffle() to prevent fusion.
+      step_name = "ExecuteGraph%s" % step_descriptor
+      pcoll = pcoll | step_name >> ExecuteGraph(  # pylint: disable=no-value-for-parameter
+          child_remote_op_name, remote_op_name_to_graph_name,
+          graph_name_to_partitioned_paths,
+          graph_to_remote_op_input_name_mapping)
+
+      step_name = "ExtractRemoteGraphOutput%s" % step_descriptor
+      pcoll = pcoll | step_name >> _ExtractRemoteGraphOutput(  # pylint: disable=no-value-for-parameter
+          remote_op_name, child_remote_op_name, remote_op_name_to_graph_name,
+          graph_name_to_partitioned_paths)
+
+  return pcoll
+
+
+def _get_saved_model(
+    directory_path: Text) -> tf.core.protobuf.saved_model_pb2.SavedModel:
+  saved_model = tf.core.protobuf.saved_model_pb2.SavedModel()
+  file_path = os.path.join(directory_path, 'saved_model.pb')
+  with tf.io.gfile.GFile(file_path, 'rb') as f:
+    saved_model.ParseFromString(f.read())
+  return saved_model
+
+
+def _get_input_node_names(
+    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel) -> List[Text]:
+  signature_def = saved_model.meta_graphs[0].signature_def['serving_default']
+  inputs = signature_def.inputs
+  # Node names are the keys for input signatures of the partitioned subgraphs.
+  input_node_names = list(dict(inputs).keys())
+  return input_node_names
+
+
+def _get_output_node_names(
+    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel) -> List[Text]:
+  signature_def = saved_model.meta_graphs[0].signature_def['serving_default']
+  outputs = signature_def.outputs
+  # Node names are the keys for output signatures of the partitioned subgraphs.
+  output_node_names = list(dict(outputs).keys())
+  return output_node_names
+
+
+class _SubgraphLayerDoFn(beam.DoFn):
+  """DoFn that executes one subgraph layer."""
+
+  def process(
+      self,
+      # Not using mapping here because it doesn't support item assignment.
+      element: Dict[Text, Dict[Text, Any]],
+      path: Text,
+      remote_op_name: Text) -> Iterator[Dict[Text, Dict[Text, Any]]]:
+    """Executes a subgraph layer.
+
+    To execute a subgraph layer, we need to prepare a feed_dict by extracting
+    tensor values from element. Then, we run the subgraph and store its outputs
+    to a copy of element.
+
+    Since we load SavedModels, all the node names now have the prefix
+    "import/". Also, TensorFlow feed_dict and outputs accept tensor
+    names instead of node names. Hence, a conversion from node_name to
+    "import/node_name:0" is necessary. Note that this conversion assumes
+    that there is one output per node.
+
+    Args:
+      element: A dictionary from remote op names to a dictionary from tensor
+               names to values. Element[remote_op_name] stores graph inputs
+               and previous specs' outputs.
+      path: A SavedModel directory path refering to a partitioned subgraph.
+            Here, the SavedModel represents a subgraph layer.
+      remote_op_name: The remote op name of the current graph.
+
+    Returns:
+      A dictionary from remote op names to a dictionary from tensor names to
+      values. The dictionary is a copy of the input element, to which the
+      outputs of this subgraph layer have been added.
+    """
+    element = copy.deepcopy(element)
+    saved_model = _get_saved_model(path)
+    input_node_names = _get_input_node_names(saved_model)
+    output_node_names = _get_output_node_names(saved_model)
+
+    input_tensor_names = [
+        _import_tensor_name(node_name) for node_name in input_node_names
+    ]
+    output_tensor_names = [
+        _import_tensor_name(node_name) for node_name in output_node_names
+    ]
+    feed_dict = {
+        tensor_name: element[remote_op_name][tensor_name]
+        for tensor_name in input_tensor_names
+    }
+
+    outputs = []
+    with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+      tf.compat.v1.saved_model.load(
+          sess, [tf.compat.v1.saved_model.tag_constants.SERVING], path)
+      outputs = sess.run(output_tensor_names, feed_dict=feed_dict)
+
+    for output_tensor_name, output_tensor in zip(output_tensor_names, outputs):
+      element[remote_op_name][output_tensor_name] = output_tensor
+
+    yield element
+
+
+def _import_tensor_name(
+    node_name: Text) -> Text:
+  return 'import/%s:0' % node_name
+
+
+@beam.ptransform_fn
+@beam.typehints.with_input_types(Dict[Text, Dict[Text, Any]])
+@beam.typehints.with_output_types(Dict[Text, Dict[Text, Any]])
+def _LoadRemoteGraphInputs(  # pylint: disable=invalid-name
+    pcoll: beam.pvalue.PCollection, parent_remote_op_name: Text,
+    child_remote_op_name: Text, remote_op_name_to_graph_name: Mapping[Text,
+                                                                      Text],
+    graph_to_remote_op_input_name_mapping: Mapping[Text, Mapping[Text,
+                                                                 Mapping[Text,
+                                                                         Text]]]
+) -> beam.pvalue.PCollection:
+  """A PTransform that prepares inputs for a remote graph.
+
+  Before executing a remote graph, we need to prepare its inputs. We first
+  get the mapping from remote graph placeholder names to parent graph input
+  names. Then, in a copy of element, we copy the inputs from the parent
+  graph's key to the remote graph's key.
+
+  Args:
+    pcoll: A PCollection of child graph inputs not loaded yet. Each element is
+           a dictionary from remote op names to a dictionary from tensor names
+           to values. Here, element[child_remote_op_name] is empty now.
+    parent_remote_op_name: The remote op name of the parent graph.
+    child_remote_op_name: The remote op name of the child graph.
+    remote_op_name_to_graph_name:
+      A mapping from remote op names to graph names.
+    graph_to_remote_op_input_name_mapping:
+      A mapping from graph names to remote op names to remote graph placeholder
+      names to parent graph input names.
+      {graph name: {remote op name: {placeholder name: input name}}}.
+
+  Returns:
+    A PCollection of inputs to the child graph. Each element is a dictionary
+    from remote op names to a dictionary from tensor names to values. Here,
+    element[child_remote_op_name] stores the inputs of child graph.
+  """
+  parent_graph_name = remote_op_name_to_graph_name[parent_remote_op_name]
+  name_mapping = (
+      graph_to_remote_op_input_name_mapping[parent_graph_name]
+      [child_remote_op_name])
+
+  mapping = name_mapping.items()
+  # Calling _copy_tensor_value multiple times may introduce a burden, since
+  # _copy_tensor_value invokes a deepcopy on element.
+  for child_graph_placeholder_name, parent_graph_input_name in mapping:
+
+    step_name = ("PrepareInput[Graph_%s][Input_%s]" %
+                 (child_remote_op_name, child_graph_placeholder_name))
+    pcoll = pcoll | step_name >> beam.Map(
+        _copy_tensor_value,
+        parent_remote_op_name,
+        _import_tensor_name(parent_graph_input_name),
+        child_remote_op_name,
+        _import_tensor_name(child_graph_placeholder_name))
+
+  return pcoll
+
+
+def _copy_tensor_value(
+    element: Dict[Text, Dict[Text,
+                             Any]], old_graph: Text, old_tensor_name: Text,
+    new_graph: Text, new_tensor_name: Text) -> Dict[Text, Dict[Text, Any]]:
+  element = copy.deepcopy(element)
+  if new_graph not in element:
+    element[new_graph] = {}
+  element[new_graph][new_tensor_name] = element[old_graph][old_tensor_name]
+  return element
+
+
+@beam.ptransform_fn
+@beam.typehints.with_input_types(Dict[Text, Dict[Text, Any]])
+@beam.typehints.with_output_types(Dict[Text, Dict[Text, Any]])
+def _ExtractRemoteGraphOutput(  # pylint: disable=invalid-name
+    pcoll: beam.pvalue.PCollection,
+    parent_remote_op_name: Text,
+    child_remote_op_name: Text,
+    remote_op_name_to_graph_name: Mapping[Text, Text],
+    graph_name_to_partitioned_paths: Mapping[Text, List[Text]],
+) -> beam.pvalue.PCollection:
+  """A PTransform that extracts remote graph output.
+
+  After finish executing a remote graph, we need to collect its output.
+  We first find the output name of the remote graph, then we copy the
+  output of the remote graph to its parent graph. Finally, we clear the
+  intermediate results of the remote graph.
+
+  Note we assumed that each node has only one output, which also applies
+  to remote op. This means that a remote graph can only have one output.
+
+  Args:
+    pcoll: A PCollection of child graph results. Each element is a dictionary
+           from remote op names to a dictionary from tensor names to values.
+           Here, element[child_remote_op_name] stores graph inputs,
+           intermediate results, and graph output.
+    parent_remote_op_name: The remote op name of the parent graph.
+    child_remote_op_name: The remote op name of the child graph.
+    remote_op_name_to_graph_name:
+      A mapping from remote op names to graph names.
+    graph_name_to_partitioned_paths:
+      A mapping from graph names to a list of SavedModel directory paths.
+
+  Returns:
+    A PCollection of child graph output in parent graph. Each element is a
+    dictionary from remote op names to a dictionary from tensor names to
+    values. Here, element[parent_remote_op_name] contains the output from
+    the child graph, and element[child_remote_op_name] is deleted.
+  """
+  child_graph_name = remote_op_name_to_graph_name[child_remote_op_name]
+  child_paths = graph_name_to_partitioned_paths[child_graph_name]
+  last_saved_model = _get_saved_model(child_paths[-1])
+  # Since we assumed that nodes have only one output, a remote op (thus
+  # a remote graph) has only one output.
+  child_output_name = _get_output_node_names(last_saved_model)[0]
+
+  step_name_extract = ("ExtractOutput[Graph_%s][Output_%s]" %
+                       (child_remote_op_name, child_output_name))
+  step_name_clear = ("ClearIntermediateOutputs[Graph_%s]" %
+                     (child_remote_op_name))
+
+  return (pcoll
+          | step_name_extract >> beam.Map(
+              _copy_tensor_value,
+              child_remote_op_name,
+              _import_tensor_name(child_output_name),
+              parent_remote_op_name,
+              _import_tensor_name(child_remote_op_name))
+          | step_name_clear >> beam.Map(
+              _clear_outputs_for_finished_graph,
+              child_remote_op_name))
+
+
+def _clear_outputs_for_finished_graph(
+    element: Dict[Text, Dict[Text, Any]],
+    finished_graph: Text) -> Dict[Text, Dict[Text, Any]]:
+  element = copy.deepcopy(element)
+  del element[finished_graph]
+  return element

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/beam_pipeline.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/beam_pipeline.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Batch inference with Beam on partitioned subgraphs.
-
 There are two libraries representing two stages: graph_partition and
-beam_pipeline. After graph_partition produces lists of SavedModel directory
-paths that refers to the partitioned subgraphs, beam_pipeline constructs a
-Beam pipeline that executes the partitioned subgraphs. The results from the
-Beam pipeline should be the same as the results from the original model.
-
+beam_pipeline. After graph_partition produces lists of ExecutionSpecs that
+contain partitioned subgraphs, beam_pipeline constructs a Beam pipeline that
+executes the partitioned subgraphs. The results from the Beam pipeline should
+be the same as the results from the original model.
   Typical usage example:
   ```
-  # Obtained graph_name_to_partitioned_paths from the graph partition
+  # Obtained graph_name_to_specs from the graph partition
   remote_op_name_to_graph_name = {
       remote_op_name: graph_name
   }
@@ -31,23 +29,23 @@ Beam pipeline should be the same as the results from the original model.
               {remote_graph_placeholder_name: parent_graph_input_name}
           }
   }
-
   with beam.Pipeline() as p:
     # Get the input_pcoll
-    output_pcoll = input_pcoll | beam_pipeline.ExecuteOneGraph(
+    output = input_pcoll | beam_pipeline.ExecuteOneGraph(
         remote_op_name,
         remote_op_name_to_graph_name,
-        graph_name_to_partitioned_paths,
+        graph_name_to_specs,
         graph_to_remote_op_input_name_mapping)
     # Extract the outputs and store them somewhere.
   ```
 """
 
 import copy
-import os
 from typing import Any, Dict, Iterator, List, Mapping, Text
 import apache_beam as beam
 import tensorflow as tf
+
+from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import execution_spec
 
 
 @beam.ptransform_fn
@@ -56,69 +54,58 @@ import tensorflow as tf
 def ExecuteGraph(  # pylint: disable=invalid-name
     pcoll: beam.pvalue.PCollection, remote_op_name: Text,
     remote_op_name_to_graph_name: Mapping[Text, Text],
-    graph_name_to_partitioned_paths: Mapping[Text, List[Text]],
+    graph_name_to_specs: Mapping[Text, List[execution_spec.ExecutionSpec]],
     graph_to_remote_op_input_name_mapping: Mapping[Text, Mapping[Text,
                                                                  Mapping[Text,
                                                                          Text]]]
 ) -> beam.pvalue.PCollection:
   """A PTransform that executes a graph.
-
-  Each graph has a list of SavedModel directory paths, in which the order of
-  the list represents the order of execution. A SavedModel can either represent
+  Each graph has a list of ExecutionSpecs, in which the order of the list
+  represents the order of execution. An ExecutionSpec can either represent
   a subgraph layer or a remote op in a remote op layer. When executing a
   subgraph layer, we can load and execute the subgraph with a beam ParDo.
   When executing a remote op (which represents another graph), we need to
   load the remote graph inputs, call ExecuteGraph to recursively execute that
   graph, and extract the remote graph output. When executing a remote op, we
   call the current graph "parent" and the remote graph "child".
-
   Here, each Beam element is a dictionary from remote op names to a dictionary
   from tensor names to values, or {remote op name: {tensor name: value}}.
   Note that at any time, PColl only stores input tensor values and computed
   tensor values. The input PColl should have the input tensor names and values
   for the graph ready. As we execute the partitioned subgraphs, we add the
   intermediate output names and values to PColl.
-
   Args:
     pcoll: A PCollection of inputs to the graph. Each element is a dictionary
-           from remote op names to a dictionary from tensor names to values.
-           Here, element[remote_op_name] contains graph inputs.
+      from remote op names to a dictionary from tensor names to values. Here,
+      element[remote_op_name] contains graph inputs.
     remote_op_name: The remote op name of the current graph.
-    remote_op_name_to_graph_name:
-      A mapping from remote op names to graph names.
-    graph_name_to_partitioned_paths:
-      A mapping from graph names to a list of SavedModel directory paths, where
-      the order of the list represents the order of execution.
-    graph_to_remote_op_input_name_mapping:
-      A mapping from graph names to remote op names to remote graph placeholder
-      names to parent graph input names. We don't have this information since
-      it was stored in PyFunc's function.
+    remote_op_name_to_graph_name: A mapping from remote op names to graph names.
+    graph_name_to_specs: A mapping from graph names to a list of ExecutionSpecs,
+      where the order of the list represents the order of execution.
+    graph_to_remote_op_input_name_mapping: A mapping from graph names to remote
+      op names to remote graph placeholder names to parent graph input names. We
+      don't have this information since it was stored in PyFunc's function.
       {graph name: {remote op name: {placeholder name: input name}}}.
-
   Returns:
     A PCollection of results of this graph. Each element is a dictionary from
     remote op names to a dictionary from tensor names to values. Here,
     element[remote_op_name] stores graph inputs, intermediate results, and
     graph outputs.
   """
-  graph_name = remote_op_name_to_graph_name[remote_op_name]
-  paths = graph_name_to_partitioned_paths[graph_name]
+  specs = graph_name_to_specs[remote_op_name_to_graph_name[remote_op_name]]
 
-  for path in paths:
-    saved_model = _get_saved_model(path)
-    output_node_names = _get_output_node_names(saved_model)
-
+  for spec in specs:
     # Construct Beam subgraph for a subgraph layer.
-    if not output_node_names[0] in remote_op_name_to_graph_name:
+    if not spec.is_remote_op:
       step_name = ("SubgraphLayerDoFn[Graph_%s][Outputs_%s]" %
-                   (remote_op_name, '_'.join(output_node_names)))
-      pcoll = pcoll | step_name >> beam.ParDo(_SubgraphLayerDoFn(), path,
+                   (remote_op_name, "_".join(spec.output_names)))
+      pcoll = pcoll | step_name >> beam.ParDo(_SubgraphLayerDoFn(), spec,
                                               remote_op_name)
 
     # Construct Beam subgraph for a remote op.
     else:
       # ExecutionSpec stores one remote op.
-      child_remote_op_name = output_node_names[0]
+      child_remote_op_name = list(spec.output_names)[0]
       step_descriptor = ("[Parent_%s][Child_%s]" %
                          (remote_op_name, child_remote_op_name))
 
@@ -131,42 +118,14 @@ def ExecuteGraph(  # pylint: disable=invalid-name
       step_name = "ExecuteGraph%s" % step_descriptor
       pcoll = pcoll | step_name >> ExecuteGraph(  # pylint: disable=no-value-for-parameter
           child_remote_op_name, remote_op_name_to_graph_name,
-          graph_name_to_partitioned_paths,
-          graph_to_remote_op_input_name_mapping)
+          graph_name_to_specs, graph_to_remote_op_input_name_mapping)
 
       step_name = "ExtractRemoteGraphOutput%s" % step_descriptor
       pcoll = pcoll | step_name >> _ExtractRemoteGraphOutput(  # pylint: disable=no-value-for-parameter
           remote_op_name, child_remote_op_name, remote_op_name_to_graph_name,
-          graph_name_to_partitioned_paths)
+          graph_name_to_specs)
 
   return pcoll
-
-
-def _get_saved_model(
-    directory_path: Text) -> tf.core.protobuf.saved_model_pb2.SavedModel:
-  saved_model = tf.core.protobuf.saved_model_pb2.SavedModel()
-  file_path = os.path.join(directory_path, 'saved_model.pb')
-  with tf.io.gfile.GFile(file_path, 'rb') as f:
-    saved_model.ParseFromString(f.read())
-  return saved_model
-
-
-def _get_input_node_names(
-    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel) -> List[Text]:
-  signature_def = saved_model.meta_graphs[0].signature_def['serving_default']
-  inputs = signature_def.inputs
-  # Node names are the keys for input signatures of the partitioned subgraphs.
-  input_node_names = list(dict(inputs).keys())
-  return input_node_names
-
-
-def _get_output_node_names(
-    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel) -> List[Text]:
-  signature_def = saved_model.meta_graphs[0].signature_def['serving_default']
-  outputs = signature_def.outputs
-  # Node names are the keys for output signatures of the partitioned subgraphs.
-  output_node_names = list(dict(outputs).keys())
-  return output_node_names
 
 
 class _SubgraphLayerDoFn(beam.DoFn):
@@ -176,43 +135,34 @@ class _SubgraphLayerDoFn(beam.DoFn):
       self,
       # Not using mapping here because it doesn't support item assignment.
       element: Dict[Text, Dict[Text, Any]],
-      path: Text,
+      spec: execution_spec.ExecutionSpec,
       remote_op_name: Text) -> Iterator[Dict[Text, Dict[Text, Any]]]:
     """Executes a subgraph layer.
-
     To execute a subgraph layer, we need to prepare a feed_dict by extracting
     tensor values from element. Then, we run the subgraph and store its outputs
     to a copy of element.
-
-    Since we load SavedModels, all the node names now have the prefix
+    Since we import `GraphDef` protos, all the node names now have the prefix
     "import/". Also, TensorFlow feed_dict and outputs accept tensor
     names instead of node names. Hence, a conversion from node_name to
     "import/node_name:0" is necessary. Note that this conversion assumes
     that there is one output per node.
-
     Args:
       element: A dictionary from remote op names to a dictionary from tensor
-               names to values. Element[remote_op_name] stores graph inputs
-               and previous specs' outputs.
-      path: A SavedModel directory path refering to a partitioned subgraph.
-            Here, the SavedModel represents a subgraph layer.
+        names to values. Element[remote_op_name] stores graph inputs and
+        previous specs' outputs.
+      spec: An ExecutionSpec for a subgraph layer.
       remote_op_name: The remote op name of the current graph.
-
-    Returns:
+    Yields:
       A dictionary from remote op names to a dictionary from tensor names to
       values. The dictionary is a copy of the input element, to which the
       outputs of this subgraph layer have been added.
     """
     element = copy.deepcopy(element)
-    saved_model = _get_saved_model(path)
-    input_node_names = _get_input_node_names(saved_model)
-    output_node_names = _get_output_node_names(saved_model)
-
     input_tensor_names = [
-        _import_tensor_name(node_name) for node_name in input_node_names
+        _import_tensor_name(node_name) for node_name in spec.input_names
     ]
     output_tensor_names = [
-        _import_tensor_name(node_name) for node_name in output_node_names
+        _import_tensor_name(node_name) for node_name in spec.output_names
     ]
     feed_dict = {
         tensor_name: element[remote_op_name][tensor_name]
@@ -221,8 +171,7 @@ class _SubgraphLayerDoFn(beam.DoFn):
 
     outputs = []
     with tf.compat.v1.Session(graph=tf.Graph()) as sess:
-      tf.compat.v1.saved_model.load(
-          sess, [tf.compat.v1.saved_model.tag_constants.SERVING], path)
+      tf.import_graph_def(spec.subgraph)
       outputs = sess.run(output_tensor_names, feed_dict=feed_dict)
 
     for output_tensor_name, output_tensor in zip(output_tensor_names, outputs):
@@ -231,9 +180,9 @@ class _SubgraphLayerDoFn(beam.DoFn):
     yield element
 
 
-def _import_tensor_name(
+def _import_tensor_name(  # pylint: disable=invalid-name
     node_name: Text) -> Text:
-  return 'import/%s:0' % node_name
+  return "import/%s:0" % node_name
 
 
 @beam.ptransform_fn
@@ -248,25 +197,20 @@ def _LoadRemoteGraphInputs(  # pylint: disable=invalid-name
                                                                          Text]]]
 ) -> beam.pvalue.PCollection:
   """A PTransform that prepares inputs for a remote graph.
-
   Before executing a remote graph, we need to prepare its inputs. We first
   get the mapping from remote graph placeholder names to parent graph input
   names. Then, in a copy of element, we copy the inputs from the parent
   graph's key to the remote graph's key.
-
   Args:
-    pcoll: A PCollection of child graph inputs not loaded yet. Each element is
-           a dictionary from remote op names to a dictionary from tensor names
-           to values. Here, element[child_remote_op_name] is empty now.
+    pcoll: A PCollection of child graph inputs not loaded yet. Each element is a
+      dictionary from remote op names to a dictionary from tensor names to
+      values. Here, element[child_remote_op_name] is empty now.
     parent_remote_op_name: The remote op name of the parent graph.
     child_remote_op_name: The remote op name of the child graph.
-    remote_op_name_to_graph_name:
-      A mapping from remote op names to graph names.
-    graph_to_remote_op_input_name_mapping:
-      A mapping from graph names to remote op names to remote graph placeholder
-      names to parent graph input names.
+    remote_op_name_to_graph_name: A mapping from remote op names to graph names.
+    graph_to_remote_op_input_name_mapping: A mapping from graph names to remote
+      op names to remote graph placeholder names to parent graph input names.
       {graph name: {remote op name: {placeholder name: input name}}}.
-
   Returns:
     A PCollection of inputs to the child graph. Each element is a dictionary
     from remote op names to a dictionary from tensor names to values. Here,
@@ -285,16 +229,14 @@ def _LoadRemoteGraphInputs(  # pylint: disable=invalid-name
     step_name = ("PrepareInput[Graph_%s][Input_%s]" %
                  (child_remote_op_name, child_graph_placeholder_name))
     pcoll = pcoll | step_name >> beam.Map(
-        _copy_tensor_value,
-        parent_remote_op_name,
-        _import_tensor_name(parent_graph_input_name),
-        child_remote_op_name,
+        _copy_tensor_value, parent_remote_op_name,
+        _import_tensor_name(parent_graph_input_name), child_remote_op_name,
         _import_tensor_name(child_graph_placeholder_name))
 
   return pcoll
 
 
-def _copy_tensor_value(
+def _copy_tensor_value(  # pylint: disable=invalid-name
     element: Dict[Text, Dict[Text,
                              Any]], old_graph: Text, old_tensor_name: Text,
     new_graph: Text, new_tensor_name: Text) -> Dict[Text, Dict[Text, Any]]:
@@ -313,30 +255,24 @@ def _ExtractRemoteGraphOutput(  # pylint: disable=invalid-name
     parent_remote_op_name: Text,
     child_remote_op_name: Text,
     remote_op_name_to_graph_name: Mapping[Text, Text],
-    graph_name_to_partitioned_paths: Mapping[Text, List[Text]],
+    graph_name_to_specs: Mapping[Text, List[execution_spec.ExecutionSpec]],
 ) -> beam.pvalue.PCollection:
   """A PTransform that extracts remote graph output.
-
   After finish executing a remote graph, we need to collect its output.
   We first find the output name of the remote graph, then we copy the
   output of the remote graph to its parent graph. Finally, we clear the
   intermediate results of the remote graph.
-
   Note we assumed that each node has only one output, which also applies
   to remote op. This means that a remote graph can only have one output.
-
   Args:
     pcoll: A PCollection of child graph results. Each element is a dictionary
-           from remote op names to a dictionary from tensor names to values.
-           Here, element[child_remote_op_name] stores graph inputs,
-           intermediate results, and graph output.
+      from remote op names to a dictionary from tensor names to values. Here,
+      element[child_remote_op_name] stores graph inputs, intermediate results,
+      and graph output.
     parent_remote_op_name: The remote op name of the parent graph.
     child_remote_op_name: The remote op name of the child graph.
-    remote_op_name_to_graph_name:
-      A mapping from remote op names to graph names.
-    graph_name_to_partitioned_paths:
-      A mapping from graph names to a list of SavedModel directory paths.
-
+    remote_op_name_to_graph_name: A mapping from remote op names to graph names.
+    graph_name_to_specs: A mapping from graph names to a list of ExecutionSpecs.
   Returns:
     A PCollection of child graph output in parent graph. Each element is a
     dictionary from remote op names to a dictionary from tensor names to
@@ -344,11 +280,8 @@ def _ExtractRemoteGraphOutput(  # pylint: disable=invalid-name
     the child graph, and element[child_remote_op_name] is deleted.
   """
   child_graph_name = remote_op_name_to_graph_name[child_remote_op_name]
-  child_paths = graph_name_to_partitioned_paths[child_graph_name]
-  last_saved_model = _get_saved_model(child_paths[-1])
-  # Since we assumed that nodes have only one output, a remote op (thus
-  # a remote graph) has only one output.
-  child_output_name = _get_output_node_names(last_saved_model)[0]
+  child_specs = graph_name_to_specs[child_graph_name]
+  child_output_name = list(child_specs[-1].output_names)[0]
 
   step_name_extract = ("ExtractOutput[Graph_%s][Output_%s]" %
                        (child_remote_op_name, child_output_name))
@@ -357,17 +290,14 @@ def _ExtractRemoteGraphOutput(  # pylint: disable=invalid-name
 
   return (pcoll
           | step_name_extract >> beam.Map(
-              _copy_tensor_value,
-              child_remote_op_name,
-              _import_tensor_name(child_output_name),
-              parent_remote_op_name,
+              _copy_tensor_value, child_remote_op_name,
+              _import_tensor_name(child_output_name), parent_remote_op_name,
               _import_tensor_name(child_remote_op_name))
-          | step_name_clear >> beam.Map(
-              _clear_outputs_for_finished_graph,
-              child_remote_op_name))
+          | step_name_clear >> beam.Map(_clear_outputs_for_finished_graph,
+                                        child_remote_op_name))
 
 
-def _clear_outputs_for_finished_graph(
+def _clear_outputs_for_finished_graph(  # pylint: disable=invalid-name
     element: Dict[Text, Dict[Text, Any]],
     finished_graph: Text) -> Dict[Text, Dict[Text, Any]]:
   element = copy.deepcopy(element)

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/beam_pipeline_test.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/beam_pipeline_test.py
@@ -20,9 +20,9 @@ from apache_beam.testing import util
 import numpy as np
 import tensorflow as tf
 
-from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import beam_pipeline
-from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import create_complex_graph
-from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import graph_partition
+from tfx.experimental.distributed_inference.savedmodel_experiments import beam_pipeline
+from tfx.experimental.distributed_inference.savedmodel_experiments import create_complex_graph
+from tfx.experimental.distributed_inference.savedmodel_experiments import graph_partition
 
 
 class BeamPipelineTest(tf.test.TestCase):
@@ -31,7 +31,7 @@ class BeamPipelineTest(tf.test.TestCase):
   def test_compare_outputs(self):
     """Compares the results from the original model and the beam pipeline."""
     with tempfile.TemporaryDirectory() as temp_dir:
-      create_complex_graph.save_examples_as_graphdefs(temp_dir)
+      create_complex_graph.save_examples_as_saved_models(temp_dir)
 
       # "main" is both a graph name and a remote op name.
       root_graph = 'main'
@@ -75,15 +75,10 @@ class BeamPipelineTest(tf.test.TestCase):
           }
       }]
 
-      graph_name_to_filepath = {
-          'main': os.path.join(temp_dir, 'main_graph.pb'),
-          'graph_b': os.path.join(temp_dir, 'graph_b.pb'),
-          'graph_a': os.path.join(temp_dir, 'graph_a.pb')
-      }
-      graph_name_to_output_names = {
-          'main': ['AddN_1'],
-          'graph_b': ['Add_1'],
-          'graph_a': ['embedding_lookup/Identity']
+      graph_name_to_unpartitioned_path = {
+          'main': os.path.join(temp_dir, 'main_graph'),
+          'graph_b': os.path.join(temp_dir, 'graph_b'),
+          'graph_a': os.path.join(temp_dir, 'graph_a')
       }
       remote_op_name_to_graph_name = {
           'main': 'main',
@@ -93,23 +88,25 @@ class BeamPipelineTest(tf.test.TestCase):
           'remote_op_b_1': 'graph_b'
       }
 
+      out_1, out_2 = graph_partition.get_info_from_paths(
+          graph_name_to_unpartitioned_path)
+      graph_name_to_graph_def, graph_name_to_output_names = out_1, out_2
+      graph_name_to_partitioned_paths = graph_partition.partition_all_graphs(
+          graph_name_to_graph_def, graph_name_to_output_names, temp_dir)
+
       original_model_outputs = _run_original_model(root_graph,
                                                    root_graph_input_data,
-                                                   graph_name_to_filepath,
+                                                   graph_name_to_graph_def,
                                                    graph_name_to_output_names)
-
-      graph_name_to_graph_def = graph_partition.get_graph_name_to_graph_def(
-          graph_name_to_filepath)
-      graph_name_to_specs = graph_partition.partition_all_graphs(
-          graph_name_to_graph_def, graph_name_to_output_names)
 
       with beam.Pipeline() as p:
 
         beam_inputs = p | 'LoadInputs' >> beam.Create(root_graph_input_data)
         beam_outputs = (
             beam_inputs
-            | 'RunModel' >> beam_pipeline.ExecuteGraph(
-                root_graph, remote_op_name_to_graph_name, graph_name_to_specs,
+            | 'RunModel' >> beam_pipeline.ExecuteGraph(  # pylint: disable=no-value-for-parameter
+                root_graph, remote_op_name_to_graph_name,
+                graph_name_to_partitioned_paths,
                 graph_to_remote_op_input_name_mapping)
             | 'ExtractOutputs' >> beam.Map(_extract_outputs, root_graph,
                                            graph_name_to_output_names))
@@ -118,10 +115,8 @@ class BeamPipelineTest(tf.test.TestCase):
 
 
 def _run_original_model(root_graph, root_graph_input_data,
-                        graph_name_to_filepath, graph_name_to_output_names):
+                        graph_name_to_graph_def, graph_name_to_output_names):
   """Runs the original model."""
-  graph_name_to_graph_def = graph_partition.get_graph_name_to_graph_def(
-      graph_name_to_filepath)
   graph_def = graph_name_to_graph_def[root_graph]
   output_tensor_names = [
       _import_tensor_name(name)

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/beam_pipeline_test.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/beam_pipeline_test.py
@@ -1,0 +1,162 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Beam Pipeline."""
+
+import os
+import tempfile
+import apache_beam as beam
+from apache_beam.testing import util
+import numpy as np
+import tensorflow as tf
+
+from tfx.experimental.distributed_inference.savedmodel_experiments import beam_pipeline
+from tfx.experimental.distributed_inference.savedmodel_experiments import create_complex_graph
+from tfx.experimental.distributed_inference.savedmodel_experiments import graph_partition
+
+
+class BeamPipelineTest(tf.test.TestCase):
+  """A test for the beam pipeline library."""
+
+  def test_compare_outputs(self):
+    """Compares the results from the original model and the beam pipeline."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      create_complex_graph.save_examples_as_saved_models(temp_dir)
+
+      # "main" is both a graph name and a remote op name.
+      root_graph = 'main'
+      graph_to_remote_op_input_name_mapping = {
+          'main': {
+              'remote_op_a': {
+                  'ids_a': 'ids1'
+              },
+              'remote_op_b': {
+                  'ids_b1': 'ids1',
+                  'ids_b2': 'ids2'
+              },
+              'remote_op_a_1': {
+                  'ids_a': 'FloorMod_1'
+              },
+              'remote_op_b_1': {
+                  'ids_b1': 'FloorMod_1',
+                  'ids_b2': 'FloorMod'
+              }
+          },
+          'graph_b': {
+              'remote_op_a': {
+                  'ids_a': 'FloorMod'
+              },
+              'remote_op_a_1': {
+                  'ids_a': 'ids_b2'
+              }
+          }
+      }
+
+      # Create input PColl with this.
+      root_graph_input_data = [{
+          'main': {
+              'import/ids1:0': 3,
+              'import/ids2:0': 3
+          }
+      }, {
+          'main': {
+              'import/ids1:0': 10,
+              'import/ids2:0': 10
+          }
+      }]
+
+      graph_name_to_unpartitioned_path = {
+          'main': os.path.join(temp_dir, 'main_graph'),
+          'graph_b': os.path.join(temp_dir, 'graph_b'),
+          'graph_a': os.path.join(temp_dir, 'graph_a')
+      }
+      remote_op_name_to_graph_name = {
+          'main': 'main',
+          'remote_op_a': 'graph_a',
+          'remote_op_a_1': 'graph_a',
+          'remote_op_b': 'graph_b',
+          'remote_op_b_1': 'graph_b'
+      }
+
+      out_1, out_2 = graph_partition.get_info_from_paths(
+          graph_name_to_unpartitioned_path)
+      graph_name_to_graph_def, graph_name_to_output_names = out_1, out_2
+      graph_name_to_partitioned_paths = graph_partition.partition_all_graphs(
+          graph_name_to_graph_def, graph_name_to_output_names, temp_dir)
+
+      original_model_outputs = _run_original_model(root_graph,
+                                                   root_graph_input_data,
+                                                   graph_name_to_graph_def,
+                                                   graph_name_to_output_names)
+
+      with beam.Pipeline() as p:
+
+        beam_inputs = p | 'LoadInputs' >> beam.Create(root_graph_input_data)
+        beam_outputs = (
+            beam_inputs
+            | 'RunModel' >> beam_pipeline.ExecuteGraph(  # pylint: disable=no-value-for-parameter
+                root_graph, remote_op_name_to_graph_name,
+                graph_name_to_partitioned_paths,
+                graph_to_remote_op_input_name_mapping)
+            | 'ExtractOutputs' >> beam.Map(_extract_outputs, root_graph,
+                                           graph_name_to_output_names))
+
+        util.assert_that(beam_outputs, almost_equal_to(original_model_outputs))
+
+
+def _run_original_model(root_graph, root_graph_input_data,
+                        graph_name_to_graph_def, graph_name_to_output_names):
+  """Runs the original model."""
+  graph_def = graph_name_to_graph_def[root_graph]
+  output_tensor_names = [
+      _import_tensor_name(name)
+      for name in graph_name_to_output_names[root_graph]
+  ]
+
+  outputs = []
+  with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+    tf.import_graph_def(graph_def)
+    for graph_name_to_feed_dict in root_graph_input_data:
+      outputs.append(
+          sess.run(output_tensor_names, graph_name_to_feed_dict[root_graph]))
+
+  return outputs
+
+
+def _import_tensor_name(node_name):
+  return 'import/%s:0' % node_name
+
+
+def _extract_outputs(element, root_graph, graph_name_to_output_names):
+  outputs = [
+      element[root_graph][_import_tensor_name(name)]
+      for name in graph_name_to_output_names[root_graph]
+  ]
+  return outputs
+
+
+def almost_equal_to(expected):
+
+  def _almost_equal(actual):
+    sorted_expected = sorted(expected)
+    sorted_actual = sorted(actual)
+    if not np.allclose(sorted_expected, sorted_actual):
+      raise util.BeamAssertException(
+          'Failed assert: {} is not almost equal to {}'.format(
+              sorted_expected, sorted_actual))
+
+  return _almost_equal
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/create_complex_graph.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/create_complex_graph.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Save examples as SavedModels."""
+
+import os
+import tensorflow as tf
+
+from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import create_complex_graph as create
+
+
+def save_examples_as_saved_models(export_dir):
+  """Saves the example graphs as SavedModels."""
+  with tf.compat.v1.Session(graph=create.graph_a) as sess:
+    tf.compat.v1.saved_model.simple_save(
+        sess, os.path.join(export_dir, 'graph_a'),
+        inputs={'input': create.ids_a},
+        outputs={'output': create.result_a})
+
+  with tf.compat.v1.Session(graph=create.graph_b) as sess:
+    tf.compat.v1.saved_model.simple_save(
+        sess, os.path.join(export_dir, 'graph_b'),
+        inputs={'input': create.ids_b1, 'input_1': create.ids_b2},
+        outputs={'output': create.result_b})
+
+  with tf.compat.v1.Session(graph=create.main_graph) as sess:
+    tf.compat.v1.saved_model.simple_save(
+        sess, os.path.join(export_dir, 'main_graph'),
+        inputs={'input': create.ids1, 'input_1': create.ids2},
+        outputs={'output': create.main_result})
+
+if __name__ == "__main__":
+  save_examples_as_saved_models('./savedmodels')

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition.py
@@ -11,206 +11,501 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Graph partitioning on TensorFlow SavedModels with remote ops.
+"""Graph partitioning on TensorFlow GraphDefs with remote ops.
 
-The current implementation invokes the subgraph partitioning algorithm.
+The current partitioning strategy aims for maximum subgraphs.
 
 There are two libraries representing two stages: graph_partition and
-beam_pipeline. In this library, we take in some SavedModel inputs, partition
-the graphs, and store the partitioned subgraphs into lists of SavedModel
-directory paths. The order of the list represents the order of execution.
-Take a look at beam_pipeline if you want to run the partitioned subgraphs.
+beam_pipeline. In this library, we take in some GraphDef inputs, partition
+the graphs, and store the partitioned subgraphs into lists of ExecutionSpecs.
+The order of the list represents the order of execution. Take a look at
+beam_pipeline if you want to run the partitioned subgraphs.
 
 The current implementation has some key limitations:
-  1. All the node/op should have one output.
-  2. This library doesn't support tf.variable.
-  3. This library doesn't support tf.function.
+  1. This library only accepts GraphDefs (or their filepaths) as the inputs.
+  2. All the node/op should only have one output.
+  3. This library doesn't support tf.variable.
+  4. This library doesn't support tf.function.
 
   Typical usage example:
   ```
-  graph_name_to_unpartitioned_path = {
-      graph_1_name: savedmodel_directory_path_1,
-      graph_2_name: savedmodel_directory_path_2
-  }
+  graph_name_to_filepath = {graph_1_name: filepath_1,
+                            graph_2_name: filepath_2}
+  graph_name_to_output_names = {graph_1_name: [output node names of graph_1],
+                                graph_2_name: [output node names of graph_2]}
 
-  graph_name_to_graph_def, graph_name_to_output_names = get_info_from_paths(
-      graph_name_to_unpartitioned_path)
-  graph_name_to_partitioned_paths = partition_all_graphs(
-      graph_to_graph_def,
-      graph_to_output_names)
+  graph_name_to_graph_def = get_graph_name_to_graph_def(
+      graph_name_to_filepath)
+  graph_name_to_execution_specs = partition_all_graphs(
+      graph_name_to_graph_def,
+      graph_name_to_output_names)
 
   # Followed by the beam pipeline.
   ```
 """
 
-import os
-from typing import Dict, List, Mapping, Set, Text, Tuple
+import collections
+from typing import Dict, List, Mapping, Set, Text
 import tensorflow as tf
-
 from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import execution_spec
-from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import graph_partition
 
 
-def get_info_from_paths(
-    graph_name_to_unpartitioned_paths: Mapping[Text, Text]
-) -> Tuple[Dict[Text, tf.compat.v1.GraphDef],
-           Dict[Text, List[Text]]]:
-  """Gets the `GraphDef` protos and graph output names from paths.
+def get_graph_name_to_graph_def(
+    graph_name_to_filepath: Mapping[Text, Text]
+) -> Dict[Text, tf.compat.v1.GraphDef]:
+  """Gets the `GraphDef` protos from files.
 
   Args:
-    graph_name_to_unpartitioned_paths:
-      A mapping from graph names to `SavedModel` directory paths. These
-      SavedModels haven't been partitioned yet.
+    graph_name_to_filepath: A mapping from graph names to filepaths. Each
+      filepath points to a `GraphDef` proto in binary.
 
   Returns:
-    A tuple consists of two mappings. The first is a mapping from graph names
-    to `GraphDef` protos. The second is a mapping from graph names to lists of
-    their graph output names.
+    A mapping from graph names to `GraphDef` protos.
   """
-  graph_name_to_saved_model = {
-      graph_name: _get_saved_model(path)
-      for graph_name, path in graph_name_to_unpartitioned_paths.items()
-  }
   graph_name_to_graph_def = {
-      graph_name: _get_graph_def(saved_model)
-      for graph_name, saved_model in graph_name_to_saved_model.items()
+      graph_name: _get_graph_def(filepath)
+      for graph_name, filepath in graph_name_to_filepath.items()
   }
-  graph_name_to_output_names = {
-      graph_name: _get_output_names(saved_model)
-      for graph_name, saved_model in graph_name_to_saved_model.items()
-  }
-  return graph_name_to_graph_def, graph_name_to_output_names
+  return graph_name_to_graph_def
 
 
-def _get_saved_model(
-    directory_path: Text
-) -> tf.core.protobuf.saved_model_pb2.SavedModel:
-  file_path = os.path.join(directory_path, 'saved_model.pb')
-  saved_model = tf.core.protobuf.saved_model_pb2.SavedModel()
-  with tf.io.gfile.GFile(file_path, 'rb') as f:
-    saved_model.ParseFromString(f.read())
-  return saved_model
-
-
-def _get_graph_def(
-    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel
-) -> tf.compat.v1.GraphDef:
-  return saved_model.meta_graphs[0].graph_def
-
-
-def _get_output_names(
-    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel
-) -> List[Text]:
-  meta_graph = saved_model.meta_graphs[0]
-  outputs = meta_graph.signature_def['serving_default'].outputs
-
-  # Remove the tensor name postfix ":0".
-  output_names = [output.name[:-2] for output in dict(outputs).values()]
-  return output_names
+def _get_graph_def(filepath: Text) -> tf.compat.v1.GraphDef:
+  graph_def = tf.compat.v1.GraphDef()
+  with tf.io.gfile.GFile(filepath, 'rb') as f:
+    graph_def.ParseFromString(f.read())
+  return graph_def
 
 
 def partition_all_graphs(
     graph_name_to_graph_def: Mapping[Text, tf.compat.v1.GraphDef],
-    graph_name_to_output_names: Mapping[Text, List[Text]],
-    export_dir: Text) -> Dict[Text, List[Text]]:
+    graph_name_to_output_names: Mapping[Text, List[Text]]
+) -> Dict[Text, List[execution_spec.ExecutionSpec]]:
   """Partitions all the graphs.
 
   For each graph, the partitioning algorithm takes in the graph's `GraphDef`
-  proto and output names, partitions the graph, stores the partitioned
-  subgraphs in SavedModels, and returns a list of SavedModel directory paths.
-  Later, the beam_pipeline library can take in the SavedModel directory paths
-  and execute the partitioned subgraphs.
-
-  A partitioned subgraph can either represent a subgraph layer (consists of
-  nodes other than remote ops) or a remote op in a remote op layer (consists
-  of remote ops that don't have dependencies on each other).
+  proto and output names, partitions the graph, and returns a list of
+  ExecutionSpecs. Later, the beam_pipeline library can take in the
+  ExecutionSpecs and execute the partitioned subgraphs.
 
   Args:
     graph_name_to_graph_def: A mapping from graph names to `GraphDef` protos.
     graph_name_to_output_names: A mapping from graph names to lists of their
-                                output node names.
+      output node names.
 
   Returns:
-    A mapping from graph names to lists of SavedModel directory paths, where
-    each SavedModel stores a partitioned subgraph. The order of the list
-    represents the order of execution.
+    A mapping from graph names to a list of ExecutionSpecs, where the order
+    of the list represents the order of execution.
   """
-  graph_name_to_specs = graph_partition.partition_all_graphs(
-      graph_name_to_graph_def, graph_name_to_output_names)
-
-  graph_name_to_partitioned_paths = {
-      graph_name: _save_as_saved_models(export_dir, graph_name, specs)
-      for graph_name, specs in graph_name_to_specs.items()
-  }
-  return graph_name_to_partitioned_paths
+  graph_name_to_specs = {}
+  for graph_name in graph_name_to_graph_def:
+    specs = _partition_one_graph(graph_name_to_graph_def[graph_name],
+                                 graph_name_to_output_names[graph_name])
+    graph_name_to_specs[graph_name] = specs
+  return graph_name_to_specs
 
 
-def _save_as_saved_models(
-    export_dir: Text, graph_name: Text,
-    specs: List[execution_spec.ExecutionSpec]) -> List[Text]:
-  """Saves the partitioned subgraphs as SavedModels.
-
-  The partitioned subgraphs were previously stored in ExecutionSpecs. Here
-  we store the partitioned subgraphs in SavedModels by identifying the
-  `GraphDef` proto, the input signatures, and the output signatures.
+def _partition_one_graph(
+    graph_def: tf.compat.v1.GraphDef,
+    output_names: List[Text]) -> List[execution_spec.ExecutionSpec]:
+  """Partitions one graph.
 
   Args:
-    export_dir: The directory to save the partitioned subgraphs.
-    graph_name: The name of the graph that we partitioned to get the specs.
-    specs: A list of ExecutionSpecs, where each spec stores a partitioned
-           subgraph. The order of the list represents the order of execution.
+    graph_def: A `GraphDef` proto for that graph.
+    output_names: A list of graph's output node names.
 
   Returns:
-    A list of SavedModel directory paths, where each SavedModel stores a
-    partitioned subgraph. The order of the list represents the order of
-    execution.
+    A list of ExecutionSpecs.
   """
-  partitioned_paths = []
-  for counter, spec in enumerate(specs):
-    saved_model_path = _get_partitioned_path(
-        export_dir, graph_name, counter, spec.output_names)
-    partitioned_paths.append(saved_model_path)
+  graph = _get_graph(graph_def)
+  node_name_to_node_def = _get_node_name_to_node_def(graph_def)
 
-    with tf.compat.v1.Session(graph=tf.Graph()) as sess:
-      if not spec.is_remote_op:
-        tf.import_graph_def(spec.subgraph)
-      else:
-        # Simple_save() requires inputs and outputs to be mappings from
-        # node names to tensors. For remote op, create a graph_def full of
-        # placeholders only to satisfy that requirement.
-        tf.import_graph_def(
-            _create_graph_def_of_placeholders(
-                spec.input_names | spec.output_names))
+  remote_op_to_immediate_dep = _get_remote_op_to_immediate_dep(
+      node_name_to_node_def)
 
-      inputs = _get_node_name_to_tensor(sess.graph, spec.input_names)
-      outputs = _get_node_name_to_tensor(sess.graph, spec.output_names)
-      tf.compat.v1.saved_model.simple_save(sess,
-                                           saved_model_path,
-                                           inputs,
-                                           outputs)
-  return partitioned_paths
+  specs = _get_execution_specs(graph_def, output_names, graph,
+                               node_name_to_node_def,
+                               remote_op_to_immediate_dep)
+
+  _modify_execution_specs_for_input_validity(specs)
+
+  return specs
 
 
-def _get_partitioned_path(
-    export_dir: Text, graph_name: Text, counter: int,
-    output_names: Set[Text]) -> Text:
-  saved_model_path = os.path.join(
-      export_dir, 'partitioned_saved_models',
-      'graph_name_%s_subgraph_%s_output_names_%s' %
-      (graph_name, str(counter), '_'.join(output_names)))
-  return saved_model_path
-
-
-def _create_graph_def_of_placeholders(
-    node_names: Set[Text]) -> tf.compat.v1.GraphDef:
+def _get_graph(graph_def: tf.compat.v1.GraphDef) -> tf.Graph:
   with tf.compat.v1.Session(graph=tf.Graph()) as sess:
-    for node_name in node_names:
-      tf.compat.v1.placeholder(dtype=tf.float32, shape=None, name=node_name)
-    return sess.graph_def
+    tf.import_graph_def(graph_def)
+    return sess.graph
 
 
-def _get_node_name_to_tensor(
-    graph: tf.Graph, node_names: Set[Text]) -> Dict[Text, tf.Tensor]:
-  node_name_to_tensor = {name: graph.get_tensor_by_name('import/%s:0' % name)
-                         for name in node_names}
-  return node_name_to_tensor
+def _get_node_name_to_node_def(
+    graph_def: tf.compat.v1.GraphDef) -> Dict[Text, tf.compat.v1.NodeDef]:
+  return {node.name: node for node in graph_def.node}
+
+
+def _get_remote_op_to_immediate_dep(
+    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef]
+) -> Dict[Text, List[Text]]:
+  """Gets the execution dependencies between remote ops.
+
+  The remote op immediate dependencies must be executed before executing
+  a remote op.
+
+  Args:
+    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
+
+  Returns:
+    A mapping from a remote op name to a set of remote op immediate
+    dependencies' names.
+  """
+  remote_op_to_immediate_dep = {}
+
+  for node in node_name_to_node_def.values():
+    if _is_remote_op(node):
+      remote_op_to_immediate_dep[node.name] = _get_remote_op_immediate_dep(
+          node.name, node_name_to_node_def)
+
+  return remote_op_to_immediate_dep
+
+
+def _get_remote_op_immediate_dep(
+    remote_op_name: Text,
+    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef]) -> List[Text]:
+  """Finds the remote op immediate dependencies for a remote op.
+
+  Args:
+    remote_op_name: The name of the child remote op.
+    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
+
+  Returns:
+    A list of remote op immediate dependencies' names.
+  """
+  queue = collections.deque([remote_op_name])
+  visited = set([remote_op_name])
+  remote_op_immediate_dep = []
+
+  while queue:
+    current_node_name = queue.popleft()
+
+    for input_node_name in node_name_to_node_def[current_node_name].input:
+      if input_node_name not in visited:
+        visited.add(input_node_name)
+        input_node = node_name_to_node_def[input_node_name]
+
+        # Stop traversing when reaching a remote op.
+        if _is_remote_op(input_node):
+          remote_op_immediate_dep.append(input_node_name)
+        else:
+          queue.append(input_node_name)
+
+  return remote_op_immediate_dep
+
+
+def _is_placeholder_op(node: tf.compat.v1.NodeDef) -> bool:
+  return node.op == 'Placeholder'
+
+
+def _is_remote_op(node: tf.compat.v1.NodeDef) -> bool:
+  return node.op == 'PyFunc'
+
+
+def _get_execution_specs(
+    graph_def: tf.compat.v1.GraphDef, graph_output_names: List[Text],
+    graph: tf.Graph, node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef],
+    remote_op_to_immediate_dep: Mapping[Text, List[Text]]
+) -> List[execution_spec.ExecutionSpec]:
+  """Generates the ExecutionSpecs for a graph.
+
+  A "layer" contains one or more nodes inside a graph. There are two types of
+  layers: subgraph layer and remote op layer. A subgraph layer doesn't
+  contain remote ops, whereas a remote op layer only contains remote ops.
+  Remote ops inside a remote op layer don't depend on each other's output,
+  so the order of execution between those remote ops doesn't matter.
+
+  We first identify the remote op layers of a graph. Then, based on the
+  remote op layers, we can derive the subgraph layers. For example, after
+  identifying the first remote op layer, we can equate the inputs of the
+  remote op layer to the outputs of the previous subgraph layer. We can
+  then traverse and construct the previous subgraph layer.
+
+  Each subgraph layer can be captured into one ExecutionSpec, but each
+  remote op layer need to be stored into N ExecutionSpecs, where N equals
+  to the number of remote ops inside a remote op layer. This happens
+  because each remote op essentially represents a graph.
+
+  Args:
+    graph_def: A `GraphDef` proto.
+    graph_output_names: A list of graph output node names.
+    graph: A tf.Graph representing the same graph as graph_def.
+    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
+    remote_op_to_immediate_dep: A mapping from remote op name to a list of
+      remote op immediate dependencies' names.
+
+  Returns:
+    A list of ExecutionSpecs, where the order of the list represents the
+    order of execution.
+  """
+  execution_specs = []  # type: List[execution_spec.ExecutionSpec]
+  previously_visited = set()  # type: Set[Text]
+
+  for remote_op_layer in _RemoteOpLayers(remote_op_to_immediate_dep):
+    # Get one subgraph layer
+    output_node_names = _get_previous_subgraph_layer_output_node_names(
+        remote_op_layer, node_name_to_node_def)
+
+    if output_node_names:
+      spec = _get_execution_spec_for_subgraph_layer(graph_def, graph,
+                                                    node_name_to_node_def,
+                                                    previously_visited,
+                                                    output_node_names)
+      execution_specs.append(spec)
+      previously_visited |= _get_non_input_names(spec.subgraph)
+
+    # Get one remote op layer
+    specs = _get_execution_specs_for_remote_op_layer(remote_op_layer,
+                                                     node_name_to_node_def)
+    execution_specs.extend(specs)
+
+  # Get the last subgraph layer
+  output_node_names = set(graph_output_names)
+  spec = _get_execution_spec_for_subgraph_layer(graph_def, graph,
+                                                node_name_to_node_def,
+                                                previously_visited,
+                                                output_node_names)
+  execution_specs.append(spec)
+
+  return execution_specs
+
+
+def _get_previous_subgraph_layer_output_node_names(
+    remote_op_layer: Set[Text],
+    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef]) -> Set[Text]:
+  """Gets the output node names of the previous subgraph layer.
+
+  Given a remote op layer, we derive the output node names of the previous
+  subgraph layer. Layers tend to have the following order: subgraph layer,
+  remote op layer, subgraph layer, remote op layer, ...
+
+  Args:
+    remote_op_layer: A set of remote op names for a remote op layer.
+    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
+
+  Returns:
+    A set of output node names of the previous subgraph layer.
+  """
+  previous_subgraph_layer_output_node_names = set()
+
+  for remote_op_name in remote_op_layer:
+    for input_node_name in node_name_to_node_def[remote_op_name].input:
+      input_node = node_name_to_node_def[input_node_name]
+
+      # Assumption: Graph inputs and previous remote op outputs are always
+      #             computed and stored.
+      if _is_placeholder_op(input_node) or _is_remote_op(input_node):
+        continue
+      previous_subgraph_layer_output_node_names.add(input_node_name)
+
+  return previous_subgraph_layer_output_node_names
+
+
+def _get_execution_spec_for_subgraph_layer(
+    graph_def: tf.compat.v1.GraphDef, graph: tf.Graph,
+    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef],
+    previously_visited: Set[Text],
+    output_node_names: Set[Text]) -> execution_spec.ExecutionSpec:
+  """Constructs one subgraph layer.
+
+  As discussed in _get_execution_specs(), a subgraph layer contains one or
+  more nodes excluding remote ops. Based on a set of output node names, we
+  traverse toward the ancestors (upward) until encountering a "special" node.
+
+  Here, we traverse upward because each node's node_def contains input names
+  but not output names.
+
+  A "special" node could be either a placeholder node, a remote op, or a node
+  visited by a previous layer. Since it is computed/stored prior to the
+  current subgraph layer, we can treat it as an input of the current subgraph
+  layer.
+
+  Args:
+    graph_def: A `GraphDef` proto for the original graph.
+    graph: A tf.Graph instance for the original graph.
+    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
+    previously_visited: A set of node names from previous subgraph layers.
+    output_node_names: A set of output node names for the current subgraph.
+
+  Returns:
+    An ExecutionSpec representing a subgraph layer.
+  """
+  subgraph = tf.compat.v1.GraphDef()
+  subgraph.versions.CopyFrom(graph_def.versions)
+  subgraph.library.CopyFrom(graph_def.library)
+
+  queue = collections.deque(output_node_names)
+  visited = set()
+
+  while queue:
+    current_node_name = queue.popleft()
+    current_node = node_name_to_node_def[current_node_name]
+
+    if current_node_name not in visited:
+      visited.add(current_node_name)
+
+      if (_is_remote_op(current_node) or _is_placeholder_op(current_node) or
+          current_node_name in previously_visited):
+        # These ops must be computed before this subgraph layer. Hence,
+        # we treat them as placeholder inputs.
+        placeholder_node = _create_placeholder_node_from_existing_node(
+            current_node, graph)
+        subgraph.node.append(placeholder_node)
+
+      else:
+        subgraph.node.append(current_node)
+        queue.extend(node_name_to_node_def[current_node_name].input)
+
+  return execution_spec.ExecutionSpec(
+      subgraph=subgraph,
+      input_names=_get_input_names(subgraph),
+      output_names=set(output_node_names),
+      is_remote_op=False)
+
+
+def _create_placeholder_node_from_existing_node(
+    node: tf.compat.v1.NodeDef, graph: tf.Graph) -> tf.compat.v1.NodeDef:
+  """Creates a placeholder node to represent an existing node.
+
+  Some partitioned subgraphs may require inputs that are loaded or computed
+  previously. Hence, we replace the input nodes with placeholder nodes that
+  share the same name, shape, and dtype. Now the inputs become placeholders
+  inside partitioned subgraphs, and can be loaded by feed dicts at the runtime.
+
+  Args:
+    node: A `NodeDef` proto for the existing node.
+    graph: A tf.Graph instance for the graph that contains the existing node.
+
+  Returns:
+    A `NodeDef` proto that stores a placeholder node.
+  """
+  operation = graph.get_operation_by_name('import/%s' % (node.name))
+  output_tensor = operation.outputs[0]
+
+  with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+    tf.compat.v1.placeholder(
+        dtype=output_tensor.dtype, shape=output_tensor.shape, name=node.name)
+    return sess.graph_def.node[0]
+
+
+def _get_input_names(subgraph: tf.compat.v1.GraphDef) -> Set[Text]:
+  input_names = {
+      node.name for node in subgraph.node if _is_placeholder_op(node)
+  }
+  return input_names
+
+
+def _get_non_input_names(subgraph: tf.compat.v1.GraphDef) -> Set[Text]:
+  non_input_names = {
+      node.name for node in subgraph.node if not _is_placeholder_op(node)
+  }
+  return non_input_names
+
+
+def _get_execution_specs_for_remote_op_layer(
+    remote_op_layer: Set[Text],
+    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef]
+) -> List[execution_spec.ExecutionSpec]:
+  """Constructs ExecutionSpecs for a remote op layer.
+
+  As discussed in _get_execution_specs(), a remote op layer contains one
+  or more remote ops having no dependencies on each other. However, instead of
+  having one ExecutionSpec to store a layer (as it is with subgraph layer),
+  we use multiple ExecutionSpecs to represent a remote op layer.
+
+  Args:
+    remote_op_layer: A set of remote op names for a remote op layer.
+    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
+
+  Returns:
+    A list of ExecutionSpecs representing a remote op layer.
+  """
+  list_of_specs = []
+
+  for remote_op_name in remote_op_layer:
+    spec = execution_spec.ExecutionSpec(
+        subgraph=None,
+        input_names=set(node_name_to_node_def[remote_op_name].input),
+        output_names=set([remote_op_name]),
+        is_remote_op=True)
+    list_of_specs.append(spec)
+
+  return list_of_specs
+
+
+def _modify_execution_specs_for_input_validity(
+    specs: List[execution_spec.ExecutionSpec]) -> None:
+  """Modifies the execution specs to ensure that all inputs are valid.
+
+  Ensure inputs have been outputted by previous specs. Sometimes an input
+  of a spec may be a node from a previous spec but not one of the outputs.
+  We'd like to add it to previous spec's outputs.
+
+  Args:
+    specs: A list of ExecutionSpecs, where order of the list represents the
+      order of the execution.
+  """
+  for current_spec_index, current_spec in enumerate(specs):
+    for previous_spec in specs[:current_spec_index]:
+      if previous_spec.is_remote_op:
+        continue
+      _add_current_spec_input_to_previous_spec_output(current_spec,
+                                                      previous_spec)
+
+
+def _add_current_spec_input_to_previous_spec_output(
+    current_spec: execution_spec.ExecutionSpec,
+    previous_spec: execution_spec.ExecutionSpec) -> None:
+  for input_name in current_spec.input_names:
+    if input_name in _get_non_input_names(previous_spec.subgraph):
+      # Output names is a set, which doesn't allow duplicates.
+      previous_spec.output_names.add(input_name)
+
+
+class _RemoteOpLayers:
+  """A class that outputs remote op layers (custom topological sort).
+
+  A remote op layer contains a set of remote op names that don't have
+  dependencies on each other. The remote op layers are returned in execution
+  order. In other words, a remote op layer returned earlier will be executed
+  earlier.
+  """
+
+  def __init__(self, remote_op_to_immediate_dep: Mapping[Text, List[Text]]):
+    """Initializes the class.
+
+    Args:
+      remote_op_to_immediate_dep: A mapping from a remote op name to a list of
+        remote op immediate dependencies' names.
+    """
+    self.remote_op_to_immediate_dep = remote_op_to_immediate_dep
+
+  def __iter__(self):
+    self._not_processed = set(self.remote_op_to_immediate_dep.keys())
+    return self
+
+  def __next__(self) -> Set[Text]:
+    """Gets the remote op names for the next remote op layer.
+
+    Returns:
+      A set of remote op names.
+    """
+    if not self._not_processed:
+      raise StopIteration
+
+    layer_node_names = set()
+    for remote_op_name in self._not_processed:
+      remote_op_immediate_dep = set(
+          self.remote_op_to_immediate_dep[remote_op_name])
+      if not remote_op_immediate_dep & self._not_processed:
+        layer_node_names.add(remote_op_name)
+
+    self._not_processed -= layer_node_names
+
+    return layer_node_names

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition.py
@@ -1,0 +1,216 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Graph partitioning on TensorFlow SavedModels with remote ops.
+
+The current implementation invokes the subgraph partitioning algorithm.
+
+There are two libraries representing two stages: graph_partition and
+beam_pipeline. In this library, we take in some SavedModel inputs, partition
+the graphs, and store the partitioned subgraphs into lists of SavedModel
+directory paths. The order of the list represents the order of execution.
+Take a look at beam_pipeline if you want to run the partitioned subgraphs.
+
+The current implementation has some key limitations:
+  1. All the node/op should have one output.
+  2. This library doesn't support tf.variable.
+  3. This library doesn't support tf.function.
+
+  Typical usage example:
+  ```
+  graph_name_to_unpartitioned_path = {
+      graph_1_name: savedmodel_directory_path_1,
+      graph_2_name: savedmodel_directory_path_2
+  }
+
+  graph_name_to_graph_def, graph_name_to_output_names = get_info_from_paths(
+      graph_name_to_unpartitioned_path)
+  graph_name_to_partitioned_paths = partition_all_graphs(
+      graph_to_graph_def,
+      graph_to_output_names)
+
+  # Followed by the beam pipeline.
+  ```
+"""
+
+import os
+from typing import Dict, List, Mapping, Set, Text, Tuple
+import tensorflow as tf
+
+from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import execution_spec
+from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import graph_partition
+
+
+def get_info_from_paths(
+    graph_name_to_unpartitioned_paths: Mapping[Text, Text]
+) -> Tuple[Dict[Text, tf.compat.v1.GraphDef],
+           Dict[Text, List[Text]]]:
+  """Gets the `GraphDef` protos and graph output names from paths.
+
+  Args:
+    graph_name_to_unpartitioned_paths:
+      A mapping from graph names to `SavedModel` directory paths. These
+      SavedModels haven't been partitioned yet.
+
+  Returns:
+    A tuple consists of two mappings. The first is a mapping from graph names
+    to `GraphDef` protos. The second is a mapping from graph names to lists of
+    their graph output names.
+  """
+  graph_name_to_saved_model = {
+      graph_name: _get_saved_model(path)
+      for graph_name, path in graph_name_to_unpartitioned_paths.items()
+  }
+  graph_name_to_graph_def = {
+      graph_name: _get_graph_def(saved_model)
+      for graph_name, saved_model in graph_name_to_saved_model.items()
+  }
+  graph_name_to_output_names = {
+      graph_name: _get_output_names(saved_model)
+      for graph_name, saved_model in graph_name_to_saved_model.items()
+  }
+  return graph_name_to_graph_def, graph_name_to_output_names
+
+
+def _get_saved_model(
+    directory_path: Text
+) -> tf.core.protobuf.saved_model_pb2.SavedModel:
+  file_path = os.path.join(directory_path, 'saved_model.pb')
+  saved_model = tf.core.protobuf.saved_model_pb2.SavedModel()
+  with tf.io.gfile.GFile(file_path, 'rb') as f:
+    saved_model.ParseFromString(f.read())
+  return saved_model
+
+
+def _get_graph_def(
+    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel
+) -> tf.compat.v1.GraphDef:
+  return saved_model.meta_graphs[0].graph_def
+
+
+def _get_output_names(
+    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel
+) -> List[Text]:
+  meta_graph = saved_model.meta_graphs[0]
+  outputs = meta_graph.signature_def['serving_default'].outputs
+
+  # Remove the tensor name postfix ":0".
+  output_names = [output.name[:-2] for output in dict(outputs).values()]
+  return output_names
+
+
+def partition_all_graphs(
+    graph_name_to_graph_def: Mapping[Text, tf.compat.v1.GraphDef],
+    graph_name_to_output_names: Mapping[Text, List[Text]],
+    export_dir: Text) -> Dict[Text, List[Text]]:
+  """Partitions all the graphs.
+
+  For each graph, the partitioning algorithm takes in the graph's `GraphDef`
+  proto and output names, partitions the graph, stores the partitioned
+  subgraphs in SavedModels, and returns a list of SavedModel directory paths.
+  Later, the beam_pipeline library can take in the SavedModel directory paths
+  and execute the partitioned subgraphs.
+
+  A partitioned subgraph can either represent a subgraph layer (consists of
+  nodes other than remote ops) or a remote op in a remote op layer (consists
+  of remote ops that don't have dependencies on each other).
+
+  Args:
+    graph_name_to_graph_def: A mapping from graph names to `GraphDef` protos.
+    graph_name_to_output_names: A mapping from graph names to lists of their
+                                output node names.
+
+  Returns:
+    A mapping from graph names to lists of SavedModel directory paths, where
+    each SavedModel stores a partitioned subgraph. The order of the list
+    represents the order of execution.
+  """
+  graph_name_to_specs = graph_partition.partition_all_graphs(
+      graph_name_to_graph_def, graph_name_to_output_names)
+
+  graph_name_to_partitioned_paths = {
+      graph_name: _save_as_saved_models(export_dir, graph_name, specs)
+      for graph_name, specs in graph_name_to_specs.items()
+  }
+  return graph_name_to_partitioned_paths
+
+
+def _save_as_saved_models(
+    export_dir: Text, graph_name: Text,
+    specs: List[execution_spec.ExecutionSpec]) -> List[Text]:
+  """Saves the partitioned subgraphs as SavedModels.
+
+  The partitioned subgraphs were previously stored in ExecutionSpecs. Here
+  we store the partitioned subgraphs in SavedModels by identifying the
+  `GraphDef` proto, the input signatures, and the output signatures.
+
+  Args:
+    export_dir: The directory to save the partitioned subgraphs.
+    graph_name: The name of the graph that we partitioned to get the specs.
+    specs: A list of ExecutionSpecs, where each spec stores a partitioned
+           subgraph. The order of the list represents the order of execution.
+
+  Returns:
+    A list of SavedModel directory paths, where each SavedModel stores a
+    partitioned subgraph. The order of the list represents the order of
+    execution.
+  """
+  partitioned_paths = []
+  for counter, spec in enumerate(specs):
+    saved_model_path = _get_partitioned_path(
+        export_dir, graph_name, counter, spec.output_names)
+    partitioned_paths.append(saved_model_path)
+
+    with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+      if not spec.is_remote_op:
+        tf.import_graph_def(spec.subgraph)
+      else:
+        # Simple_save() requires inputs and outputs to be mappings from
+        # node names to tensors. For remote op, create a graph_def full of
+        # placeholders only to satisfy that requirement.
+        tf.import_graph_def(
+            _create_graph_def_of_placeholders(
+                spec.input_names | spec.output_names))
+
+      inputs = _get_node_name_to_tensor(sess.graph, spec.input_names)
+      outputs = _get_node_name_to_tensor(sess.graph, spec.output_names)
+      tf.compat.v1.saved_model.simple_save(sess,
+                                           saved_model_path,
+                                           inputs,
+                                           outputs)
+  return partitioned_paths
+
+
+def _get_partitioned_path(
+    export_dir: Text, graph_name: Text, counter: int,
+    output_names: Set[Text]) -> Text:
+  saved_model_path = os.path.join(
+      export_dir, 'partitioned_saved_models',
+      'graph_name_%s_subgraph_%s_output_names_%s' %
+      (graph_name, str(counter), '_'.join(output_names)))
+  return saved_model_path
+
+
+def _create_graph_def_of_placeholders(
+    node_names: Set[Text]) -> tf.compat.v1.GraphDef:
+  with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+    for node_name in node_names:
+      tf.compat.v1.placeholder(dtype=tf.float32, shape=None, name=node_name)
+    return sess.graph_def
+
+
+def _get_node_name_to_tensor(
+    graph: tf.Graph, node_names: Set[Text]) -> Dict[Text, tf.Tensor]:
+  node_name_to_tensor = {name: graph.get_tensor_by_name('import/%s:0' % name)
+                         for name in node_names}
+  return node_name_to_tensor

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition.py
@@ -11,501 +11,206 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Graph partitioning on TensorFlow GraphDefs with remote ops.
+"""Graph partitioning on TensorFlow SavedModels with remote ops.
 
-The current partitioning strategy aims for maximum subgraphs.
+The current implementation invokes the subgraph partitioning algorithm.
 
 There are two libraries representing two stages: graph_partition and
-beam_pipeline. In this library, we take in some GraphDef inputs, partition
-the graphs, and store the partitioned subgraphs into lists of ExecutionSpecs.
-The order of the list represents the order of execution. Take a look at
-beam_pipeline if you want to run the partitioned subgraphs.
+beam_pipeline. In this library, we take in some SavedModel inputs, partition
+the graphs, and store the partitioned subgraphs into lists of SavedModel
+directory paths. The order of the list represents the order of execution.
+Take a look at beam_pipeline if you want to run the partitioned subgraphs.
 
 The current implementation has some key limitations:
-  1. This library only accepts GraphDefs (or their filepaths) as the inputs.
-  2. All the node/op should only have one output.
-  3. This library doesn't support tf.variable.
-  4. This library doesn't support tf.function.
+  1. All the node/op should have one output.
+  2. This library doesn't support tf.variable.
+  3. This library doesn't support tf.function.
 
   Typical usage example:
   ```
-  graph_name_to_filepath = {graph_1_name: filepath_1,
-                            graph_2_name: filepath_2}
-  graph_name_to_output_names = {graph_1_name: [output node names of graph_1],
-                                graph_2_name: [output node names of graph_2]}
+  graph_name_to_unpartitioned_path = {
+      graph_1_name: savedmodel_directory_path_1,
+      graph_2_name: savedmodel_directory_path_2
+  }
 
-  graph_name_to_graph_def = get_graph_name_to_graph_def(
-      graph_name_to_filepath)
-  graph_name_to_execution_specs = partition_all_graphs(
-      graph_name_to_graph_def,
-      graph_name_to_output_names)
+  graph_name_to_graph_def, graph_name_to_output_names = get_info_from_paths(
+      graph_name_to_unpartitioned_path)
+  graph_name_to_partitioned_paths = partition_all_graphs(
+      graph_to_graph_def,
+      graph_to_output_names)
 
   # Followed by the beam pipeline.
   ```
 """
 
-import collections
-from typing import Dict, List, Mapping, Set, Text
+import os
+from typing import Dict, List, Mapping, Set, Text, Tuple
 import tensorflow as tf
+
 from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import execution_spec
+from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import graph_partition
 
 
-def get_graph_name_to_graph_def(
-    graph_name_to_filepath: Mapping[Text, Text]
-) -> Dict[Text, tf.compat.v1.GraphDef]:
-  """Gets the `GraphDef` protos from files.
+def get_info_from_paths(
+    graph_name_to_unpartitioned_paths: Mapping[Text, Text]
+) -> Tuple[Dict[Text, tf.compat.v1.GraphDef],
+           Dict[Text, List[Text]]]:
+  """Gets the `GraphDef` protos and graph output names from paths.
 
   Args:
-    graph_name_to_filepath: A mapping from graph names to filepaths. Each
-      filepath points to a `GraphDef` proto in binary.
+    graph_name_to_unpartitioned_paths:
+      A mapping from graph names to `SavedModel` directory paths. These
+      SavedModels haven't been partitioned yet.
 
   Returns:
-    A mapping from graph names to `GraphDef` protos.
+    A tuple consists of two mappings. The first is a mapping from graph names
+    to `GraphDef` protos. The second is a mapping from graph names to lists of
+    their graph output names.
   """
-  graph_name_to_graph_def = {
-      graph_name: _get_graph_def(filepath)
-      for graph_name, filepath in graph_name_to_filepath.items()
+  graph_name_to_saved_model = {
+      graph_name: _get_saved_model(path)
+      for graph_name, path in graph_name_to_unpartitioned_paths.items()
   }
-  return graph_name_to_graph_def
+  graph_name_to_graph_def = {
+      graph_name: _get_graph_def(saved_model)
+      for graph_name, saved_model in graph_name_to_saved_model.items()
+  }
+  graph_name_to_output_names = {
+      graph_name: _get_output_names(saved_model)
+      for graph_name, saved_model in graph_name_to_saved_model.items()
+  }
+  return graph_name_to_graph_def, graph_name_to_output_names
 
 
-def _get_graph_def(filepath: Text) -> tf.compat.v1.GraphDef:
-  graph_def = tf.compat.v1.GraphDef()
-  with tf.io.gfile.GFile(filepath, 'rb') as f:
-    graph_def.ParseFromString(f.read())
-  return graph_def
+def _get_saved_model(
+    directory_path: Text
+) -> tf.core.protobuf.saved_model_pb2.SavedModel:
+  file_path = os.path.join(directory_path, 'saved_model.pb')
+  saved_model = tf.core.protobuf.saved_model_pb2.SavedModel()
+  with tf.io.gfile.GFile(file_path, 'rb') as f:
+    saved_model.ParseFromString(f.read())
+  return saved_model
+
+
+def _get_graph_def(
+    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel
+) -> tf.compat.v1.GraphDef:
+  return saved_model.meta_graphs[0].graph_def
+
+
+def _get_output_names(
+    saved_model: tf.core.protobuf.saved_model_pb2.SavedModel
+) -> List[Text]:
+  meta_graph = saved_model.meta_graphs[0]
+  outputs = meta_graph.signature_def['serving_default'].outputs
+
+  # Remove the tensor name postfix ":0".
+  output_names = [output.name[:-2] for output in dict(outputs).values()]
+  return output_names
 
 
 def partition_all_graphs(
     graph_name_to_graph_def: Mapping[Text, tf.compat.v1.GraphDef],
-    graph_name_to_output_names: Mapping[Text, List[Text]]
-) -> Dict[Text, List[execution_spec.ExecutionSpec]]:
+    graph_name_to_output_names: Mapping[Text, List[Text]],
+    export_dir: Text) -> Dict[Text, List[Text]]:
   """Partitions all the graphs.
 
   For each graph, the partitioning algorithm takes in the graph's `GraphDef`
-  proto and output names, partitions the graph, and returns a list of
-  ExecutionSpecs. Later, the beam_pipeline library can take in the
-  ExecutionSpecs and execute the partitioned subgraphs.
+  proto and output names, partitions the graph, stores the partitioned
+  subgraphs in SavedModels, and returns a list of SavedModel directory paths.
+  Later, the beam_pipeline library can take in the SavedModel directory paths
+  and execute the partitioned subgraphs.
+
+  A partitioned subgraph can either represent a subgraph layer (consists of
+  nodes other than remote ops) or a remote op in a remote op layer (consists
+  of remote ops that don't have dependencies on each other).
 
   Args:
     graph_name_to_graph_def: A mapping from graph names to `GraphDef` protos.
     graph_name_to_output_names: A mapping from graph names to lists of their
-      output node names.
+                                output node names.
 
   Returns:
-    A mapping from graph names to a list of ExecutionSpecs, where the order
-    of the list represents the order of execution.
+    A mapping from graph names to lists of SavedModel directory paths, where
+    each SavedModel stores a partitioned subgraph. The order of the list
+    represents the order of execution.
   """
-  graph_name_to_specs = {}
-  for graph_name in graph_name_to_graph_def:
-    specs = _partition_one_graph(graph_name_to_graph_def[graph_name],
-                                 graph_name_to_output_names[graph_name])
-    graph_name_to_specs[graph_name] = specs
-  return graph_name_to_specs
+  graph_name_to_specs = graph_partition.partition_all_graphs(
+      graph_name_to_graph_def, graph_name_to_output_names)
+
+  graph_name_to_partitioned_paths = {
+      graph_name: _save_as_saved_models(export_dir, graph_name, specs)
+      for graph_name, specs in graph_name_to_specs.items()
+  }
+  return graph_name_to_partitioned_paths
 
 
-def _partition_one_graph(
-    graph_def: tf.compat.v1.GraphDef,
-    output_names: List[Text]) -> List[execution_spec.ExecutionSpec]:
-  """Partitions one graph.
+def _save_as_saved_models(
+    export_dir: Text, graph_name: Text,
+    specs: List[execution_spec.ExecutionSpec]) -> List[Text]:
+  """Saves the partitioned subgraphs as SavedModels.
+
+  The partitioned subgraphs were previously stored in ExecutionSpecs. Here
+  we store the partitioned subgraphs in SavedModels by identifying the
+  `GraphDef` proto, the input signatures, and the output signatures.
 
   Args:
-    graph_def: A `GraphDef` proto for that graph.
-    output_names: A list of graph's output node names.
+    export_dir: The directory to save the partitioned subgraphs.
+    graph_name: The name of the graph that we partitioned to get the specs.
+    specs: A list of ExecutionSpecs, where each spec stores a partitioned
+           subgraph. The order of the list represents the order of execution.
 
   Returns:
-    A list of ExecutionSpecs.
+    A list of SavedModel directory paths, where each SavedModel stores a
+    partitioned subgraph. The order of the list represents the order of
+    execution.
   """
-  graph = _get_graph(graph_def)
-  node_name_to_node_def = _get_node_name_to_node_def(graph_def)
+  partitioned_paths = []
+  for counter, spec in enumerate(specs):
+    saved_model_path = _get_partitioned_path(
+        export_dir, graph_name, counter, spec.output_names)
+    partitioned_paths.append(saved_model_path)
 
-  remote_op_to_immediate_dep = _get_remote_op_to_immediate_dep(
-      node_name_to_node_def)
-
-  specs = _get_execution_specs(graph_def, output_names, graph,
-                               node_name_to_node_def,
-                               remote_op_to_immediate_dep)
-
-  _modify_execution_specs_for_input_validity(specs)
-
-  return specs
-
-
-def _get_graph(graph_def: tf.compat.v1.GraphDef) -> tf.Graph:
-  with tf.compat.v1.Session(graph=tf.Graph()) as sess:
-    tf.import_graph_def(graph_def)
-    return sess.graph
-
-
-def _get_node_name_to_node_def(
-    graph_def: tf.compat.v1.GraphDef) -> Dict[Text, tf.compat.v1.NodeDef]:
-  return {node.name: node for node in graph_def.node}
-
-
-def _get_remote_op_to_immediate_dep(
-    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef]
-) -> Dict[Text, List[Text]]:
-  """Gets the execution dependencies between remote ops.
-
-  The remote op immediate dependencies must be executed before executing
-  a remote op.
-
-  Args:
-    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
-
-  Returns:
-    A mapping from a remote op name to a set of remote op immediate
-    dependencies' names.
-  """
-  remote_op_to_immediate_dep = {}
-
-  for node in node_name_to_node_def.values():
-    if _is_remote_op(node):
-      remote_op_to_immediate_dep[node.name] = _get_remote_op_immediate_dep(
-          node.name, node_name_to_node_def)
-
-  return remote_op_to_immediate_dep
-
-
-def _get_remote_op_immediate_dep(
-    remote_op_name: Text,
-    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef]) -> List[Text]:
-  """Finds the remote op immediate dependencies for a remote op.
-
-  Args:
-    remote_op_name: The name of the child remote op.
-    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
-
-  Returns:
-    A list of remote op immediate dependencies' names.
-  """
-  queue = collections.deque([remote_op_name])
-  visited = set([remote_op_name])
-  remote_op_immediate_dep = []
-
-  while queue:
-    current_node_name = queue.popleft()
-
-    for input_node_name in node_name_to_node_def[current_node_name].input:
-      if input_node_name not in visited:
-        visited.add(input_node_name)
-        input_node = node_name_to_node_def[input_node_name]
-
-        # Stop traversing when reaching a remote op.
-        if _is_remote_op(input_node):
-          remote_op_immediate_dep.append(input_node_name)
-        else:
-          queue.append(input_node_name)
-
-  return remote_op_immediate_dep
-
-
-def _is_placeholder_op(node: tf.compat.v1.NodeDef) -> bool:
-  return node.op == 'Placeholder'
-
-
-def _is_remote_op(node: tf.compat.v1.NodeDef) -> bool:
-  return node.op == 'PyFunc'
-
-
-def _get_execution_specs(
-    graph_def: tf.compat.v1.GraphDef, graph_output_names: List[Text],
-    graph: tf.Graph, node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef],
-    remote_op_to_immediate_dep: Mapping[Text, List[Text]]
-) -> List[execution_spec.ExecutionSpec]:
-  """Generates the ExecutionSpecs for a graph.
-
-  A "layer" contains one or more nodes inside a graph. There are two types of
-  layers: subgraph layer and remote op layer. A subgraph layer doesn't
-  contain remote ops, whereas a remote op layer only contains remote ops.
-  Remote ops inside a remote op layer don't depend on each other's output,
-  so the order of execution between those remote ops doesn't matter.
-
-  We first identify the remote op layers of a graph. Then, based on the
-  remote op layers, we can derive the subgraph layers. For example, after
-  identifying the first remote op layer, we can equate the inputs of the
-  remote op layer to the outputs of the previous subgraph layer. We can
-  then traverse and construct the previous subgraph layer.
-
-  Each subgraph layer can be captured into one ExecutionSpec, but each
-  remote op layer need to be stored into N ExecutionSpecs, where N equals
-  to the number of remote ops inside a remote op layer. This happens
-  because each remote op essentially represents a graph.
-
-  Args:
-    graph_def: A `GraphDef` proto.
-    graph_output_names: A list of graph output node names.
-    graph: A tf.Graph representing the same graph as graph_def.
-    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
-    remote_op_to_immediate_dep: A mapping from remote op name to a list of
-      remote op immediate dependencies' names.
-
-  Returns:
-    A list of ExecutionSpecs, where the order of the list represents the
-    order of execution.
-  """
-  execution_specs = []  # type: List[execution_spec.ExecutionSpec]
-  previously_visited = set()  # type: Set[Text]
-
-  for remote_op_layer in _RemoteOpLayers(remote_op_to_immediate_dep):
-    # Get one subgraph layer
-    output_node_names = _get_previous_subgraph_layer_output_node_names(
-        remote_op_layer, node_name_to_node_def)
-
-    if output_node_names:
-      spec = _get_execution_spec_for_subgraph_layer(graph_def, graph,
-                                                    node_name_to_node_def,
-                                                    previously_visited,
-                                                    output_node_names)
-      execution_specs.append(spec)
-      previously_visited |= _get_non_input_names(spec.subgraph)
-
-    # Get one remote op layer
-    specs = _get_execution_specs_for_remote_op_layer(remote_op_layer,
-                                                     node_name_to_node_def)
-    execution_specs.extend(specs)
-
-  # Get the last subgraph layer
-  output_node_names = set(graph_output_names)
-  spec = _get_execution_spec_for_subgraph_layer(graph_def, graph,
-                                                node_name_to_node_def,
-                                                previously_visited,
-                                                output_node_names)
-  execution_specs.append(spec)
-
-  return execution_specs
-
-
-def _get_previous_subgraph_layer_output_node_names(
-    remote_op_layer: Set[Text],
-    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef]) -> Set[Text]:
-  """Gets the output node names of the previous subgraph layer.
-
-  Given a remote op layer, we derive the output node names of the previous
-  subgraph layer. Layers tend to have the following order: subgraph layer,
-  remote op layer, subgraph layer, remote op layer, ...
-
-  Args:
-    remote_op_layer: A set of remote op names for a remote op layer.
-    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
-
-  Returns:
-    A set of output node names of the previous subgraph layer.
-  """
-  previous_subgraph_layer_output_node_names = set()
-
-  for remote_op_name in remote_op_layer:
-    for input_node_name in node_name_to_node_def[remote_op_name].input:
-      input_node = node_name_to_node_def[input_node_name]
-
-      # Assumption: Graph inputs and previous remote op outputs are always
-      #             computed and stored.
-      if _is_placeholder_op(input_node) or _is_remote_op(input_node):
-        continue
-      previous_subgraph_layer_output_node_names.add(input_node_name)
-
-  return previous_subgraph_layer_output_node_names
-
-
-def _get_execution_spec_for_subgraph_layer(
-    graph_def: tf.compat.v1.GraphDef, graph: tf.Graph,
-    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef],
-    previously_visited: Set[Text],
-    output_node_names: Set[Text]) -> execution_spec.ExecutionSpec:
-  """Constructs one subgraph layer.
-
-  As discussed in _get_execution_specs(), a subgraph layer contains one or
-  more nodes excluding remote ops. Based on a set of output node names, we
-  traverse toward the ancestors (upward) until encountering a "special" node.
-
-  Here, we traverse upward because each node's node_def contains input names
-  but not output names.
-
-  A "special" node could be either a placeholder node, a remote op, or a node
-  visited by a previous layer. Since it is computed/stored prior to the
-  current subgraph layer, we can treat it as an input of the current subgraph
-  layer.
-
-  Args:
-    graph_def: A `GraphDef` proto for the original graph.
-    graph: A tf.Graph instance for the original graph.
-    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
-    previously_visited: A set of node names from previous subgraph layers.
-    output_node_names: A set of output node names for the current subgraph.
-
-  Returns:
-    An ExecutionSpec representing a subgraph layer.
-  """
-  subgraph = tf.compat.v1.GraphDef()
-  subgraph.versions.CopyFrom(graph_def.versions)
-  subgraph.library.CopyFrom(graph_def.library)
-
-  queue = collections.deque(output_node_names)
-  visited = set()
-
-  while queue:
-    current_node_name = queue.popleft()
-    current_node = node_name_to_node_def[current_node_name]
-
-    if current_node_name not in visited:
-      visited.add(current_node_name)
-
-      if (_is_remote_op(current_node) or _is_placeholder_op(current_node) or
-          current_node_name in previously_visited):
-        # These ops must be computed before this subgraph layer. Hence,
-        # we treat them as placeholder inputs.
-        placeholder_node = _create_placeholder_node_from_existing_node(
-            current_node, graph)
-        subgraph.node.append(placeholder_node)
-
+    with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+      if not spec.is_remote_op:
+        tf.import_graph_def(spec.subgraph)
       else:
-        subgraph.node.append(current_node)
-        queue.extend(node_name_to_node_def[current_node_name].input)
+        # Simple_save() requires inputs and outputs to be mappings from
+        # node names to tensors. For remote op, create a graph_def full of
+        # placeholders only to satisfy that requirement.
+        tf.import_graph_def(
+            _create_graph_def_of_placeholders(
+                spec.input_names | spec.output_names))
 
-  return execution_spec.ExecutionSpec(
-      subgraph=subgraph,
-      input_names=_get_input_names(subgraph),
-      output_names=set(output_node_names),
-      is_remote_op=False)
+      inputs = _get_node_name_to_tensor(sess.graph, spec.input_names)
+      outputs = _get_node_name_to_tensor(sess.graph, spec.output_names)
+      tf.compat.v1.saved_model.simple_save(sess,
+                                           saved_model_path,
+                                           inputs,
+                                           outputs)
+  return partitioned_paths
 
 
-def _create_placeholder_node_from_existing_node(
-    node: tf.compat.v1.NodeDef, graph: tf.Graph) -> tf.compat.v1.NodeDef:
-  """Creates a placeholder node to represent an existing node.
+def _get_partitioned_path(
+    export_dir: Text, graph_name: Text, counter: int,
+    output_names: Set[Text]) -> Text:
+  saved_model_path = os.path.join(
+      export_dir, 'partitioned_saved_models',
+      'graph_name_%s_subgraph_%s_output_names_%s' %
+      (graph_name, str(counter), '_'.join(output_names)))
+  return saved_model_path
 
-  Some partitioned subgraphs may require inputs that are loaded or computed
-  previously. Hence, we replace the input nodes with placeholder nodes that
-  share the same name, shape, and dtype. Now the inputs become placeholders
-  inside partitioned subgraphs, and can be loaded by feed dicts at the runtime.
 
-  Args:
-    node: A `NodeDef` proto for the existing node.
-    graph: A tf.Graph instance for the graph that contains the existing node.
-
-  Returns:
-    A `NodeDef` proto that stores a placeholder node.
-  """
-  operation = graph.get_operation_by_name('import/%s' % (node.name))
-  output_tensor = operation.outputs[0]
-
+def _create_graph_def_of_placeholders(
+    node_names: Set[Text]) -> tf.compat.v1.GraphDef:
   with tf.compat.v1.Session(graph=tf.Graph()) as sess:
-    tf.compat.v1.placeholder(
-        dtype=output_tensor.dtype, shape=output_tensor.shape, name=node.name)
-    return sess.graph_def.node[0]
+    for node_name in node_names:
+      tf.compat.v1.placeholder(dtype=tf.float32, shape=None, name=node_name)
+    return sess.graph_def
 
 
-def _get_input_names(subgraph: tf.compat.v1.GraphDef) -> Set[Text]:
-  input_names = {
-      node.name for node in subgraph.node if _is_placeholder_op(node)
-  }
-  return input_names
-
-
-def _get_non_input_names(subgraph: tf.compat.v1.GraphDef) -> Set[Text]:
-  non_input_names = {
-      node.name for node in subgraph.node if not _is_placeholder_op(node)
-  }
-  return non_input_names
-
-
-def _get_execution_specs_for_remote_op_layer(
-    remote_op_layer: Set[Text],
-    node_name_to_node_def: Mapping[Text, tf.compat.v1.NodeDef]
-) -> List[execution_spec.ExecutionSpec]:
-  """Constructs ExecutionSpecs for a remote op layer.
-
-  As discussed in _get_execution_specs(), a remote op layer contains one
-  or more remote ops having no dependencies on each other. However, instead of
-  having one ExecutionSpec to store a layer (as it is with subgraph layer),
-  we use multiple ExecutionSpecs to represent a remote op layer.
-
-  Args:
-    remote_op_layer: A set of remote op names for a remote op layer.
-    node_name_to_node_def: A mapping from node names to `NodeDef` protos.
-
-  Returns:
-    A list of ExecutionSpecs representing a remote op layer.
-  """
-  list_of_specs = []
-
-  for remote_op_name in remote_op_layer:
-    spec = execution_spec.ExecutionSpec(
-        subgraph=None,
-        input_names=set(node_name_to_node_def[remote_op_name].input),
-        output_names=set([remote_op_name]),
-        is_remote_op=True)
-    list_of_specs.append(spec)
-
-  return list_of_specs
-
-
-def _modify_execution_specs_for_input_validity(
-    specs: List[execution_spec.ExecutionSpec]) -> None:
-  """Modifies the execution specs to ensure that all inputs are valid.
-
-  Ensure inputs have been outputted by previous specs. Sometimes an input
-  of a spec may be a node from a previous spec but not one of the outputs.
-  We'd like to add it to previous spec's outputs.
-
-  Args:
-    specs: A list of ExecutionSpecs, where order of the list represents the
-      order of the execution.
-  """
-  for current_spec_index, current_spec in enumerate(specs):
-    for previous_spec in specs[:current_spec_index]:
-      if previous_spec.is_remote_op:
-        continue
-      _add_current_spec_input_to_previous_spec_output(current_spec,
-                                                      previous_spec)
-
-
-def _add_current_spec_input_to_previous_spec_output(
-    current_spec: execution_spec.ExecutionSpec,
-    previous_spec: execution_spec.ExecutionSpec) -> None:
-  for input_name in current_spec.input_names:
-    if input_name in _get_non_input_names(previous_spec.subgraph):
-      # Output names is a set, which doesn't allow duplicates.
-      previous_spec.output_names.add(input_name)
-
-
-class _RemoteOpLayers:
-  """A class that outputs remote op layers (custom topological sort).
-
-  A remote op layer contains a set of remote op names that don't have
-  dependencies on each other. The remote op layers are returned in execution
-  order. In other words, a remote op layer returned earlier will be executed
-  earlier.
-  """
-
-  def __init__(self, remote_op_to_immediate_dep: Mapping[Text, List[Text]]):
-    """Initializes the class.
-
-    Args:
-      remote_op_to_immediate_dep: A mapping from a remote op name to a list of
-        remote op immediate dependencies' names.
-    """
-    self.remote_op_to_immediate_dep = remote_op_to_immediate_dep
-
-  def __iter__(self):
-    self._not_processed = set(self.remote_op_to_immediate_dep.keys())
-    return self
-
-  def __next__(self) -> Set[Text]:
-    """Gets the remote op names for the next remote op layer.
-
-    Returns:
-      A set of remote op names.
-    """
-    if not self._not_processed:
-      raise StopIteration
-
-    layer_node_names = set()
-    for remote_op_name in self._not_processed:
-      remote_op_immediate_dep = set(
-          self.remote_op_to_immediate_dep[remote_op_name])
-      if not remote_op_immediate_dep & self._not_processed:
-        layer_node_names.add(remote_op_name)
-
-    self._not_processed -= layer_node_names
-
-    return layer_node_names
+def _get_node_name_to_tensor(
+    graph: tf.Graph, node_names: Set[Text]) -> Dict[Text, tf.Tensor]:
+  node_name_to_tensor = {name: graph.get_tensor_by_name('import/%s:0' % name)
+                         for name in node_names}
+  return node_name_to_tensor

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition_test.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition_test.py
@@ -1,0 +1,63 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Graph Partitioning."""
+
+import os
+import tempfile
+import tensorflow as tf
+
+from tfx.experimental.distributed_inference.savedmodel_experiments import create_complex_graph
+from tfx.experimental.distributed_inference.savedmodel_experiments import graph_partition
+
+
+class PartitionTest(tf.test.TestCase):
+  """Tests for graph partitioning."""
+
+  def test_subgraph_import_validity(self):
+    """Tests if the partitioned subgraphs can be imported."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+      create_complex_graph.save_examples_as_saved_models(temp_dir)
+
+      graph_name_to_unpartitioned_paths = {
+          'remote_op_a': os.path.join(temp_dir, 'graph_a'),
+          'remote_op_b': os.path.join(temp_dir, 'graph_b'),
+          'main': os.path.join(temp_dir, 'main_graph')
+      }
+
+      out_1, out_2 = graph_partition.get_info_from_paths(
+          graph_name_to_unpartitioned_paths)
+      graph_name_to_graph_def, graph_name_to_output_names = out_1, out_2
+      graph_name_to_partitioned_paths = graph_partition.partition_all_graphs(
+          graph_name_to_graph_def, graph_name_to_output_names, temp_dir)
+
+      for partitioned_paths in graph_name_to_partitioned_paths.values():
+        for path in partitioned_paths:
+          with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            meta_graph_def = tf.compat.v1.saved_model.load(
+                sess, [tf.compat.v1.saved_model.tag_constants.SERVING], path)
+            self.assertIsNotNone(meta_graph_def)
+
+  def test_with_golden_set(self):
+    """Tests if the SavedModels match the golden set.
+
+    Problem: Saved_model.save or saved_model.simple_save doesn't allow us
+             to specify the format (binary or text) of the saved_model file
+             inside the folder. Not sure if I should use binary files
+             for the golden set.
+    """
+
+
+if __name__ == '__main__':
+  tf.test.main()
+  

--- a/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition_test.py
+++ b/tfx/experimental/distributed_inference/savedmodel_experiments/graph_partition_test.py
@@ -17,47 +17,111 @@ import os
 import tempfile
 import tensorflow as tf
 
-from tfx.experimental.distributed_inference.savedmodel_experiments import create_complex_graph
-from tfx.experimental.distributed_inference.savedmodel_experiments import graph_partition
+from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import create_complex_graph
+from tfx.experimental.distributed_inference.graphdef_experiments.subgraph_partitioning import graph_partition
+from google.protobuf import text_format
+
+
+class RemoteOpLayerTest(tf.test.TestCase):
+  """A test for the class _RemoteOpLayer."""
+
+  def test_layers(self):
+    """Validates the class through an example."""
+    remote_op_relations = {
+        'a1': [],
+        'a2': [],
+        'b1': ['a1'],
+        'b2': ['a1', 'a2'],
+        'c1': ['b1'],
+        'c2': ['b1', 'a1', 'b2', 'a2']
+    }
+    desired_outputs = [{'a1', 'a2'}, {'b1', 'b2'}, {'c1', 'c2'}]
+
+    order = graph_partition._RemoteOpLayers(remote_op_relations)
+    self.assertEqual(desired_outputs, list(order))
 
 
 class PartitionTest(tf.test.TestCase):
-  """Tests for graph partitioning."""
+  """A set of tests for the graph partitioning library."""
+
+  def setUp(self):
+    """Sets up some example graphs and their partitions."""
+    super().setUp()
+    with tempfile.TemporaryDirectory() as temp_dir:
+      # Save examples into a temporary directory
+      create_complex_graph.save_examples_as_graphdefs(temp_dir)
+
+      graph_name_to_filepath = {
+          'main': os.path.join(temp_dir, 'main_graph.pb'),
+          'remote_op_a': os.path.join(temp_dir, 'graph_a.pb'),
+          'remote_op_b': os.path.join(temp_dir, 'graph_b.pb')
+      }
+      graph_name_to_outputs = {
+          'main': ['AddN_1'],
+          'remote_op_b': ['Add_1'],
+          'remote_op_a': ['embedding_lookup/Identity']
+      }
+
+      graph_name_to_graph_def = graph_partition.get_graph_name_to_graph_def(
+          graph_name_to_filepath)
+      self.graph_name_to_specs = graph_partition.partition_all_graphs(
+          graph_name_to_graph_def, graph_name_to_outputs)
 
   def test_subgraph_import_validity(self):
     """Tests if the partitioned subgraphs can be imported."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-      create_complex_graph.save_examples_as_saved_models(temp_dir)
+    for execution_specs in self.graph_name_to_specs.values():
+      for execution_spec in execution_specs:
+        if execution_spec.is_remote_op:
+          continue
 
-      graph_name_to_unpartitioned_paths = {
-          'remote_op_a': os.path.join(temp_dir, 'graph_a'),
-          'remote_op_b': os.path.join(temp_dir, 'graph_b'),
-          'main': os.path.join(temp_dir, 'main_graph')
-      }
+        graph = tf.Graph()
+        with graph.as_default():
+          tf.import_graph_def(execution_spec.subgraph)
 
-      out_1, out_2 = graph_partition.get_info_from_paths(
-          graph_name_to_unpartitioned_paths)
-      graph_name_to_graph_def, graph_name_to_output_names = out_1, out_2
-      graph_name_to_partitioned_paths = graph_partition.partition_all_graphs(
-          graph_name_to_graph_def, graph_name_to_output_names, temp_dir)
+  def test_remote_op_specs(self):
+    """Validates a remote op spec."""
+    for execution_specs in self.graph_name_to_specs.values():
+      for spec in execution_specs:
+        if not spec.is_remote_op:
+          continue
 
-      for partitioned_paths in graph_name_to_partitioned_paths.values():
-        for path in partitioned_paths:
-          with tf.compat.v1.Session(graph=tf.Graph()) as sess:
-            meta_graph_def = tf.compat.v1.saved_model.load(
-                sess, [tf.compat.v1.saved_model.tag_constants.SERVING], path)
-            self.assertIsNotNone(meta_graph_def)
+        self.assertIsNone(spec.subgraph)
+        self.assertLen(spec.output_names, 1)
 
-  def test_with_golden_set(self):
-    """Tests if the SavedModels match the golden set.
+  def test_subgraphs_with_golden_set(self):
+    """Checks if the partitioned subgraphs match the golden set."""
+    for graph_name, specs in self.graph_name_to_specs.items():
+      for spec in specs:
+        if spec.is_remote_op:
+          continue
+        golden_graph_def = _get_golden_subgraph(graph_name, spec)
+        # Compare node names instead of `GraphDef` protos because sets in
+        # graph_partition are not ordered. If there are two nodes with the
+        # same type in a subgraph layer, for example Add. Sometimes a node
+        # may have name "Add" while other times have name "Add_1".
+        self.assertEqual(
+            _get_node_names(golden_graph_def), _get_node_names(spec.subgraph))
 
-    Problem: Saved_model.save or saved_model.simple_save doesn't allow us
-             to specify the format (binary or text) of the saved_model file
-             inside the folder. Not sure if I should use binary files
-             for the golden set.
-    """
+
+def _get_golden_subgraph(graph_name, spec):
+  """Retrieves a corresponding golden subgraph."""
+  filename = _generate_unique_filename(spec.input_names)
+  filepath = os.path.join(
+      os.path.dirname(__file__), 'testdata', graph_name, filename)
+
+  graph_def = tf.compat.v1.GraphDef()
+  with tf.io.gfile.GFile(filepath, 'r') as f:
+    text_format.Parse(f.read(), graph_def)
+  return graph_def
+
+
+def _generate_unique_filename(input_names):
+  return 'input_names-%s.pbtxt' % ('-'.join(sorted(input_names)))
+
+
+def _get_node_names(graph_def):
+  return {node.name for node in graph_def.node}
 
 
 if __name__ == '__main__':
   tf.test.main()
-  


### PR DESCRIPTION
OSS Intern Project: Map distributed inference graph to beam pipeline.

Shortly speaking, we want to demonstrate that models with remote graphs can be partitioned and arranged in a beam pipeline. The results from the beam pipeline should be the same as the original TF model's results.

After working with GraphDefs (PRs: https://github.com/tensorflow/tfx/pull/2157, https://github.com/tensorflow/tfx/pull/2296), we moved our attention to SavedModels.

In this PR, the create_complex_graph file saves the example graphs as SavedModels. The graph partitioning library takes in SavedModel directory paths, extracts `GraphDef` protos and output names for each graph, invokes partition_all() from graphdef_experiments/subgraph_partitioning, then saves the partitioned subgraphs into SavedModels. The beam pipeline library takes in partitioned SavedModel directory paths and builds a PTransform that executes the partitioned subgraphs. The results from the beam pipeline and the results from the original model are indeed the same.

After experimenting with GraphDefs and SavedModels, I realized that a much better/modular code structure can be designed. Hopefully in the future, someone (maybe me) will use these experiments as a starting point of building a feature for production.