### PR TITLE
Generalize tensorboard visualization for KFP

### DIFF
--- a/tfx/orchestration/kubeflow/container_entrypoint.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint.py
@@ -35,7 +35,7 @@ from tfx.orchestration.portable import launcher
 from tfx.orchestration.portable import runtime_parameter_utils
 from tfx.proto.orchestration import executable_spec_pb2
 from tfx.proto.orchestration import pipeline_pb2
-from tfx.types import artifact
+from tfx.types import artifact, standard_artifacts
 from tfx.types import channel
 from tfx.utils import telemetry_utils
 
@@ -340,9 +340,9 @@ def _dump_ui_metadata(
   }]
   # Add Tensorboard view for ModelRun outpus.
   for name, spec in node.outputs.outputs.items():
-    if spec.artifact_spec.type.name.lower() == 'modelrun':
+    if spec.artifact_spec.type.name == standard_artifacts.ModelRun.TYPE_NAME:
       output_model = execution_info.output_dict[name][0]
-      
+
       # Add Tensorboard view.
       tensorboard_output = {'type': 'tensorboard', 'source': output_model.uri}
       outputs.append(tensorboard_output)

--- a/tfx/orchestration/kubeflow/container_entrypoint.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint.py
@@ -341,7 +341,8 @@ def _dump_ui_metadata(
   # Add Tensorboard view for ModelRun outpus.
   for name, spec in node.outputs.outputs.items():
     if spec.artifact_spec.type.name.lower() == 'modelrun':
-       output_model = execution_info.output_dict[name][0]
+      output_model = execution_info.output_dict[name][0]
+      
       # Add Tensorboard view.
       tensorboard_output = {'type': 'tensorboard', 'source': output_model.uri}
       outputs.append(tensorboard_output)

--- a/tfx/orchestration/kubeflow/container_entrypoint.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint.py
@@ -338,16 +338,13 @@ def _dump_ui_metadata(
       'type':
           'markdown',
   }]
-  # Add Tensorboard view for Trainer.
-  # TODO(b/142804764): Visualization based on component type seems a bit of
-  # arbitrary and fragile. We need a better way to improve this. See also
-  # b/146594754
-  if node.node_info.type.name == 'tfx.components.trainer.component.Trainer':
-    output_model = execution_info.output_dict['model_run'][0]
-
-    # Add Tensorboard view.
-    tensorboard_output = {'type': 'tensorboard', 'source': output_model.uri}
-    outputs.append(tensorboard_output)
+  # Add Tensorboard view for ModelRun outpus.
+  for name, spec in node.outputs.outputs.items():
+    if spec.artifact_spec.type.name.lower() == 'modelrun':
+       output_model = execution_info.output_dict[name][0]
+      # Add Tensorboard view.
+      tensorboard_output = {'type': 'tensorboard', 'source': output_model.uri}
+      outputs.append(tensorboard_output)
 
   metadata_dict = {'outputs': outputs}
 

--- a/tfx/orchestration/kubeflow/container_entrypoint_test.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint_test.py
@@ -95,6 +95,11 @@ class MLMDConfigTest(test_case_utils.TfxTest):
   def testDumpUiMetadata(self):
     trainer = pipeline_pb2.PipelineNode()
     trainer.node_info.type.name = 'tfx.components.trainer.component.Trainer'
+    model_run_out_spec = pipeline_pb2.OutputSpec(
+      artifact_spec=pipeline_pb2.OutputSpec.ArtifactSpec(
+          type=metadata_store_pb2.ArtifactType(name=standard_artifacts.ModelRun.TYPE_NAME)))
+    trainer.outputs.outputs['model_run'].CopyFrom(model_run_out_spec)
+
     model_run = standard_artifacts.ModelRun()
     model_run.uri = 'model_run_uri'
     exec_info = data_types.ExecutionInfo(


### PR DESCRIPTION
Currently KFP only shows Tensorboard if model has use the Trainer. This means that even when using Vertex Trainer, KFP wont show the Tensorboard. Instead of creating when Trainer component id is present, we should show the UI when model_run output is present.


We run into this with our extended Trainer since we extend Trainer by inheriting.