### PR TITLE
Fixes issues of cherry-pick in https://github.com/tensorflow/tfx/pull/3983.

### DIFF
--- a/tfx/dsl/components/base/base_node.py
+++ b/tfx/dsl/components/base/base_node.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, Optional, Text, Type
 from tfx.dsl.components.base import base_driver
 from tfx.dsl.components.base import base_executor
 from tfx.dsl.components.base import executor_spec as executor_spec_module
-from tfx.dsl.components.base import node_registry
 from tfx.utils import deprecation_utils
 from tfx.utils import doc_controls
 from tfx.utils import json_utils

--- a/tfx/orchestration/kubeflow/container_entrypoint.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint.py
@@ -259,12 +259,12 @@ def _dump_ui_metadata(
 
   src_str_inputs = '# Inputs:\n{}'.format(''.join(
       _dump_populated_artifacts(
-          name_to_channel=component.inputs.get_all(),
+          name_to_channel=component.inputs,
           name_to_artifacts=execution_info.input_dict)) or 'No input.')
 
   src_str_outputs = '# Outputs:\n{}'.format(''.join(
       _dump_populated_artifacts(
-          name_to_channel=component.outputs.get_all(),
+          name_to_channel=component.outputs,
           name_to_artifacts=execution_info.output_dict)) or 'No output.')
 
   outputs = [{


### PR DESCRIPTION
1) Note on the cherry pick in https://github.com/tensorflow/tfx/pull/3983.
https://github.com/tensorflow/tfx/commit/6f073c9f7570d6e6ab29ec1fcc14e31bce506222#diff-e1fd4c84c29238e5c1ab64975d2032afd8d5374aeea170347448eb28f9ab37bd

It seems like the import statement `from tfx.dsl.components.base import node_registry` should be deleted.
Because `node_registry.py` doesn't exist in 1.0.0 branch, it will result in a import error, and it seems like the import can be deleted.

2) https://github.com/tensorflow/tfx/pull/3983 didn't fix already
deleted code after 1.0.0 branch cut. `get_all()` is not needed because
inputs and outputs are just a Dict.