### PR TITLE
Add configuration option for project used in BQ pusher

### DIFF
--- a/tfx/extensions/google_cloud_big_query/pusher/executor.py
+++ b/tfx/extensions/google_cloud_big_query/pusher/executor.py
@@ -41,6 +41,9 @@ _PROJECT_ID_KEY = 'project_id'
 _BQ_DATASET_ID_KEY = 'bq_dataset_id'
 _MODEL_NAME_KEY = 'model_name'
 
+# Project where query will be executed
+_COMPUTE_PRROJECT_ID_KEY = 'compute_project_id'
+
 # Keys for custom_config.
 _CUSTOM_CONFIG_KEY = 'custom_config'
 
@@ -130,7 +133,11 @@ class Executor(tfx_pusher_executor.Executor):
         {telemetry_utils.LABEL_TFX_EXECUTOR: executor_class_path}):
       default_query_job_config = bigquery.job.QueryJobConfig(
           labels=telemetry_utils.get_labels_dict())
-    client = bigquery.Client(default_query_job_config=default_query_job_config)
+
+    project_id = bigquery_serving_args.get(_COMPUTE_PRROJECT_ID_KEY)
+    client = bigquery.Client(
+         default_query_job_config=default_query_job_config, project=project_id
+    )
 
     try:
       query_job = client.query(query)


### PR DESCRIPTION
Add a way to configure what project the query is run for BQ Pusher. This allows for more flexible configuration without requiring to set an environment variable.