### PR TITLE
Update run_fn -> trainer_fn for penguin example

### DIFF
--- a/tfx/examples/penguin/penguin_utils.py
+++ b/tfx/examples/penguin/penguin_utils.py
@@ -206,7 +206,7 @@ def tuner_fn(fn_args: FnArgs) -> TunerFnResult:
 
 
 # TFX Trainer will call this function.
-def run_fn(fn_args: FnArgs):
+def trainer_fn(fn_args: FnArgs):
   """Train the model based on given args.
 
   Args:


### PR DESCRIPTION
I have issues building an [kubeflow example](https://github.com/NikeNano/pipelines/tree/nikenano/penguins/samples/core/penguins) from the penguin example and are getting:

```
INFO:absl:Loading /tfx/src/tfx/examples/penguin/penguin_utils.py because it has not been loaded before.
91 Traceback (most recent call last):
92  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
93  "__main__", mod_spec)
94 File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
95  exec(code, run_globals)
96 File "/usr/local/lib/python3.7/dist-packages/tfx/orchestration/kubeflow/container_entrypoint.py", line 360, in <module>
97   main()
98 File "/usr/local/lib/python3.7/dist-packages/tfx/orchestration/kubeflow/container_entrypoint.py", line 353, in main
99 execution_info = launcher.launch()
100  File "/usr/local/lib/python3.7/dist-packages/tfx/orchestration/launcher/base_component_launcher.py", line 209, in launch
101  copy.deepcopy(execution_decision.exec_properties))
102 File "/usr/local/lib/python3.7/dist-packages/tfx/orchestration/launcher/in_process_component_launcher.py", line 72, in _run_executor
103 copy.deepcopy(input_dict), output_dict, copy.deepcopy(exec_properties))
104 File "/usr/local/lib/python3.7/dist-packages/tfx/components/trainer/executor.py", line 249, in Do
105 trainer_fn = udf_utils.get_fn(exec_properties, 'trainer_fn')
106 File "/usr/local/lib/python3.7/dist-packages/tfx/components/util/udf_utils.py", line 49, in get_fn
107 exec_properties[_MODULE_FILE_KEY], fn_name)
108  File "/usr/local/lib/python3.7/dist-packages/tfx/utils/import_utils.py", line 80, in import_func_from_source
109 return getattr(_imported_modules_from_source[source_path], fn_name)
110 AttributeError: module 'user_module_0' has no attribute 'trainer_fn'
```

as I understand this is because https://github.com/tensorflow/tfx/blob/master/tfx/examples/penguin/penguin_utils.py are missing the `trainer_fn` [which is needed](https://github.com/tensorflow/tfx/blob/74d7b28d040973f37263d0a04afa150d5ce0b6eb/tfx/components/trainer/component.py#L40) which currently is named `run_fn`

Please let me know if I have misunderstood the error. 