### PR TITLE
Updated Tensorflow serving URL

### DIFF
--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -67,7 +67,7 @@
         "id": "FbVhjPpzn6BM"
       },
       "source": [
-        "This guide trains a neural network model to classify [images of clothing, like sneakers and shirts](https://github.com/zalandoresearch/fashion-mnist), saves the trained model, and then serves it with [TensorFlow Serving](https://www.tensorflow.org/serving/).  The focus is on TensorFlow Serving, rather than the modeling and training in TensorFlow, so for a complete example which focuses on the modeling and training see the [Basic Classification example](https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/keras/basic_classification.ipynb).\n",
+        "This guide trains a neural network model to classify [images of clothing, like sneakers and shirts](https://github.com/zalandoresearch/fashion-mnist), saves the trained model, and then serves it with [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving).  The focus is on TensorFlow Serving, rather than the modeling and training in TensorFlow, so for a complete example which focuses on the modeling and training see the [Basic Classification example](https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/keras/basic_classification.ipynb).\n",
         "\n",
         "This guide uses [tf.keras](https://github.com/tensorflow/docs/blob/master/site/en/r1/guide/keras.ipynb), a high-level API to build and train models in TensorFlow."
       ]


### PR DESCRIPTION
URL mentioned in the document for Tensorflow Serving throwing 404 error(https://www.tensorflow.org/serving/), made changes with the updated serving URL(https://www.tensorflow.org/tfx/guide/serving)