### PR TITLE
Update rest_simple.ipynb

### DIFF
--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -96,7 +96,7 @@
       "source": [
         "# TensorFlow and tf.keras\n",
         "print(\"Installing dependencies for Colab environment\")\n",
-        "!pip install -Uq grpcio==1.26.0\n",
+        "!pip install -Uq grpcio==1.34.0\n",
         "\n",
         "import tensorflow as tf\n",
         "from tensorflow import keras\n",


### PR DESCRIPTION
Colab now hosts TF 2.5 version which installs `grpcio=1.34.0` as a dependency.
Thus upgrading the grpcio version for the example.