### PR TITLE
Enable custom pod specs for infra validator kubernetes serving pod

### DIFF
--- a/tfx/components/infra_validator/model_server_runners/kubernetes_runner.py
+++ b/tfx/components/infra_validator/model_server_runners/kubernetes_runner.py
@@ -112,6 +112,10 @@ class KubernetesRunner(base_runner.BaseModelServerRunner):
     self._label_dict = {
         _APP_KEY: _MODEL_SERVER_APP_LABEL,
     }
+    self._annotations_dict = {k_v_pair.k: k_v_pair.v for k_v_pair in
+                              self._config.serving_pod_specs_overrides.annotations}
+    self._custom_env_vars_dict = {k_v_pair.k: k_v_pair.v for k_v_pair in
+                                  self._config.serving_pod_specs_overrides.environment_variables}
     # Pod name would be populated once creation request sent.
     self._pod_name = None
     # Endpoint would be populated once the Pod is running.
@@ -208,6 +212,9 @@ class KubernetesRunner(base_runner.BaseModelServerRunner):
     if isinstance(self._serving_binary, serving_bins.TensorFlowServing):
       env_vars_dict = self._serving_binary.MakeEnvVars(
           model_path=self._model_path)
+      for key, value in self._custom_env_vars_dict.items():
+        if key not in env_vars_dict:
+          env_vars_dict[key] = value
       env_vars = [k8s_client.V1EnvVar(name=key, value=value)
                   for key, value in env_vars_dict.items()]
     else:
