### PR TITLE
Add test to remove fields from artifact

### DIFF
--- a/tfx/orchestration/metadata.py
+++ b/tfx/orchestration/metadata.py
@@ -182,7 +182,7 @@ class Metadata(object):
     if artifact_type.id:
       return artifact_type
     type_id = self.store.put_artifact_type(
-        artifact_type=artifact_type, can_add_fields=True)
+        artifact_type=artifact_type, can_add_fields=True, all_fields_match=False)
     artifact_type.id = type_id
     return artifact_type
 

--- a/tfx/orchestration/metadata_test.py
+++ b/tfx/orchestration/metadata_test.py
@@ -173,40 +173,16 @@ class MetadataTest(tf.test.TestCase):
       artifact.prop1 = 1
       m.publish_artifacts([artifact])
       [artifact] = m.store.get_artifacts()
-      # # Skip verifying time sensitive fields.
-      # artifact.ClearField('create_time_since_epoch')
-      # artifact.ClearField('last_update_time_since_epoch')
-      # self.assertProtoEquals(
-      #     """id: 1
-      #   type_id: 1
-      #   uri: "uri"
-      #   properties {
-      #     key: "split_names"
-      #     value {
-      #       string_value: "[\\"train\\", \\"eval\\"]"
-      #     }
-      #   }
-      #   custom_properties {
-      #     key: "state"
-      #     value {
-      #       string_value: "published"
-      #     }
-      #   }
-      #   state: LIVE
-      #   """, artifact)
+      self.assertListEqual([artifact], m.get_artifacts_by_uri('uri'))
+      self.assertListEqual([artifact],
+                           m.get_artifacts_by_type(
+                               TestArtifact.TYPE_NAME))
 
-      # # Test get artifact.
-      # [artifact] = m.store.get_artifacts()
-      # self.assertListEqual([artifact], m.get_artifacts_by_uri('uri'))
-      # self.assertListEqual([artifact],
-      #                      m.get_artifacts_by_type(
-      #                          standard_artifacts.Examples.TYPE_NAME))
-
-      # # Test artifact state.
-      # self.assertEqual(artifact.state, metadata_store_pb2.Artifact.LIVE)
-      # self._check_artifact_state(m, artifact, ArtifactState.PUBLISHED)
-      # m.update_artifact_state(artifact, ArtifactState.DELETED)
-      # self._check_artifact_state(m, artifact, ArtifactState.DELETED)
+      # Test artifact state.
+      self.assertEqual(artifact.state, metadata_store_pb2.Artifact.LIVE)
+      self._check_artifact_state(m, artifact, ArtifactState.PUBLISHED)
+      m.update_artifact_state(artifact, ArtifactState.DELETED)
+      self._check_artifact_state(m, artifact, ArtifactState.DELETED)
 
   def testExecution(self):
     with metadata.Metadata(connection_config=self._connection_config) as m:


### PR DESCRIPTION
In https://github.com/tensorflow/tfx/issues/2506 we have detected an issue when running BigQueryExampleGen in different versions of TFX. After reviewing some code I wanted to check if the issue was in registering Artifacts where fields have been removed. It seems so. 

This PR will be updated with a fix. Current added test fails to run which allows us to figure out a solution.