### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tfx/experimental/templates/test_utils.py
+++ b/tfx/experimental/templates/test_utils.py
@@ -117,7 +117,7 @@ class BaseEndToEndTest(tf.test.TestCase):
       long indented line
     # OTHER STUFF
 
-    Arguments:
+    Args:
       filepath: file to modify.
       variables: List of variables.
 

--- a/tfx/tools/build_docs.py
+++ b/tfx/tools/build_docs.py
@@ -68,7 +68,7 @@ FLAGS = flags.FLAGS
 def ignore_test_objects(path, parent, children):
   """Removes all "test" modules. These are not part of the public api.
 
-  Arguments:
+  Args:
     path: A tuple of name parts forming the attribute-lookup path to this
       object. For `tf.keras.layers.Dense` path is:
         ("tf","keras","layers","Dense")


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420