@@ -225,6 +232,7 @@ class KubernetesRunner(base_runner.BaseModelServerRunner):
     result = k8s_client.V1Pod(
         metadata=k8s_client.V1ObjectMeta(
             generate_name=_MODEL_SERVER_POD_NAME_PREFIX,
+            annotations=self._annotations_dict,
             labels=self._label_dict,
             # Resources with ownerReferences are automatically deleted once all
             # its owners are deleted.

--- a/tfx/components/infra_validator/model_server_runners/kubernetes_runner.py
+++ b/tfx/components/infra_validator/model_server_runners/kubernetes_runner.py
@@ -214,6 +214,20 @@ class KubernetesRunner(base_runner.BaseModelServerRunner):
             environment_variables.update(env_vars_dict)
       env_vars = [k8s_client.V1EnvVar(name=key, value=value)
                   for key, value in env_vars_dict.items()]
+      if self._serving_pod_manifest_overrides.pod_secret_to_environment_mapping:
+        for secret_name, secret_key_to_env_var in self._serving_pod_manifest_overrides.pod_secret_to_environment_mapping:
+          for secret_key, env_var in secret_key_to_env_var.items():
+            env_vars.append(
+              k8s_client.V1EnvVar(
+                name=env_var,
+                value_from=k8s_client.V1EnvVarSource(
+                  secret_key_ref=k8s_client.V1SecretKeySelector(
+                    name=secret_name,
+                    key=secret_key
+                  )
+                )
+              )
+            )
     else:
       raise NotImplementedError('Unsupported serving binary {}'.format(
           type(self._serving_binary).__name__))

--- a/tfx/components/infra_validator/model_server_runners/kubernetes_runner.py
+++ b/tfx/components/infra_validator/model_server_runners/kubernetes_runner.py
@@ -209,20 +209,19 @@ class KubernetesRunner(base_runner.BaseModelServerRunner):
     if isinstance(self._serving_binary, serving_bins.TensorFlowServing):
       env_vars_dict = self._serving_binary.MakeEnvVars(
           model_path=self._model_path)
-      if self._serving_pod_manifest_overrides:
-        env_vars_dict = self._serving_pod_manifest_overrides.\
-            environment_variables.update(env_vars_dict)
+      if self._serving_pod_manifest_overrides and self._serving_pod_manifest_overrides.environment_variables:
+        env_vars_dict.update(self._serving_pod_manifest_overrides.environment_variables)
       env_vars = [k8s_client.V1EnvVar(name=key, value=value)
                   for key, value in env_vars_dict.items()]
       if self._serving_pod_manifest_overrides.pod_secret_to_environment_mapping:
-        for secret_name, secret_key_to_env_var in self._serving_pod_manifest_overrides.pod_secret_to_environment_mapping:
-          for secret_key, env_var in secret_key_to_env_var.items():
+        for secret_to_environment_mapping in self._serving_pod_manifest_overrides.pod_secret_to_environment_mapping:
+          for secret_key, env_var in secret_to_environment_mapping.k8s_secret_key_to_environment_variable.items():
             env_vars.append(
               k8s_client.V1EnvVar(
                 name=env_var,
                 value_from=k8s_client.V1EnvVarSource(
                   secret_key_ref=k8s_client.V1SecretKeySelector(
-                    name=secret_name,
+                    name=secret_to_environment_mapping.secret_name,
                     key=secret_key
                   )
                 )

--- a/tfx/proto/infra_validator.proto
+++ b/tfx/proto/infra_validator.proto
@@ -121,23 +121,43 @@ message KubernetesConfig {
   int32 active_deadline_seconds = 2;
 
   // Optional.
-  // Additional Kubernetes pod specifications to apply to the serving pod
-  ServingPodSpecsOverrides serving_pod_specs_overrides = 3;
+  // Additional Kubernetes pod overrides to apply to the serving pod
+  PodManifestOverrides serving_pod_manifest_overrides = 3;
 }
 
-message ServingPodSpecsOverrides {
+message PodManifestOverrides {
   // Optional.
   // Kubernetes annotations to apply to the pod
-  repeated KeyValuePair annotations = 1;
+  map<string, string> annotations = 1;
 
   // Optional.
   // Kubernetes environment variables to apply to the pod
-  repeated KeyValuePair environment_variables = 2;
+  map<string, string> environment_variables = 2;
+
+  // Optional.
+  // Mapping from Kubernetes secret to environment variable to apply to the pod
+  repeated PodSecretToEnvironmentMapping pod_secret_to_environment_mapping = 3;
 }
 
-message KeyValuePair {
-  string key = 1;
-  string value = 2;
+message PodSecretToEnvironmentMapping {
+  // Mapping from Kubernetes secret to environment variable to apply to the pod
+  // Example:
+  // s3-secret = my_s3_secret
+  // k8s_secret_key_to_environment_variable = {'secret_key': 'AWS_SECRET_ACCESS_KEY'}
+  // This will load the value in secret 's3-secret' at key 'secret_key' and source it as the environment variable
+  //    'AWS_SECRET_ACCESS_KEY'. I.e. it will produce the following section on the pod:
+  //    env:
+  //    - name: AWS_SECRET_ACCESS_KEY
+  //      valueFrom:
+  //        secretKeyRef:
+  //          name: s3-secret
+  //          key: secret_key
+  // Note that the the secret 'my_s3_secret' needs to be deployed a priori
+
+  // Name of the secret in k8s
+  string secret_name = 1;
+  // A dict that contains a mapping from secret keys to environment variables
+  map<string, string> k8s_secret_key_to_environment_variable = 2;
 }
 
 // Specification for validation criteria and thresholds.

--- a/tfx/proto/infra_validator.proto
+++ b/tfx/proto/infra_validator.proto
@@ -156,6 +156,7 @@ message PodSecretToEnvironmentMapping {
 
   // Name of the secret in k8s
   string secret_name = 1;
+
   // A dict that contains a mapping from secret keys to environment variables
   map<string, string> k8s_secret_key_to_environment_variable = 2;
 }

--- a/tfx/proto/infra_validator.proto
+++ b/tfx/proto/infra_validator.proto
@@ -132,33 +132,23 @@ message PodManifestOverrides {
 
   // Optional.
   // Kubernetes environment variables to apply to the pod
-  map<string, string> environment_variables = 2;
-
-  // Optional.
-  // Mapping from Kubernetes secret to environment variable to apply to the pod
-  repeated PodSecretToEnvironmentMapping pod_secret_to_environment_mapping = 3;
+  repeated EnvVar env = 2;
 }
 
-message PodSecretToEnvironmentMapping {
-  // Mapping from Kubernetes secret to environment variable to apply to the pod
-  // Example:
-  // s3-secret = my_s3_secret
-  // k8s_secret_key_to_environment_variable = {'secret_key': 'AWS_SECRET_ACCESS_KEY'}
-  // This will load the value in secret 's3-secret' at key 'secret_key' and source it as the environment variable
-  //    'AWS_SECRET_ACCESS_KEY'. I.e. it will produce the following section on the pod:
-  //    env:
-  //    - name: AWS_SECRET_ACCESS_KEY
-  //      valueFrom:
-  //        secretKeyRef:
-  //          name: s3-secret
-  //          key: secret_key
-  // Note that the the secret 'my_s3_secret' needs to be deployed a priori
+message EnvVar {
+  string name = 1;
+  string value = 2;
+  EnvVarSource valueFrom = 3;
+}
 
-  // Name of the secret in k8s
-  string secret_name = 1;
+message EnvVarSource {
+  SecretKeySelector secretKeyRef = 4;
+  reserved 1, 2, 3;
+}
 
-  // A dict that contains a mapping from secret keys to environment variables
-  map<string, string> k8s_secret_key_to_environment_variable = 2;
+message SecretKeySelector {
+  string name = 1;
+  string key = 2;
 }
 
 // Specification for validation criteria and thresholds.

--- a/tfx/proto/infra_validator.proto
+++ b/tfx/proto/infra_validator.proto
@@ -119,6 +119,25 @@ message KubernetesConfig {
   //
   // Should be a positive integer. Default to 24 hours (86400).
   int32 active_deadline_seconds = 2;
+
+  // Optional.
+  // Additional Kubernetes pod specifications to apply to the serving pod
+  ServingPodSpecsOverrides serving_pod_specs_overrides = 3;
+}
+
+message ServingPodSpecsOverrides {
+  // Optional.
+  // Kubernetes annotations to apply to the pod
+  repeated KeyValuePair annotations = 1;
+
+  // Optional.
+  // Kubernetes environment variables to apply to the pod
+  repeated KeyValuePair environment_variables = 2;
+}
+
+message KeyValuePair {
+  string key = 1;
+  string value = 2;
 }
 
 // Specification for validation criteria and thresholds.


### PR DESCRIPTION
This PR adds logic for enabling custom pod specs for infra validator kubernetes serving pod. It solves https://github.com/tensorflow/tfx/issues/3257.