### PR TITLE
Adds numpy dependency to TFX to cap numpy version to <1.20.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,27 @@
-# Version 0.26.1
+# Version 0.27.0
 
-*   This a bug fix only version
 ## Major Features and Improvements
 
-*   N/A
+*   Supports different types of quantizations on TFLite conversion using
+    TFLITE_REWRITER by setting `quantization_optimizations`,
+    `quantization_supported_types` and `quantization_enable_full_integer`. Flag
+    definitions can be found here: [Post-traning
+    quantization](https://www.tensorflow.org/lite/performance/post_training_quantization).
+*   Added automatic population of `tfdv.StatsOptions.vocab_paths` when computing
+    statistics within the Transform component.
 
 ## Breaking changes
 
-*   N/A
-
 ### For pipeline authors
 
-*   N/A
+*   `enable_quantization` from TFLITE_REWRITER is removed and setting
+    quantization_optimizations = [tf.lite.Optimize.DEFAULT] will perform the
+    same type of quantization, dynamic range quantization. Users of the
+    TFLITE_REWRITER who do not enable quantization should be uneffected.
+*   Default value for `infer_feature_shape` for SchemaGen changed from `False`
+    to `True`, as indicated in previous release log. The inferred schema might
+    change if you do not specify `infer_feature_shape`. It might leads to
+    changes of the type of input features in Transform and Trainer code.
 
 ### For component authors
 
@@ -19,11 +29,53 @@
 
 ## Deprecations
 
-*   N/A
+*   Pipeline information is not be stored on the local filesystem anymore using
+    Kubeflow Pipelines orchestration with CLI. Instead, CLI will always use the
+    latest version of the pipeline in the Kubeflow Pipeline cluster. All
+    operations will be executed based on the information on the Kubeflow
+    Pipeline cluster. There might be some left files on
+    `${HOME}/tfx/kubeflow` or `${HOME}/kubeflow` but those will not be used
+    any more.
+*   The `tfx.components.common_nodes.importer_node.ImporterNode` class has been
+    moved to `tfx.dsl.components.common.importer.Importer`, with its
+    old module path kept as a deprecated alias, which will be removed in a
+    future version.
+*   The `tfx.components.common_nodes.resolver_node.ResolverNode` class has been
+    moved to `tfx.dsl.components.common.resolver.Resolver`, with its
+    old module path kept as a deprecated alias, which will be removed in a
+    future version.
+*   The `tfx.dsl.resolvers.BaseResolver` class has been
+    moved to `tfx.dsl.components.common.resolver.ResolverStrategy`, with its
+    old module path kept as a deprecated alias, which will be removed in a
+    future version.
+*   Deprecated input/output compatibility aliases for ExampleValidator,
+    Evaluator, Trainer and Pusher.
 
 ## Bug fixes and other changes
 
-*   The tfx.__version__ attribute was restored.
+*   InfraValidator supports using alternative TensorFlow Serving image in case
+    deployed environment cannot reach the public internet (nor the docker hub).
+    Such alternative image should behave the same as official
+    `tensorflow/serving` image such as the same model volume path, serving port,
+    etc.
+*   Executor in `tfx.extensions.google_cloud_ai_platform.pusher.executor`
+    supported regional endpoint and machine_type.
+*   Starting from this version, proto files which are used to generate
+    component-level configs are included in the `tfx` package directly.
+*   The `tfx.dsl.io.fileio.NotFoundError` exception unifies handling of not-
+    found errors across different filesystem plugin backends.
+*   Fixes the serialization of zero-valued default when using `RuntimeParameter`
+    on Kubeflow.
+*   Depends on `apache-beam[gcp]>=2.27,<3`.
+*   Depends on `ml-metadata>=0.27.0,<0.28.0`.
+*   Depends on `numpy>=1.16,<1.20`.
+*   Depends on `pyarrow>=1,<3`.
+*   Depends on `tensorflow>=1.15.2,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,<3`.
+*   Depends on `tensorflow-data-validation>=0.27.0,<0.28.0`.
+*   Depends on `tensorflow-model-analysis>=0.27.0,<0.28.0`.
+*   Depends on `tensorflow-serving-api>=1.15,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,<3`.
+*   Depends on `tensorflow-transform>=0.27.0,<0.28.0`.
+*   Depends on `tfx-bsl>=0.27.0,<0.28.0`.
 
 ## Documentation updates
 

--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -83,7 +83,10 @@ def make_required_install_packages():
       # dependency expecatation with TensorFlow is sorted out.
       'keras-tuner>=1,<1.0.2',
       'kubernetes>=10.0.1,<12',
-      'pyarrow>=0.17,<0.18',
+      # TODO(b/179195488): remove numpy dependency after 1.20 migration.
+      # This dependency was added only to limit numpy 1.20 installation.
+      'numpy>=1.16,<1.20',
+      'pyarrow>=1,<3',
       'pyyaml>=3.12,<6',
       'tensorflow>=1.15.2,!=2.0.*,!=2.1.*,!=2.2.*,!=2.4.*,<3',
       'tensorflow-hub>=0.9.0,<0.10',


### PR DESCRIPTION
This changes doesn't actually add a new dependency to TFX, because many dependent libraries have numpy dependency. The purpose of this change is only to limit the versions installed with TFX.

PiperOrigin-RevId: 355319099