### PR TITLE
Fix serialization of Transform.custom_config

### DIFF
--- a/tfx/components/transform/component.py
+++ b/tfx/components/transform/component.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import json
 from typing import Any, Dict, Optional, Text, Union
 
 import absl
@@ -29,6 +28,7 @@ from tfx.orchestration import data_types
 from tfx.proto import transform_pb2
 from tfx.types import standard_artifacts
 from tfx.types.standard_component_specs import TransformSpec
+from tfx.utils import json_utils
 
 
 class Transform(base_component.BaseComponent):
@@ -184,5 +184,5 @@ class Transform(base_component.BaseComponent):
         transformed_examples=transformed_examples,
         analyzer_cache=analyzer_cache,
         updated_analyzer_cache=updated_analyzer_cache,
-        custom_config=json.dumps(custom_config))
+        custom_config=json_utils.dumps(custom_config))
     super(Transform, self).__init__(spec=spec, instance_name=instance_name)

--- a/tfx/components/transform/executor.py
+++ b/tfx/components/transform/executor.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 
 import functools
 import hashlib
-import json
 import os
 from typing import Any, Dict, Generator, Iterable, List, Mapping, Optional, Sequence, Set, Text, Tuple, Union
 
@@ -50,6 +49,7 @@ from tfx.proto import transform_pb2
 from tfx.types import artifact_utils
 from tfx.utils import import_utils
 from tfx.utils import io_utils
+from tfx.utils import json_utils
 import tfx_bsl
 from tfx_bsl.tfxio import tfxio as tfxio_module
 
@@ -792,7 +792,7 @@ class Executor(base_executor.BaseExecutor):
     if value_utils.FunctionHasArg(fn, labels.CUSTOM_CONFIG):
       custom_config_json = value_utils.GetSoleValue(inputs,
                                                     labels.CUSTOM_CONFIG)
-      custom_config = (json.loads(
+      custom_config = (json_utils.loads(
           custom_config_json) if custom_config_json else {}) or {}
       result = functools.partial(fn, custom_config=custom_config)
     else:


### PR DESCRIPTION
Use `tfx.utils.json_utils.dumps()` instead of `json.dumps()` to correctly serialize `RuntimeParameter` values.