### PR TITLE
Support fetching beam args at runtime from env vars. Fixes issue #3326

### DIFF
--- a/tfx/orchestration/kubeflow/container_entrypoint.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint.py
@@ -309,7 +309,7 @@ def _get_beam_args_from_env(beam_pipeline_args, additional_pipeline_args) -> \
       if beam_pipeline_arg in supplied_beam_pipeline_args:
         logging.info('Arg %s already present in '
                      'beam_pipeline_args and will not be fetched from env.',
-                     beam_pipeline_args)
+                     beam_pipeline_arg)
       else:
         env_var_value = os.environ.get(env_var, None)
         if env_var_value:
@@ -317,7 +317,7 @@ def _get_beam_args_from_env(beam_pipeline_args, additional_pipeline_args) -> \
                   .format(beam_pipeline_arg, env_var_value))
         else:
           logging.info('Env var %s not present. Skipping corresponding beam arg'
-                       ': %s.', env_var, beam_pipeline_args)
+                       ': %s.', env_var, beam_pipeline_arg)
   return list(beam_pipeline_args_from_env_set)
 
 
@@ -357,13 +357,13 @@ def main():
       _get_metadata_connection_config(kubeflow_metadata_config))
   driver_args = data_types.DriverArgs(enable_cache=args.enable_cache)
 
-  additional_pipeline_args = json.loads(args.additional_pipeline_args)
-
   beam_pipeline_args = json.loads(args.beam_pipeline_args)
 
