### PR TITLE
Add support for  RuntimeParams in airflow and template resolution for exec_properties

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -122,6 +122,9 @@ venv.bak/
 # Intellij project settings
 .idea
 
+# VSCode project settings
+.vscode
+
 # mkdocs documentation
 /site
 

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ venv.bak/
 # Intellij project settings
 .idea
 
+# VSCode project settings
+.vscode
+
 # mkdocs documentation
 /site
 

--- a/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_simple.py
+++ b/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_simple.py
@@ -32,6 +32,7 @@ from tfx.components import StatisticsGen
 from tfx.components import Trainer
 from tfx.components import Transform
 from tfx.dsl.experimental import latest_blessed_model_resolver
+from tfx.orchestration import data_types
 from tfx.orchestration import metadata
 from tfx.orchestration import pipeline
 from tfx.orchestration.airflow.airflow_dag_runner import AirflowDagRunner
@@ -85,8 +86,11 @@ def _create_pipeline(pipeline_name: Text, pipeline_root: Text, data_root: Text,
                      metadata_path: Text,
                      beam_pipeline_args: List[Text]) -> pipeline.Pipeline:
   """Implements the chicago taxi pipeline with TFX."""
+  data_root_runtime = data_types.RuntimeParameter(
+    'data_root', default=data_root
+  )
   # Brings data into the pipeline or otherwise joins/converts training data.
-  example_gen = CsvExampleGen(input_base=data_root)
+  example_gen = CsvExampleGen(input_base=data_root_runtime)
 
   # Computes statistics over data for visualization and example validation.
   statistics_gen = StatisticsGen(examples=example_gen.outputs['examples'])

--- a/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_simple.py
+++ b/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_simple.py
@@ -86,9 +86,11 @@ def _create_pipeline(pipeline_name: Text, pipeline_root: Text, data_root: Text,
                      metadata_path: Text,
                      beam_pipeline_args: List[Text]) -> pipeline.Pipeline:
   """Implements the chicago taxi pipeline with TFX."""
+  # Parametrize data root so it can be replaced on runtime.
   data_root_runtime = data_types.RuntimeParameter(
-    'data_root', default=data_root
+    'data_root', ptype=str, default=data_root
   )
+
   # Brings data into the pipeline or otherwise joins/converts training data.
   example_gen = CsvExampleGen(input_base=data_root_runtime)
 

--- a/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_simple.py
+++ b/tfx/examples/chicago_taxi_pipeline/taxi_pipeline_simple.py
@@ -87,6 +87,8 @@ def _create_pipeline(pipeline_name: Text, pipeline_root: Text, data_root: Text,
                      beam_pipeline_args: List[Text]) -> pipeline.Pipeline:
   """Implements the chicago taxi pipeline with TFX."""
   # Parametrize data root so it can be replaced on runtime.
+  # See: https://airflow.apache.org/docs/apache-airflow/stable/dag-run.html#passing-parameters-when-triggering-dags 
+  # for more details.
   data_root_runtime = data_types.RuntimeParameter(
     'data_root', ptype=str, default=data_root
   )

