### PR TITLE
Adds numpy dependency to TFX to cap numpy version to <1.20.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,6 +68,7 @@
     on Kubeflow.
 *   Depends on `apache-beam[gcp]>=2.27,<3`.
 *   Depends on `ml-metadata>=0.27.0,<0.28.0`.
+*   Depends on `numpy>=1.16,<1.20`.
 *   Depends on `pyarrow>=1,<3`.
 *   Depends on `tensorflow>=1.15.2,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,<3`.
 *   Depends on `tensorflow-data-validation>=0.27.0,<0.28.0`.

--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -83,6 +83,9 @@ def make_required_install_packages():
       # dependency expecatation with TensorFlow is sorted out.
       'keras-tuner>=1,<1.0.2',
       'kubernetes>=10.0.1,<12',
+      # TODO(b/179195488): remove numpy dependency after 1.20 migration.
+      # This dependency was added only to limit numpy 1.20 installation.
+      'numpy>=1.16,<1.20',
       'pyarrow>=1,<3',
       'pyyaml>=3.12,<6',
       'tensorflow>=1.15.2,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,<3',


### PR DESCRIPTION
This changes doesn't actually add a new dependency to TFX, because many dependent libraries have numpy dependency. The purpose of this change is only to limit the versions installed with TFX.

PiperOrigin-RevId: 355319099