-  beam_pipeline_args_from_env_set = _get_beam_args_from_env(beam_pipeline_args,
+  additional_pipeline_args = json.loads(args.additional_pipeline_args)
+
+  beam_pipeline_args_from_env = _get_beam_args_from_env(beam_pipeline_args,
                                                     additional_pipeline_args)
-  beam_pipeline_args += list(beam_pipeline_args_from_env_set)
+  beam_pipeline_args += beam_pipeline_args_from_env
 
   launcher = component_launcher_class.create(
       component=component,

--- a/tfx/orchestration/kubeflow/container_entrypoint.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint.py
@@ -294,7 +294,7 @@ def _dump_ui_metadata(component: base_node.BaseNode,
     json.dump(metadata, f)
 
 
-def _add_beam_args_from_env(beam_pipeline_args, additional_pipeline_args):
+def _get_beam_args_from_env(beam_pipeline_args, additional_pipeline_args):
   beam_pipeline_args_from_env_set = set()
   if BEAM_PIPELINE_ARGS_FROM_ENV in additional_pipeline_args:
     beam_pipeline_args_from_env = additional_pipeline_args[
@@ -360,7 +360,7 @@ def main():
 
   beam_pipeline_args = json.loads(args.beam_pipeline_args)
 
-  beam_pipeline_args_from_env_set = _add_beam_args_from_env(beam_pipeline_args,
+  beam_pipeline_args_from_env_set = _get_beam_args_from_env(beam_pipeline_args,
                                                     additional_pipeline_args)
   beam_pipeline_args += list(beam_pipeline_args_from_env_set)
 

--- a/tfx/orchestration/kubeflow/container_entrypoint.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint.py
@@ -294,7 +294,8 @@ def _dump_ui_metadata(component: base_node.BaseNode,
     json.dump(metadata, f)
 
 
-def _get_beam_args_from_env(beam_pipeline_args, additional_pipeline_args):
+def _get_beam_args_from_env(beam_pipeline_args, additional_pipeline_args) -> \
+        list:
   beam_pipeline_args_from_env_set = set()
   if BEAM_PIPELINE_ARGS_FROM_ENV in additional_pipeline_args:
     beam_pipeline_args_from_env = additional_pipeline_args[
@@ -307,13 +308,13 @@ def _get_beam_args_from_env(beam_pipeline_args, additional_pipeline_args):
       # over env vars.
       if beam_pipeline_arg in supplied_beam_pipeline_args:
         logging.info('Arg %s already present in '
-                     'beam_pipeline_args and will not be fetched from env.'
-            , beam_pipeline_args)
+                     'beam_pipeline_args and will not be fetched from env.',
+                     beam_pipeline_args)
       else:
         env_var_value = os.environ.get(env_var, None)
         if env_var_value:
           beam_pipeline_args_from_env_set.add('--{}={}'
-                  .format(beam_pipeline_args, env_var_value))
+                  .format(beam_pipeline_arg, env_var_value))
         else:
           logging.info('Env var %s not present. Skipping corresponding beam arg'
                        ': %s.', env_var, beam_pipeline_args)

--- a/tfx/orchestration/kubeflow/container_entrypoint_test.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint_test.py
@@ -79,5 +79,30 @@ class MLMDConfigTest(tf.test.TestCase):
     self.assertEqual(ml_metadata_config.port, 8080)
 
 
+class BeamArgsTest(tf.test.TestCase):
+
+  def testResolveBeamArgs(self):
+    self._set_required_env_vars({
+      'S3_SECRET_ACCESS_KEY': 'minio123',
+      'S3_VERIFY': '1',
+    })
+
+    beam_pipeline_args = [f'--s3_endpoint_url=s3_endpoint_url',
+                          f'--s3_access_key_id=minio',
+                          's3_verify=0'
+                          ]
+    additional_pipeline_args = {'foo': 'bar',
+                                'beam_pipeline_args_from_env': {'s3_secret_access_key': 'S3_SECRET_ACCESS_KEY',
+                                                                's3_verify': 'S3_VERIFY'}}
+
+    updated_beam_pipeline_args = container_entrypoint._add_beam_args_from_env(beam_pipeline_args=beam_pipeline_args,
+                                                                              additional_pipeline_args=
+                                                                              additional_pipeline_args)
+    self.assertEqual(set(updated_beam_pipeline_args), {f'--s3_endpoint_url=s3_endpoint_url',
+                                                       f'--s3_access_key_id=minio',
+                                                       f'--s3_secret_access_key=minio123',
+                                                       's3_verify=0'})
+
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tfx/orchestration/kubeflow/container_entrypoint_test.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint_test.py
@@ -101,8 +101,7 @@ class BeamArgsTest(tf.test.TestCase):
 
     beam_pipeline_args_from_env = container_entrypoint._get_beam_args_from_env(
         beam_pipeline_args=beam_pipeline_args,
-        additional_pipeline_args=
-        additional_pipeline_args)
+        additional_pipeline_args=additional_pipeline_args)
     self.assertEqual(set(beam_pipeline_args + beam_pipeline_args_from_env),
                      {'--s3_endpoint_url=s3_endpoint_url',
                       '--s3_access_key_id=minio',

--- a/tfx/orchestration/kubeflow/container_entrypoint_test.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint_test.py
@@ -92,17 +92,17 @@ class BeamArgsTest(tf.test.TestCase):
 
     beam_pipeline_args = ['--s3_endpoint_url=s3_endpoint_url',
                           '--s3_access_key_id=minio',
-                          's3_verify=0'
+                          '--s3_verify=0'
                           ]
     additional_pipeline_args = {'foo': 'bar',
-                                container_entrypoint.BEAM_PIPELINE_ARGS_FROM_ENV
-                                :
+                                'beam_pipeline_args_from_env':
                                 {'s3_secret_access_key': 'S3_SECRET_ACCESS_KEY',
                                  's3_verify': 'S3_VERIFY'}}
 
     beam_pipeline_args_from_env = container_entrypoint._get_beam_args_from_env(
         beam_pipeline_args=beam_pipeline_args,
-        additional_pipeline_args=additional_pipeline_args)
+        additional_pipeline_args=
+        additional_pipeline_args)
     self.assertEqual(set(beam_pipeline_args + beam_pipeline_args_from_env),
                      {'--s3_endpoint_url=s3_endpoint_url',
                       '--s3_access_key_id=minio',

--- a/tfx/orchestration/kubeflow/container_entrypoint_test.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint_test.py
@@ -66,8 +66,10 @@ class MLMDConfigTest(tf.test.TestCase):
     })
 
     grpc_config = kubeflow_pb2.KubeflowGrpcMetadataConfig()
-    grpc_config.grpc_service_host.environment_variable = 'METADATA_GRPC_SERVICE_HOST'
-    grpc_config.grpc_service_port.environment_variable = 'METADATA_GRPC_SERVICE_PORT'
+    grpc_config.grpc_service_host.environment_variable = \
+        'METADATA_GRPC_SERVICE_HOST'
+    grpc_config.grpc_service_port.environment_variable = \
+        'METADATA_GRPC_SERVICE_PORT'
     metadata_config = kubeflow_pb2.KubeflowMetadataConfig()
     metadata_config.grpc_config.CopyFrom(grpc_config)
 
@@ -81,27 +83,30 @@ class MLMDConfigTest(tf.test.TestCase):
 
 class BeamArgsTest(tf.test.TestCase):
 
-  def testResolveBeamArgs(self):
+  def testResolveBeamArgsFromEnv(self):
     self._set_required_env_vars({
       'S3_SECRET_ACCESS_KEY': 'minio123',
       'S3_VERIFY': '1',
     })
 
-    beam_pipeline_args = [f'--s3_endpoint_url=s3_endpoint_url',
-                          f'--s3_access_key_id=minio',
+    beam_pipeline_args = ['--s3_endpoint_url=s3_endpoint_url',
+                          '--s3_access_key_id=minio',
                           's3_verify=0'
                           ]
     additional_pipeline_args = {'foo': 'bar',
-                                'beam_pipeline_args_from_env': {'s3_secret_access_key': 'S3_SECRET_ACCESS_KEY',
-                                                                's3_verify': 'S3_VERIFY'}}
+                                container_entrypoint.BEAM_PIPELINE_ARGS_FROM_ENV
+                                :
+                                {'s3_secret_access_key': 'S3_SECRET_ACCESS_KEY',
+                                 's3_verify': 'S3_VERIFY'}}
 
-    updated_beam_pipeline_args = container_entrypoint._add_beam_args_from_env(beam_pipeline_args=beam_pipeline_args,
-                                                                              additional_pipeline_args=
-                                                                              additional_pipeline_args)
-    self.assertEqual(set(updated_beam_pipeline_args), {f'--s3_endpoint_url=s3_endpoint_url',
-                                                       f'--s3_access_key_id=minio',
-                                                       f'--s3_secret_access_key=minio123',
-                                                       's3_verify=0'})
+    updated_beam_pipeline_args = container_entrypoint._add_beam_args_from_env(
+        beam_pipeline_args=beam_pipeline_args,
+        additional_pipeline_args=additional_pipeline_args)
+    self.assertEqual(set(updated_beam_pipeline_args),
+                     {'--s3_endpoint_url=s3_endpoint_url',
+                      '--s3_access_key_id=minio',
+                      '--s3_secret_access_key=minio123',
+                      's3_verify=0'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, TFX only support passing Beam args as static values defined at pipeline compile time. This is undesirable since one Beam needs to pass credentials to in order to use certain file systems, e.g. S3. 

This PR allows Beam args to be populated from environment variables, which in turn can be populated by k8s secrets, and hence leaves no credentials visible in code nor pipeline definition yaml files. 

This PR fixes the issues for beam args highlighted in: https://github.com/tensorflow/tfx/issues/3326 