--- a/tfx/orchestration/airflow/airflow_component.py
+++ b/tfx/orchestration/airflow/airflow_component.py
@@ -58,6 +58,8 @@ def _airflow_component_launcher(
       For more details, please refer to the code:
       https://github.com/apache/airflow/blob/master/airflow/operators/python_operator.py
   """
+  component.spec.exec_properties.update(kwargs['exec_properties'])
+
   # Populate run id from Airflow task instance.
   pipeline_info.run_id = kwargs['ti'].get_dagrun().run_id
   launcher = component_launcher_class.create(
@@ -106,6 +108,8 @@ class AirflowComponent(python_operator.PythonOperator):
     # Prepare parameters to create TFX worker.
     driver_args = data_types.DriverArgs(enable_cache=enable_cache)
 
+    exec_properties = component.spec.exec_properties
+
     super(AirflowComponent, self).__init__(
         task_id=component.id,
         # TODO(b/183172663): Delete `provide_context` when we drop support of
@@ -121,4 +125,5 @@ class AirflowComponent(python_operator.PythonOperator):
             beam_pipeline_args=beam_pipeline_args,
             additional_pipeline_args=additional_pipeline_args,
             component_config=component_config),
+        op_kwargs={'exec_properties': exec_properties},
         dag=parent_dag)

--- a/tfx/orchestration/airflow/airflow_component.py
+++ b/tfx/orchestration/airflow/airflow_component.py
@@ -110,7 +110,7 @@ class AirflowComponent(python_operator.PythonOperator):
     # Prepare parameters to create TFX worker.
     driver_args = data_types.DriverArgs(enable_cache=enable_cache)
 
-    exec_properties = component.spec.exec_properties
+    exec_properties = component.exec_properties
 
     super(AirflowComponent, self).__init__(
         task_id=component.id,

--- a/tfx/orchestration/airflow/airflow_component.py
+++ b/tfx/orchestration/airflow/airflow_component.py
@@ -127,5 +127,7 @@ class AirflowComponent(python_operator.PythonOperator):
             beam_pipeline_args=beam_pipeline_args,
             additional_pipeline_args=additional_pipeline_args,
             component_config=component_config),
+        # op_kwargs is a templated field for PythonOperator, which means Airflow
+        # will inspect the dictionary and resolve any templated fields.
         op_kwargs={'exec_properties': exec_properties},
         dag=parent_dag)

--- a/tfx/orchestration/airflow/airflow_component.py
+++ b/tfx/orchestration/airflow/airflow_component.py
@@ -35,6 +35,7 @@ def _airflow_component_launcher(
     metadata_connection_config: metadata_store_pb2.ConnectionConfig,
     beam_pipeline_args: List[Text], additional_pipeline_args: Dict[Text, Any],
     component_config: base_component_config.BaseComponentConfig,
+    exec_properties: Dict,
     **kwargs) -> None:
   """Helper function to launch TFX component execution.
 
@@ -52,13 +53,14 @@ def _airflow_component_launcher(
     beam_pipeline_args: Pipeline arguments for Beam powered Components.
     additional_pipeline_args: A dict of additional pipeline args.
     component_config: Component config to launch the component.
+    exec_properties: Execution properties from the ComponentSpec
     **kwargs: Context arguments that will be passed in by Airflow, including:
       - ti: TaskInstance object from which we can get run_id of the running
         pipeline.
       For more details, please refer to the code:
       https://github.com/apache/airflow/blob/master/airflow/operators/python_operator.py
   """
-  component.spec.exec_properties.update(kwargs['exec_properties'])
+  component.spec.exec_properties.update(exec_properties)
 
   # Populate run id from Airflow task instance.
   pipeline_info.run_id = kwargs['ti'].get_dagrun().run_id

--- a/tfx/orchestration/airflow/airflow_component.py
+++ b/tfx/orchestration/airflow/airflow_component.py
@@ -60,7 +60,7 @@ def _airflow_component_launcher(
       For more details, please refer to the code:
       https://github.com/apache/airflow/blob/master/airflow/operators/python_operator.py
   """
-  component.spec.exec_properties.update(exec_properties)
+  component.exec_properties.update(exec_properties)
 
   # Populate run id from Airflow task instance.
   pipeline_info.run_id = kwargs['ti'].get_dagrun().run_id

--- a/tfx/orchestration/airflow/airflow_dag_runner.py
+++ b/tfx/orchestration/airflow/airflow_dag_runner.py
@@ -117,7 +117,7 @@ class AirflowDagRunner(tfx_runner.TfxRunner):
 
 
   def _replace_runtime_params(self, comp):
-    for k, prop in comp.spec.exec_properties.copy().items():
+    for k, prop in comp.exec_properties.copy().items():
       if isinstance(prop, RuntimeParameter):
 
         # Airflow only supports string parameters.
@@ -135,7 +135,7 @@ class AirflowDagRunner(tfx_runner.TfxRunner):
 
         # Todo: Once we move to Airflow 2.0 we should instead use airflow.models.DagParam class.
         template_field = f'{{{{ dag_run.conf.get("{prop.name}", {default}) }}}}'
-        comp.spec.exec_properties[k] = template_field
+        comp.exec_properties[k] = template_field
     return comp
 
       

--- a/tfx/orchestration/airflow/airflow_dag_runner.py
+++ b/tfx/orchestration/airflow/airflow_dag_runner.py
@@ -64,7 +64,8 @@ class AirflowDagRunner(tfx_runner.TfxRunner):
     """
     if config and not isinstance(config, AirflowPipelineConfig):
       absl.logging.warning(
-          'Pass config as a dict type is going to deprecated in 0.1.16. Use AirflowPipelineConfig type instead.',
+          'Pass config as a dict type is going to deprecated in 0.1.16. '
+          'Use AirflowPipelineConfig type instead.',
           PendingDeprecationWarning)
       config = AirflowPipelineConfig(airflow_dag_config=config)
     super(AirflowDagRunner, self).__init__(config)
@@ -137,5 +138,4 @@ class AirflowDagRunner(tfx_runner.TfxRunner):
         template_field = f'{{{{ dag_run.conf.get("{prop.name}", {default}) }}}}'
         comp.exec_properties[k] = template_field
     return comp
-
-      
+    

--- a/tfx/orchestration/airflow/airflow_dag_runner_test.py
+++ b/tfx/orchestration/airflow/airflow_dag_runner_test.py
@@ -210,8 +210,8 @@ class AirflowDagRunnerTest(tf.test.TestCase):
 
     self.assertEqual(airflow_config, runner._config.airflow_dag_config)
 
-  def testRuntimParam(self):
-    param = RuntimeParameter('name', str, 'tfx')
+  def testRuntimeParam(self):
+    param = RuntimeParameter('name', str, 'tf"x')
     component_f = _FakeComponent(_FakeComponentSpecF(a=param))
     airflow_config = {
         'schedule_interval': '* * * * *',
@@ -230,9 +230,9 @@ class AirflowDagRunnerTest(tf.test.TestCase):
             airflow_dag_config=airflow_config))
     dag = runner.run(test_pipeline)
     task = dag.tasks[0]
-    self.assertDictEqual({'exec_properties':{'a':'{{ dag_run.conf.get("name", "tfx") }}'}}, task.op_kwargs)
+    self.assertDictEqual({'exec_properties':{'a':'{{ dag_run.conf.get("name", "tf\\"x") }}'}}, task.op_kwargs)
 
-  def testRuntimParamTemplated(self):
+  def testRuntimeParamTemplated(self):
     param = RuntimeParameter('name', str, '{{execution_date}}')
     component_f = _FakeComponent(_FakeComponentSpecF(a=param))
     airflow_config = {
@@ -254,7 +254,7 @@ class AirflowDagRunnerTest(tf.test.TestCase):
     task = dag.tasks[0]
     self.assertDictEqual({'exec_properties':{'a':'{{ dag_run.conf.get("name", execution_date) }}'}}, task.op_kwargs)
 
-  def testRuntimParamIntError(self):
+  def testRuntimeParamIntError(self):
     param = RuntimeParameter('name', int, 1)
     component_f = _FakeComponent(_FakeComponentSpecG(a=param))
     airflow_config = {

--- a/tfx/orchestration/airflow/airflow_dag_runner_test.py
+++ b/tfx/orchestration/airflow/airflow_dag_runner_test.py
@@ -230,10 +230,13 @@ class AirflowDagRunnerTest(tf.test.TestCase):
             airflow_dag_config=airflow_config))
     dag = runner.run(test_pipeline)
     task = dag.tasks[0]
-    self.assertDictEqual({'exec_properties':{'a':'{{ dag_run.conf.get("name", "tf\\"x") }}'}}, task.op_kwargs)
+    self.assertDictEqual(
+      {'exec_properties':{'a':'{{ dag_run.conf.get("name", "tf\\"x") }}'}},
+      task.op_kwargs
+    )
 
   def testRuntimeParamTemplated(self):
-    param = RuntimeParameter('name', str, '{{execution_date}}')
+    param = RuntimeParameter('a', str, '{{execution_date}}')
     component_f = _FakeComponent(_FakeComponentSpecF(a=param))
     airflow_config = {
         'schedule_interval': '* * * * *',
@@ -252,7 +255,10 @@ class AirflowDagRunnerTest(tf.test.TestCase):
             airflow_dag_config=airflow_config))
     dag = runner.run(test_pipeline)
     task = dag.tasks[0]
-    self.assertDictEqual({'exec_properties':{'a':'{{ dag_run.conf.get("name", execution_date) }}'}}, task.op_kwargs)
+    self.assertDictEqual(
+      {'exec_properties':{'a':'{{ dag_run.conf.get("a", execution_date) }}'}},
+      task.op_kwargs
+    )
 
   def testRuntimeParamIntError(self):
     param = RuntimeParameter('name', int, 1)
@@ -273,7 +279,7 @@ class AirflowDagRunnerTest(tf.test.TestCase):
         airflow_dag_runner.AirflowPipelineConfig(
             airflow_dag_config=airflow_config)
       ).run(test_pipeline)
-    
+
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
**Template resolution for exec_properties**
AirflowDagRunner was using `functools.partial` for exec_properties, which meant that Airflow can't resolved templated fields. By setting it as a `op_kwarg` it resolves recursively the dictionary if it finds any resolvable string. This allows you to parametrize your operator by using `{{execution_ds}}` as you in any normal Airflow DAG.

**Support for RuntimeParams**
Airflow supports parametrizing a DagRun as seen [here](https://airflow.apache.org/docs/apache-airflow/stable/dag-run.html#dagrun-parameters). This is further improved in Airflow 2.0 by adding [DagParam class](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dagparam/index.html#module-airflow.models.dagparam). This allows users to parametrize a run by using the manual trigger options. Current option is backwards compatible, we should migrate to DagParam and Airflow 2.0 though for easier composability.


----
Missing pieces: 

- [x] Add tests for new code (tested on a local Airflow instance, but missing adding unit tests still)
- [x] Add disclaimer on DagParam support
- [x] Add E2E test for AirflowDagRunner


CC @1025KB @zhitaoli 