### PR TITLE
Update path to penguins_processed.csv files in notebooks

### DIFF
--- a/docs/tutorials/mlmd/mlmd_tutorial.ipynb
+++ b/docs/tutorials/mlmd/mlmd_tutorial.ipynb
@@ -240,7 +240,7 @@
       },
       "outputs": [],
       "source": [
-        "DATA_PATH = 'https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/penguin/data/penguins_processed.csv'\n",
+        "DATA_PATH = 'https://storage.googleapis.com/download.tensorflow.org/data/palmer_penguins/penguins_processed.csv'\n",
         "_data_root = tempfile.mkdtemp(prefix='tfx-data')\n",
         "_data_filepath = os.path.join(_data_root, \"penguins_processed.csv\")\n",
         "urllib.request.urlretrieve(DATA_PATH, _data_filepath)"

--- a/docs/tutorials/tfx/penguin_simple.ipynb
+++ b/docs/tutorials/tfx/penguin_simple.ipynb
@@ -263,7 +263,7 @@
         "import tempfile\n",
         "\n",
         "DATA_ROOT = tempfile.mkdtemp(prefix='tfx-data')  # Create a temporary directory.\n",
-        "_data_url = 'https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/penguin/data/penguins_processed.csv'\n",
+        "_data_url = 'https://storage.googleapis.com/download.tensorflow.org/data/palmer_penguins/penguins_processed.csv'\n",
         "_data_filepath = os.path.join(DATA_ROOT, \"data.csv\")\n",
         "urllib.request.urlretrieve(_data_url, _data_filepath)"
       ],

--- a/docs/tutorials/tfx/penguin_tfdv.ipynb
+++ b/docs/tutorials/tfx/penguin_tfdv.ipynb
@@ -292,7 +292,7 @@
         "import tempfile\n",
         "\n",
         "DATA_ROOT = tempfile.mkdtemp(prefix='tfx-data')  # Create a temporary directory.\n",
-        "_data_url = 'https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/penguin/data/penguins_processed.csv'\n",
+        "_data_url = 'https://storage.googleapis.com/download.tensorflow.org/data/palmer_penguins/penguins_processed.csv'\n",
         "_data_filepath = os.path.join(DATA_ROOT, \"data.csv\")\n",
         "urllib.request.urlretrieve(_data_url, _data_filepath)"
       ],

--- a/docs/tutorials/tfx/penguin_tfma.ipynb
+++ b/docs/tutorials/tfx/penguin_tfma.ipynb
@@ -267,7 +267,7 @@
         "import tempfile\n",
         "\n",
         "DATA_ROOT = tempfile.mkdtemp(prefix='tfx-data')  # Create a temporary directory.\n",
-        "_data_url = 'https://raw.githubusercontent.com/tensorflow/tfx/master/tfx/examples/penguin/data/penguins_processed.csv'\n",
+        "_data_url = 'https://storage.googleapis.com/download.tensorflow.org/data/palmer_penguins/penguins_processed.csv'\n",
         "_data_filepath = os.path.join(DATA_ROOT, \"data.csv\")\n",
         "urllib.request.urlretrieve(_data_url, _data_filepath)"
       ],


### PR DESCRIPTION
A recent PR #3810 moved the penguins_processed.csv file in the repo, but did not update URLs to github. This proposes using the cloud storage URL instead.