### PR TITLE
Prototype remote @component executor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -139,6 +139,7 @@ dmypy.json
 # Bazel generated files
 bazel-*
 **/*_pb2.py
+**/*_pb2_grpc.py
 # LINT.ThenChange(.gitignore)
 
 # Github integration settings

--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,5 @@ dmypy.json
 # Bazel generated files
 bazel-*
 **/*_pb2.py
+**/*_pb2_grpc.py
 # LINT.ThenChange(.dockerignore)

--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -60,6 +60,7 @@ def make_pipeline_sdk_required_install_packages():
           git_master='@git+https://github.com/google/ml-metadata@master'),
       'packaging>=20,<21',
       'portpicker>=1.3.1,<2',
+      'strip-hints>=0.1.0<1'
       'protobuf>=3.13,<4',
       'docker>=4.1,<5',
       'google-apitools>=0.5,<1',

--- a/tfx/dsl/component/experimental/decorators.py
+++ b/tfx/dsl/component/experimental/decorators.py
@@ -16,6 +16,7 @@
 Experimental: no backwards compatibility guarantees.
 """
 
+import inspect
 import sys
 import types
 from typing import Any, Callable, Dict, List
@@ -27,10 +28,41 @@ from tfx.dsl.components.base import base_executor
 from tfx.dsl.components.base import executor_spec
 from tfx.types import channel_utils
 from tfx.types import component_spec
+from tfx.utils import json_utils
+
+_ARG_FORMATS_KEY = '_arg_format'
+_ARG_DEFAULTS_KEY = '_arg_defaults'
+_FUNCTION_BODY_KEY = '_function_body'
+_FUNCTION_NAME_KEY = '_function_name'
+_RETURNED_VALUES_KEY = '_returned_values'
+
+
+def _strip_hints(py_code:str)-> str:  
+  from strip_hints import strip_string_to_string
+  if py_code[-1] != '\n':
+    py_code += '\n'
+  return strip_string_to_string(py_code, to_empty=True)
+
+def _dedent(py_code: str) -> str:
+  import textwrap
+  return textwrap.dedent(py_code)
+
+def _remove_decorators(py_code:str)-> str:
+  func_code_lines = py_code.split('\n')
+  # Removing possible decorators (can be multiline) until the function definition is found
+  while func_code_lines and not func_code_lines[0].startswith('def '):
+      del func_code_lines[0]
+  return '\n'.join(func_code_lines)
+
+
+def _get_function_code(callable: Callable) -> str:
+  return _remove_decorators(_strip_hints(_dedent(inspect.getsource(callable))))
 
 
 class _SimpleComponent(base_component.BaseComponent):
   """Component whose constructor generates spec instance from arguments."""
+
+  EXTRA_EXEC_PARAMS = {}
 
   def __init__(self, *unused_args, **kwargs):
     if unused_args:
@@ -46,6 +78,9 @@ class _SimpleComponent(base_component.BaseComponent):
         spec_kwargs[key] = kwargs[key]
         unseen_args.remove(key)
     for key, parameter in self.SPEC_CLASS.PARAMETERS.items():
+      if key in self.EXTRA_EXEC_PARAMS:
+        spec_kwargs[key] = self.EXTRA_EXEC_PARAMS[key]
+        continue
       if key not in kwargs and not parameter.optional:
         raise ValueError('%s expects parameter %r of type %s.' %
                          (self.__class__.__name__, key, parameter.type))
@@ -58,6 +93,7 @@ class _SimpleComponent(base_component.BaseComponent):
           (self.__class__.__name__, ', '.join(sorted(unseen_args))))
     for key, channel_parameter in self.SPEC_CLASS.OUTPUTS.items():
       spec_kwargs[key] = channel_utils.as_channel([channel_parameter.type()])
+    
     spec = self.SPEC_CLASS(**spec_kwargs)
     super().__init__(spec)
     # Set class name, which is the decorated function name, as the default id.
@@ -79,14 +115,28 @@ class _FunctionExecutor(base_executor.BaseExecutor):
   # User-defined component function. Should be wrapped in staticmethod() to
   # avoid being interpreted as a bound method (i.e. one taking `self` as its
   # first argument.
-  _FUNCTION = staticmethod(lambda: None)
+  _FUNCTION_BODY = ''
+  _FUNCTION_NAME = ''
   # Set of output names that are primitive type values returned from the user
   # function.
   _RETURNED_VALUES = set()
 
+  def _execute_function(self, **kwargs):
+    """Executes the user function with the given arguments."""
+    code = self._FUNCTION_BODY
+    out = {}
+    exec(code, out)
+    return out[self._FUNCTION_NAME](**kwargs)
+
   def Do(self, input_dict: Dict[str, List[tfx_types.Artifact]],
          output_dict: Dict[str, List[tfx_types.Artifact]],
          exec_properties: Dict[str, Any]) -> None:
+    self._ARG_FORMATS = {k: function_parser.ArgFormats(v) for k,v in json_utils.loads(exec_properties.pop(_ARG_FORMATS_KEY)).items()}
+    self._ARG_DEFAULTS = json_utils.loads(exec_properties.pop(_ARG_DEFAULTS_KEY))
+    self._FUNCTION_BODY = exec_properties.pop(_FUNCTION_BODY_KEY)
+    self._FUNCTION_NAME = exec_properties.pop(_FUNCTION_NAME_KEY)
+    self._RETURNED_VALUES = set(json_utils.loads(exec_properties.pop(_RETURNED_VALUES_KEY)))
+
     function_args = {}
     for name, arg_format in self._ARG_FORMATS.items():
       if arg_format == function_parser.ArgFormats.INPUT_ARTIFACT:
@@ -133,19 +183,19 @@ class _FunctionExecutor(base_executor.BaseExecutor):
         raise ValueError('Unknown argument format: %r' % (arg_format,))
 
     # Call function and check returned values.
-    outputs = self._FUNCTION(**function_args)
+    outputs = self._execute_function(**function_args)
     outputs = outputs or {}
     if not isinstance(outputs, dict):
       raise ValueError(
           ('Expected component executor function %s to return a dict of '
-           'outputs (got %r instead).') % (self._FUNCTION, outputs))
+           'outputs (got %r instead).') % (self._FUNCTION_NAME, outputs))
 
     # Assign returned ValueArtifact values.
     for name in self._RETURNED_VALUES:
       if name not in outputs:
         raise ValueError(
             'Did not receive expected output %r as return value from '
-            'component executor function %s.' % (name, self._FUNCTION))
+            'component executor function %s.' % (name, self._FUNCTION_NAME))
       try:
         output_dict[name][0].value = outputs[name]
       except TypeError:
@@ -276,6 +326,10 @@ def component(func: types.FunctionType) -> Callable[..., Any]:
   for key, primitive_type in parameters.items():
     spec_parameters[key] = component_spec.ExecutionParameter(
         type=primitive_type, optional=(key in arg_defaults))
+  
+  for key in [_RETURNED_VALUES_KEY, _FUNCTION_BODY_KEY, _FUNCTION_NAME_KEY, _ARG_FORMATS_KEY, _ARG_DEFAULTS_KEY]:
+    spec_parameters[key] = component_spec.ExecutionParameter(type=str)
+
   component_spec_class = type(
       '%s_Spec' % func.__name__, (tfx_types.ComponentSpec,), {
           'INPUTS': spec_inputs,
@@ -283,33 +337,23 @@ def component(func: types.FunctionType) -> Callable[..., Any]:
           'PARAMETERS': spec_parameters,
       })
 
-  executor_class = type(
-      '%s_Executor' % func.__name__,
-      (_FunctionExecutor,),
-      {
-          '_ARG_FORMATS': arg_formats,
-          '_ARG_DEFAULTS': arg_defaults,
-          # The function needs to be marked with `staticmethod` so that later
-          # references of `self._FUNCTION` do not result in a bound method (i.e.
-          # one with `self` as its first parameter).
-          '_FUNCTION': staticmethod(func),
-          '_RETURNED_VALUES': returned_values,
-          '__module__': func.__module__,
-      })
-
-  # Expose the generated executor class in the same module as the decorated
-  # function. This is needed so that the executor class can be accessed at the
-  # proper module path. One place this is needed is in the Dill pickler used by
-  # Apache Beam serialization.
-  module = sys.modules[func.__module__]
-  setattr(module, '%s_Executor' % func.__name__, executor_class)
-
   executor_spec_instance = executor_spec.ExecutorClassSpec(
-      executor_class=executor_class)
+      executor_class=_FunctionExecutor)
+
+
+  extra_exec_params = {
+      _FUNCTION_BODY_KEY: _get_function_code(func),
+      _FUNCTION_NAME_KEY: func.__name__,
+      _ARG_FORMATS_KEY: json_utils.dumps({k: v.value for k,v in arg_formats.items()}),
+      _ARG_DEFAULTS_KEY: json_utils.dumps(arg_defaults),
+      _RETURNED_VALUES_KEY: json_utils.dumps(list(returned_values)),
+  }
 
   return type(
       func.__name__, (_SimpleComponent,), {
           'SPEC_CLASS': component_spec_class,
           'EXECUTOR_SPEC': executor_spec_instance,
+          'EXTRA_EXEC_PARAMS': extra_exec_params,
           '__module__': func.__module__,
       })
+  

--- a/tfx/dsl/component/experimental/decorators_test.py
+++ b/tfx/dsl/component/experimental/decorators_test.py
@@ -27,7 +27,6 @@ from tfx.dsl.component.experimental.decorators import _SimpleComponent
 from tfx.dsl.component.experimental.decorators import component
 from tfx.dsl.components.base import base_executor
 from tfx.dsl.components.base import executor_spec
-from tfx.dsl.io import fileio
 from tfx.orchestration import metadata
 from tfx.orchestration import pipeline
 from tfx.orchestration.beam import beam_dag_runner
@@ -82,6 +81,8 @@ def _injector_2(
     examples: OutputArtifact[standard_artifacts.Examples]
 ) -> OutputDict(
     a=int, b=float, c=str, d=bytes, e=str):
+  from tfx.dsl.io import fileio
+
   fileio.makedirs(examples.uri)
   return {'a': 1, 'b': 2.0, 'c': '3', 'd': b'4', 'e': 'passed'}
 
@@ -97,12 +98,13 @@ def _optionalarg_component(
     d: bytes,
     e1: str = 'default',
     e2: Optional[str] = 'default',
-    f: bytes = b'default',
+    f: str = 'default',
     g: Parameter[float] = 1000.0,
     h: Parameter[str] = '2000',
     optional_examples_1: InputArtifact[standard_artifacts.Examples] = None,
     optional_examples_2: InputArtifact[standard_artifacts.Examples] = None):
   # Test non-optional parameters.
+  from tfx.types import standard_artifacts
   assert foo == 9
   assert bar == 'secret'
   assert isinstance(examples, standard_artifacts.Examples)
@@ -116,7 +118,7 @@ def _optionalarg_component(
   assert e1 == 'passed'
   assert e2 == 'passed'
   # Test that non-passed optional argument becomes the argument default.
-  assert f == b'default'
+  assert f == 'default'
   # Test passed optional parameter.
   assert g == 999.0
   # Test non-passed optional parameter.


### PR DESCRIPTION
Still under work, but the idea here is to have a way to define @component components without having to send the modules to KFP/Vertex and instead serializing from the client on pipeline compilation time.

Need to:
- [x] Serialize executor
- [x] Serialize component
- [ ] Make it optional to use this version