### PR TITLE
Include uuid4 string in default generated ai platform job name.

### DIFF
--- a/tfx/extensions/google_cloud_ai_platform/training_clients.py
+++ b/tfx/extensions/google_cloud_ai_platform/training_clients.py
@@ -17,6 +17,7 @@ import abc
 import datetime
 import json
 from typing import Any, Dict, List, Optional, Text, Union
+import uuid
 
 from absl import logging
 from google.cloud.aiplatform import gapic
@@ -423,10 +424,11 @@ class UCAIPJobClient(AbstractJobClient):
         {telemetry_utils.LABEL_TFX_EXECUTOR: executor_class_path}):
       job_labels = telemetry_utils.make_labels_dict()
 
-    # 'tfx_YYYYmmddHHMMSS' is the default job display name if not explicitly
-    # specified.
-    job_id = job_id or 'tfx_{}'.format(
-        datetime.datetime.now().strftime('%Y%m%d%H%M%S'))
+    # 'tfx_YYYYmmddHHMMSS_xxxxxxxx' is the default job display name if not
+    # explicitly specified.
+    job_id = job_id or 'tfx_{}_{}'.format(
+        datetime.datetime.now().strftime('%Y%m%d%H%M%S'),
+        str(uuid.uuid4())[:8])
 
     training_args = {
         'job_id': job_id,


### PR DESCRIPTION
In a TFX pipeline with multiple parallel ai platform jobs usually all but one will fail to start since the default job id will be the same for all jobs. This PR adds a substring of a uuid4 to avoid the naming collision.