### PR TITLE
Make ExampleGen driver fingerprint execution property optional

### DIFF
--- a/tfx/components/example_gen/driver.py
+++ b/tfx/components/example_gen/driver.py
@@ -53,9 +53,10 @@ def update_output_artifact(
     exec_properties: execution properties passed to the example gen.
     output_artifact: the example artifact to be output.
   """
-  output_artifact.custom_properties[
-      utils.FINGERPRINT_PROPERTY_NAME].string_value = str(
-          exec_properties[utils.FINGERPRINT_PROPERTY_NAME])
+  if exec_properties[utils.FINGERPRINT_PROPERTY_NAME] is not None:
+    output_artifact.custom_properties[
+        utils.FINGERPRINT_PROPERTY_NAME].string_value = (
+            exec_properties[utils.FINGERPRINT_PROPERTY_NAME])
   output_artifact.custom_properties[
       utils.SPAN_PROPERTY_NAME].string_value = str(
           exec_properties[utils.SPAN_PROPERTY_NAME])


### PR DESCRIPTION
Make ExampleGen driver fingerprint execution property optional. This is necessary since otherwise the QueryBased Driver created by @1025KB in
https://github.com/tensorflow/tfx/commit/8b6e3f12a0b3015ea3a02115abf6a18ce92400b8 does not work and raises an exception (since it does not generate a fingerprint).