### PR TITLE
CUSTOM_CONFIG_KEY is set twice

### DIFF
--- a/tfx/types/standard_component_specs.py
+++ b/tfx/types/standard_component_specs.py
@@ -33,7 +33,6 @@ from tfx.types.component_spec import ExecutionParameter
 SCHEMA_KEY = 'schema'
 EXAMPLES_KEY = 'examples'
 MODEL_KEY = 'model'
-CUSTOM_CONFIG_KEY = 'custom_config'
 BLESSING_KEY = 'blessing'
 TRAIN_ARGS_KEY = 'train_args'
 CUSTOM_CONFIG_KEY = 'custom_config'


### PR DESCRIPTION
Noticed that `CUSTOM_CONFIG_KEY` is defined twice at lines 36 and 39.