### PR TITLE
Modify the method of using stub executors

### DIFF
--- a/docs/tutorials/tfx/stub_template.md
+++ b/docs/tutorials/tfx/stub_template.md
@@ -1,0 +1,115 @@
+
+## Testing the pipeline using Stub Executors
+
+### Introduction
+**You should complete [template.ipynb](https://github.com/tensorflow/tfx/blob/master/docs/tutorials/tfx/template.ipynb) tutorial up to *Step 6* in order to proceed this tutorial.**
+
+This document will provide instructions to test a TensorFlow Extended (TFX) pipeline
+using `BaseStubExecuctor`, which generates fake artifacts using the golden test data. This is intended for users to replace executors they don't want to test so that they could save time from running the actual executors. Stub executor is provided with TFX Python package under `tfx.experimental.pipeline_testing.base_stub_executor`.
+
+This tutorial serves as an extension to `template.ipynb` tutorial, thus you will also use [Taxi Trips dataset](
+https://data.cityofchicago.org/Transportation/Taxi-Trips/wrvz-psew)
+released by the City of Chicago. We strongly encourage you to try modifying the components prior to utilizing stub executors.
+
+### 1. Record the pipeline outputs in Google Cloud Storage
+
+We first need to record the pipeline outputs so that the stub executors can copy over the artifacts from the recorded outputs.
+
+Since this tutorial assumes that you have completed `template.ipynb` up to step 6, a successful pipeline run must have been saved in the [MLMD](https://www.tensorflow.org/tfx/guide/mlmd). The execution information in MLMD can be accessed using gRPC server. 
+
+Open a Terminal and run the following commands:
+
+1.  Generate a kubeconfig file with appropriate credentials:
+```bash
+gcloud container clusters get-credentials $cluster_name --zone $compute_zone --project $gcp_project_id
+```
+`$compute_zone` is region for gcp engine and `$gcp_project_id` is project id of your GCP project.
+
+2.  Set up port-forwarding for connecting to MLMD:
+```bash
+nohup kubectl port-forward deployment/metadata-grpc-deployment -n $namespace $port:8080 &
+```
+`$namespace` is the cluster namespace and `$port` is any unused port that will be used for port-forwarding.
+
+3.  Clone the tfx GitHub repository. Inside the tfx directory, run the following command:
+
+```bash
+python tfx/experimental/pipeline_testing/pipeline_recorder.py \
+--output_dir=gs://<gcp_project_id>-kubeflowpipelines-default/testdata \
+--host=$host \
+--port=$port \
+--pipeline_name=$pipeline_name
+```
+
+`$output_dir` should be set to a path in Google Cloud Storage where the pipeline outputs are to be recorded, so make sure to replace `<gcp_project_id>` with GCP project id.
+
+`$host` and `$port` are hostname and port of the metadata grpc server to connect to MLMD. `$port` should be set to the port number you used for port-forwarding and you may set "localhost" for the hostname.
+
+In `template.ipynb` tutorial, the pipeline name is set as "my_pipeline" by default, so set `pipeline_name="my_pipeline"`. If you have modified the pipeline name when running the template tutorial, you should modify the `--pipeline_name` accordingly.
+
+### 2. Enable Stub Executors in Kubeflow DAG Runner
+
+First, make sure that the predefined template has been copied to your project directory using `tfx template copy` CLI command. It is necessary to edit the following two files in the copied source files.
+
+1.  In `kubeflow_dag_runner.py`, add `StubComponentLauncher` class to `KubeflowDagRunnerConfig`'s `supported_launcher_class` to enable launch of stub executors:
+
+```python
+  runner_config = kubeflow_dag_runner.KubeflowDagRunnerConfig(
+      # TODO(StubExecutor): Uncomment below to use stub executors.
+      supported_launcher_classes=[
+        stub_component_launcher.StubComponentLauncher
+      ],
+```
+
+2.  In `launcher/stub_component_launcher.py`, modify the default list of component ids that are to be tested (in other words, other components' executors are replaced with BaseStubExecutor).
+```python
+# GCS directory where KFP outputs are recorded
+test_data_dir = "gs://{}/testdata".format(configs.GCS_BUCKET_NAME)
+# TODO(StubExecutor): customize self.test_component_ids to test components,
+# replacing other component executors with a BaseStubExecutor
+# For example, test_component_ids = ['Trainer', 'Transform']
+test_component_ids = []
+
+StubComponentLauncher.initialize(
+    test_data_dir=test_data_dir,
+    test_component_ids=test_component_ids)
+```
+
+#### In Jupyter lab file editor:
+>**Double-click to open `kubeflow_dag_runner.py`**. 
+Uncomment `supported_launcher_classes` argument of `KubeflowDagRunnerConfig` to be able to launch stub executors (Tip: search for comments containing `TODO(StubExecutor):`),  Make sure to save `kubeflow_dag_runner.py` after you edit it.
+
+
+
+>**Double-click to change directory to `launcher` and double-click again to open `stub_component_launcher.py`.**
+Make sure to set `test_data_dir` to the GCS directory where KFP outputs are recorded, or `output_dir` (Tip: search for comments containing `TODO(StubExecutor):`). Customize the list `self.stubbed_component_ids`, or ids of components that should be replaced with BaseStubExecutor(Tip: search for comments containing `TODO(StubExecutor):`). You may additionally insert custom stub executor in `self.stubbed_component_map` with component id as a key and custom stub executor class as value (Tip: search for comments containing `TODO(StubExecutor):`). Make sure to save `stub_component_launcher.py` after you edit it.
+
+### 3. Update and run the pipeline with stub executors
+Update the existing pipeline with modified pipeline definition with stub executors.
+```bash
+tfx pipeline update
+--pipeline-path=kubeflow_dag_runner.py
+--endpoint=$endpoint --engine=kubeflow
+```
+`$endpoint` should be set to your KFP cluster endpoint.
+
+Run the following command to create a new execution run of your updated pipeline.
+
+```bash
+tfx run create --pipeline-name $pipeline_name --endpoint=$endpoint --engine=kubeflow
+```
+
+
+## Cleaning up
+
+Use command `fg` to access the port-forwarding in the background then ctrl-C to terminate.
+You can delete the directory with recorded pipeline outputs using `gsutil -m rm -R $output_dir`.
+
+To clean up all Google Cloud resources used in this project, you can
+[delete the Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects)
+you used for the tutorial.
+
+Alternatively, you can clean up individual resources by visiting each
+consoles: - [Google Cloud Storage](https://console.cloud.google.com/storage) -
+[Google Container Registry](https://console.cloud.google.com/gcr) -
+[Google Kubernetes Engine](https://console.cloud.google.com/kubernetes)

--- a/tfx/experimental/pipeline_testing/base_stub_component_launcher.py
+++ b/tfx/experimental/pipeline_testing/base_stub_component_launcher.py
@@ -1,0 +1,106 @@
+# Lint as: python3
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Base stub component launcher for launching component executors and stub executors in process."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+from typing import Any, Dict, List, Text, Type
+
+from tfx import types
+from tfx.components.base import base_executor
+from tfx.experimental.pipeline_testing import base_stub_executor
+from tfx.orchestration.launcher import in_process_component_launcher
+
+
+class BaseStubComponentLauncher(
+    in_process_component_launcher.InProcessComponentLauncher):
+  """Responsible for launching a stub executor.
+
+  A stub component launcher class inheriting BaseStubComponentLauncher can be
+  supported by the pipeline. This class should be defined in a separate python
+  module because the class is pickled by module path in beam and imported by
+  module path in KFP.
+  The executor will be launched in the same process of the rest of the
+  component, i.e. its driver and publisher.
+  """
+
+  test_component_ids = ...  # type: List[Text]
+  test_data_dir = ...  # type: Text
+
+  @classmethod
+  def initialize(
+      cls,
+      test_data_dir: Text,
+      test_component_ids: List[Text]
+  ):
+    """Initializes variables in the stub launcher class.
+
+    For beam pipeline, stub launcher class inheriting this class is defined in
+    tfx.experimental.pipeline_testing.stub_component_launcher.py
+
+    For KFP, stub launcher class inheriting this class is defined in
+    tfx.experimental.templates.taxi.launcher.stub_component_launcher.py.
+
+    These classes then can be used to launch stub executors in the pipeline.
+
+    For example,
+
+    stub_component_launcher.StubComponentLauncher.initialize(
+        test_data_dir,
+        test_component_ids = ['Trainer', 'Transform'])
+    PipelineConfig(
+        supported_launcher_classes=[
+            stub_component_launcher.StubComponentLauncher
+        ],
+    )
+
+    The method initializes the necessary class variables for the
+    BaseStubComponentLauncher class, including test_component_ids.
+
+    Args:
+      test_data_dir: The directory where pipeline outputs are recorded
+        (pipeline_recorder.py).
+      test_component_ids: List of ids of components that are to be tested.
+        In other words, executors of components other than those specified
+        by this list will be replaced with a BaseStubExecutor.
+
+    Returns:
+      None
+    """
+    cls.test_component_ids = test_component_ids
+    cls.test_data_dir = test_data_dir
+
+  def _run_executor(self, execution_id: int,
+                    input_dict: Dict[Text, List[types.Artifact]],
+                    output_dict: Dict[Text, List[types.Artifact]],
+                    exec_properties: Dict[Text, Any]) -> None:
+    """Execute underlying component implementation."""
+    component_id = self._component_info.component_id
+    if component_id in self.test_component_ids or component_id.startswith('ResolverNode'):
+      super(BaseStubComponentLauncher,
+            self)._run_executor(execution_id, input_dict, output_dict,
+                                exec_properties)
+    else:
+      executor_context = base_executor.BaseExecutor.Context(
+          beam_pipeline_args=self._beam_pipeline_args,
+          tmp_dir=os.path.join(self._pipeline_info.pipeline_root, '.temp', ''),
+          unique_id=str(execution_id))
+      executor = base_stub_executor.BaseStubExecutor(component_id,
+                                                     self.test_data_dir,
+                                                     executor_context)
+      executor.Do(input_dict, output_dict, exec_properties)

--- a/tfx/experimental/pipeline_testing/base_stub_component_launcher.py
+++ b/tfx/experimental/pipeline_testing/base_stub_component_launcher.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-from typing import Any, Dict, List, Text, Type
+from typing import Any, Dict, List, Text
 
 from tfx import types
 from tfx.components.base import base_executor
@@ -91,7 +91,7 @@ class BaseStubComponentLauncher(
                     exec_properties: Dict[Text, Any]) -> None:
     """Execute underlying component implementation."""
     component_id = self._component_info.component_id
-    if component_id in self.test_component_ids or component_id.startswith('ResolverNode'):
+    if component_id in self.test_component_ids:
       super(BaseStubComponentLauncher,
             self)._run_executor(execution_id, input_dict, output_dict,
                                 exec_properties)

--- a/tfx/experimental/pipeline_testing/stub_component_launcher.py
+++ b/tfx/experimental/pipeline_testing/stub_component_launcher.py
@@ -12,96 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Stub component launcher which launches component executors and stub executors in process."""
+"""Stub component launcher for launching stub executors in Beam."""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-from typing import Any, Dict, List, Text, Type
-
-from tfx import types
-from tfx.components.base import base_executor
-from tfx.experimental.pipeline_testing import base_stub_executor
-from tfx.orchestration.launcher import in_process_component_launcher
+from tfx.experimental.pipeline_testing import base_stub_component_launcher
 
 
 class StubComponentLauncher(
-    in_process_component_launcher.InProcessComponentLauncher):
-  """Responsible for launching a stub executor.
-
-  The executor will be launched in the same process of the rest of the
-  component, i.e. its driver and publisher.
-  """
-
-  stubbed_component_map = ...  # type: Dict[Text, Type[base_stub_executor.BaseStubExecutor]]
-  test_data_dir = ...  # type: Text
-
-  def _run_executor(self, execution_id: int,
-                    input_dict: Dict[Text, List[types.Artifact]],
-                    output_dict: Dict[Text, List[types.Artifact]],
-                    exec_properties: Dict[Text, Any]) -> None:
-    """Execute underlying component implementation."""
-    component_id = self._component_info.component_id
-    if component_id not in self.stubbed_component_map:
-      super(StubComponentLauncher,
-            self)._run_executor(execution_id, input_dict, output_dict,
-                                exec_properties)
-    else:
-      executor_context = base_executor.BaseExecutor.Context(
-          beam_pipeline_args=self._beam_pipeline_args,
-          tmp_dir=os.path.join(self._pipeline_info.pipeline_root, '.temp', ''),
-          unique_id=str(execution_id))
-      executor = self.stubbed_component_map[component_id](component_id,
-                                                          self.test_data_dir,
-                                                          executor_context)
-      executor.Do(input_dict, output_dict, exec_properties)
-
-
-def get_stub_launcher_class(
-    test_data_dir: Text, stubbed_component_ids: List[Text],
-    stubbed_component_map: Dict[Text, Type[base_stub_executor.BaseStubExecutor]]
-) -> Type[StubComponentLauncher]:
-  """Returns a StubComponentLauncher class.
-
-  Factory method returns a StubComponentLauncher class, which then can be
-  supported by the pipeline.
-  For example:
-    class MyPusherStubExecutor(base_stub_executor.BaseStubExecutor){...}
-    class MyTransformStubExecutor(base_stub_executor.BaseStubExecutor){...}
-
-    PipelineConfig(
-        supported_launcher_classes=[
-            stub_component_launcher.get_stub_launcher_class(
-                test_data_dir,
-                stubbed_component_ids = ['CsvExampleGen'],
-                stubbed_component_map = {
-                    'Transform': MyTransformStubExecutor,
-                    'Pusher': MyPusherStubExecutor})
-        ],
-    )
-  The method also sets the necessary class variables for the
-  StubComponentLauncher class, including stubbed_component_ids and
-  stubbed_component_map holding custom executor classes, which
-  users may define differently per component.
-
-  Args:
-    test_data_dir: The directory where pipeline outputs are recorded
-      (pipeline_recorder.py).
-    stubbed_component_ids: List of component ids that should be replaced with a
-      BaseStubExecutor.
-    stubbed_component_map: Dictionary holding user-defined stub executor. These
-      user-defined stub executors must inherit from
-      base_stub_executor.BaseStubExecutor.
-
-  Returns:
-    StubComponentLauncher class holding stub executors.
-  """
-  cls = StubComponentLauncher
-  cls.stubbed_component_map = dict(stubbed_component_map)
-  for component_id in stubbed_component_ids:
-    cls.stubbed_component_map[component_id] = \
-                    base_stub_executor.BaseStubExecutor
-  cls.test_data_dir = test_data_dir
-  return cls
+    base_stub_component_launcher.BaseStubComponentLauncher):
+  """Responsible for launching stub executors in Beam."""
+  pass

--- a/tfx/experimental/pipeline_testing/stub_component_launcher_test.py
+++ b/tfx/experimental/pipeline_testing/stub_component_launcher_test.py
@@ -19,14 +19,10 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-from typing import Any, Dict, List, Text
 
-import absl
 import mock
 import tensorflow as tf
 
-from tfx import types
-from tfx.experimental.pipeline_testing import base_stub_executor
 from tfx.experimental.pipeline_testing import stub_component_launcher
 from tfx.orchestration import data_types
 from tfx.orchestration import metadata

--- a/tfx/experimental/pipeline_testing/stub_component_launcher_test.py
+++ b/tfx/experimental/pipeline_testing/stub_component_launcher_test.py
@@ -38,27 +38,6 @@ from tfx.utils import io_utils
 from ml_metadata.proto import metadata_store_pb2
 
 
-class CustomStubExecutor(base_stub_executor.BaseStubExecutor):
-  """Example of custom stub executor.
-
-  This is intended to test whether custom component's Do() is executed.
-  At success, this executor would save a file "result.txt" containing
-  a string "custom component" in the output artifacts' uri. We don't
-  rely on the default behavior of base class `BaseStubExecutor` which
-  copies test data to the output artifact.
-  """
-
-  def Do(self, input_dict: Dict[Text, List[types.Artifact]],
-         output_dict: Dict[Text, List[types.Artifact]],
-         exec_properties: Dict[Text, Any]) -> None:
-    # Don't call super().Do() to skip copying.
-    absl.logging.info('Running CustomStubExecutor')
-    for artifact_list in output_dict.values():
-      for artifact in artifact_list:
-        custom_output_path = os.path.join(artifact.uri, 'result.txt')
-        io_utils.write_string_file(custom_output_path, 'custom component')
-
-
 class StubComponentLauncherTest(tf.test.TestCase):
 
   def setUp(self):
@@ -66,7 +45,6 @@ class StubComponentLauncherTest(tf.test.TestCase):
     test_dir = os.path.join(
         os.environ.get('TEST_UNDECLARED_OUTPUTS_DIR', self.get_temp_dir()),
         self._testMethodName)
-    # test_dir = "/Users/sujipark/tfx/test"
 
     connection_config = metadata_store_pb2.ConnectionConfig()
     connection_config.sqlite.SetInParent()
@@ -98,35 +76,6 @@ class StubComponentLauncherTest(tf.test.TestCase):
         pipeline_name='Test', pipeline_root=self.pipeline_root, run_id='123')
 
   @mock.patch.object(publisher, 'Publisher')
-  def testCustomStubExecutor(self, mock_publisher):
-    # verify whether custom stub executor substitution works
-    mock_publisher.return_value.publish_execution.return_value = {}
-
-    component_map = \
-        {self.component.id: CustomStubExecutor}
-
-    my_stub_launcher = \
-        stub_component_launcher.get_stub_launcher_class(
-            test_data_dir=self.record_dir,
-            stubbed_component_ids=[],
-            stubbed_component_map=component_map)
-
-    launcher = my_stub_launcher.create(
-        component=self.component,
-        pipeline_info=self.pipeline_info,
-        driver_args=self.driver_args,
-        metadata_connection=self.metadata_connection,
-        beam_pipeline_args=[],
-        additional_pipeline_args={})
-    launcher.launch()
-
-    output_path = self.component.outputs[self.output_key].get()[0].uri
-    generated_file = os.path.join(output_path, 'result.txt')
-    self.assertTrue(tf.io.gfile.exists(generated_file))
-    contents = io_utils.read_string_file(generated_file)
-    self.assertEqual('custom component', contents)
-
-  @mock.patch.object(publisher, 'Publisher')
   def testStubExecutor(self, mock_publisher):
     # verify whether base stub executor substitution works
     mock_publisher.return_value.publish_execution.return_value = {}
@@ -134,15 +83,12 @@ class StubComponentLauncherTest(tf.test.TestCase):
     record_file = os.path.join(self.record_dir, self.component.id,
                                self.output_key, '0', 'recorded.txt')
     io_utils.write_string_file(record_file, 'hello world')
-    component_ids = [self.component.id]
 
-    my_stub_launcher = \
-        stub_component_launcher.get_stub_launcher_class(
-            test_data_dir=self.record_dir,
-            stubbed_component_ids=component_ids,
-            stubbed_component_map={})
+    stub_component_launcher.StubComponentLauncher.initialize(
+        test_data_dir=self.record_dir,
+        test_component_ids=[])
 
-    launcher = my_stub_launcher.create(
+    launcher = stub_component_launcher.StubComponentLauncher.create(
         component=self.component,
         pipeline_info=self.pipeline_info,
         driver_args=self.driver_args,
@@ -165,13 +111,11 @@ class StubComponentLauncherTest(tf.test.TestCase):
     io_utils.write_string_file(
         os.path.join(self.input_dir, 'result.txt'), 'test')
 
-    my_stub_launcher = \
-        stub_component_launcher.get_stub_launcher_class(
-            test_data_dir=self.record_dir,
-            stubbed_component_ids=[],
-            stubbed_component_map={})
+    stub_component_launcher.StubComponentLauncher.initialize(
+        test_data_dir=self.record_dir,
+        test_component_ids=[self.component.id])
 
-    launcher = my_stub_launcher.create(
+    launcher = stub_component_launcher.StubComponentLauncher.create(
         component=self.component,
         pipeline_info=self.pipeline_info,
         driver_args=self.driver_args,

--- a/tfx/experimental/templates/taxi/launcher/stub_component_launcher.py
+++ b/tfx/experimental/templates/taxi/launcher/stub_component_launcher.py
@@ -1,0 +1,47 @@
+# Lint as: python3
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stub component launcher for launching stub executors.
+
+For information on how to use stub executors for KFP pipeline, please
+refer to tfx/docs/tutorials/stub_template.md for a tutorial.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tfx.experimental.pipeline_testing import base_stub_component_launcher
+from tfx.experimental.templates.taxi.pipeline import configs
+
+
+class StubComponentLauncher(
+    base_stub_component_launcher.BaseStubComponentLauncher):
+  """Responsible for launching stub executors in KFP Template.
+
+  This stub component launcher cannot be defined within kubeflow_dag_runner.py
+  because launcher class is imported by the module path.
+  """
+  pass
+
+# GCS directory where KFP outputs are recorded
+test_data_dir = "gs://{}/testdata".format(configs.GCS_BUCKET_NAME)
+# TODO(StubExecutor): customize self.test_component_ids to test components,
+# replacing other component executors with a BaseStubExecutor
+# For example, test_component_ids = ['Trainer', 'Transform']
+test_component_ids = []
+
+StubComponentLauncher.initialize(
+    test_data_dir=test_data_dir,
+    test_component_ids=test_component_ids)


### PR DESCRIPTION
Removed stubbed_component_map, support for custom stub executors. In addition, instead of specifying ids to replace with stub executors, change to ids of components that are to be tested. 