### PR TITLE
[WIP] Restore changes in PR #3842 to persist TFX IR to pipeline_root

### DIFF
--- a/tfx/orchestration/kubeflow/base_component.py
+++ b/tfx/orchestration/kubeflow/base_component.py
@@ -71,7 +71,8 @@ class BaseComponent:
       pipeline_root: dsl.PipelineParam,
       tfx_image: str,
       kubeflow_metadata_config: kubeflow_pb2.KubeflowMetadataConfig,
-      tfx_ir: pipeline_pb2.Pipeline, pod_labels_to_attach: Dict[str, str],
+      tfx_ir_path: str, 
+      pod_labels_to_attach: Dict[str, str],
       runtime_parameters: List[data_types.RuntimeParameter]):
     """Creates a new Kubeflow-based component.
 
@@ -87,7 +88,8 @@ class BaseComponent:
       tfx_image: The container image to use for this component.
       kubeflow_metadata_config: Configuration settings for connecting to the
         MLMD store in a Kubeflow cluster.
-      tfx_ir: The TFX intermedia representation of the pipeline.
+      tfx_ir_path: The path where TFX intermedia representation of the
+        pipeline persists.
       pod_labels_to_attach: Dict of pod labels to attach to the GKE pod.
       runtime_parameters: Runtime parameters of the pipeline.
     """
@@ -102,11 +104,8 @@ class BaseComponent:
             message=kubeflow_metadata_config, preserving_proto_field_name=True),
         '--node_id',
         component.id,
-        # TODO(b/182220464): write IR to pipeline_root and let
-        # container_entrypoint.py read it back to avoid future issue that IR
-        # exeeds the flag size limit.
         '--tfx_ir',
-        json_format.MessageToJson(tfx_ir),
+        tfx_ir_path,
     ]
 
     for param in runtime_parameters:

--- a/tfx/orchestration/kubeflow/base_component_test.py
+++ b/tfx/orchestration/kubeflow/base_component_test.py
@@ -26,7 +26,6 @@ from tfx.orchestration import data_types
 from tfx.orchestration import pipeline as tfx_pipeline
 from tfx.orchestration.kubeflow import base_component
 from tfx.orchestration.kubeflow.proto import kubeflow_pb2
-from tfx.proto.orchestration import pipeline_pb2
 
 from ml_metadata.proto import metadata_store_pb2
 
@@ -53,7 +52,6 @@ class BaseComponentTest(tf.test.TestCase):
 
     self._metadata_config = kubeflow_pb2.KubeflowMetadataConfig()
     self._metadata_config.mysql_db_service_host.environment_variable = 'MYSQL_SERVICE_HOST'
-    self._tfx_ir = pipeline_pb2.Pipeline()
     with dsl.Pipeline('test_pipeline'):
       self.component = base_component.BaseComponent(
           component=statistics_gen,
@@ -62,7 +60,7 @@ class BaseComponentTest(tf.test.TestCase):
           pipeline_root=test_pipeline_root,
           tfx_image='container_image',
           kubeflow_metadata_config=self._metadata_config,
-          tfx_ir=self._tfx_ir,
+          tfx_ir_path='path/to/tfx_ir',
           pod_labels_to_attach={},
           runtime_parameters=[]
       )
@@ -88,6 +86,8 @@ class BaseComponentTest(tf.test.TestCase):
         '}',
         '--node_id',
         'foo',
+        '--tfx_ir_path',
+        'path/to/tfx_ir',
     ]
     try:
       self.assertEqual(
@@ -132,7 +132,6 @@ class BaseComponentWithPipelineParamTest(tf.test.TestCase):
 
     self._metadata_config = kubeflow_pb2.KubeflowMetadataConfig()
     self._metadata_config.mysql_db_service_host.environment_variable = 'MYSQL_SERVICE_HOST'
-    self._tfx_ir = pipeline_pb2.Pipeline()
     with dsl.Pipeline('test_pipeline'):
       self.example_gen = base_component.BaseComponent(
           component=example_gen,
@@ -141,7 +140,7 @@ class BaseComponentWithPipelineParamTest(tf.test.TestCase):
           pipeline_root=test_pipeline_root,
           tfx_image='container_image',
           kubeflow_metadata_config=self._metadata_config,
-          tfx_ir=self._tfx_ir,
+          tfx_ir_path='path/to/tfx_ir',
           pod_labels_to_attach={},
           runtime_parameters=[example_gen_output_config])
       self.statistics_gen = base_component.BaseComponent(
@@ -151,7 +150,7 @@ class BaseComponentWithPipelineParamTest(tf.test.TestCase):
           pipeline_root=test_pipeline_root,
           tfx_image='container_image',
           kubeflow_metadata_config=self._metadata_config,
-          tfx_ir=self._tfx_ir,
+          tfx_ir='path/to/tfx_ir',
           pod_labels_to_attach={},
           runtime_parameters=[]
       )
@@ -174,8 +173,8 @@ class BaseComponentWithPipelineParamTest(tf.test.TestCase):
         '}',
         '--node_id',
         'foo',
-        '--tfx_ir',
-        '{}',
+        '--tfx_ir_path',
+        'path/to/tfx_ir',
     ]
     example_gen_expected_args = [
         '--pipeline_root',
@@ -189,7 +188,7 @@ class BaseComponentWithPipelineParamTest(tf.test.TestCase):
         '--node_id',
         'CsvExampleGen',
         '--tfx_ir',
-        '{}',
+        'path/to/tfx_ir',
         '--runtime_parameter',
         'example-gen-output-config=STRING:{{pipelineparam:op=;name=example-gen-output-config}}',
     ]

--- a/tfx/orchestration/kubeflow/container_entrypoint.py
+++ b/tfx/orchestration/kubeflow/container_entrypoint.py
@@ -24,6 +24,7 @@ from typing import cast, Dict, List, Mapping, MutableMapping, Optional, Sequence
 
 from tfx import types
 from tfx.dsl.compiler import constants
+from tfx.dsl.io import fileio
 from tfx.orchestration import metadata
 from tfx.orchestration.kubeflow import kubeflow_metadata_adapter
 from tfx.orchestration.kubeflow.proto import kubeflow_pb2
@@ -411,7 +412,7 @@ def main(argv):
   parser = argparse.ArgumentParser()
   parser.add_argument('--pipeline_root', type=str, required=True)
   parser.add_argument('--kubeflow_metadata_config', type=str, required=True)
-  parser.add_argument('--tfx_ir', type=str, required=True)
+  parser.add_argument('--tfx_ir_path', type=str, required=True)
   parser.add_argument('--node_id', type=str, required=True)
   # There might be multiple runtime parameters.
   # `args.runtime_parameter` should become List[str] by using "append".
@@ -423,7 +424,8 @@ def main(argv):
   args = parser.parse_args(argv)
 
   tfx_ir = pipeline_pb2.Pipeline()
-  json_format.Parse(args.tfx_ir, tfx_ir)
+  with fileio.open(args.tfx_ir_path, 'rb') as f:
+    tfx_ir.ParseFromString(f.read())
 
   _resolve_runtime_parameters(tfx_ir, args.runtime_parameter)
 


### PR DESCRIPTION
Restores changes in https://github.com/tensorflow/tfx/pull/3842/ to persist TFX IR to pipeline_root and prevent components from failing on Kubeflow Pipelines due to tfx_ir exceeding the command line argument length limit.

This would resolve issues like https://github.com/tensorflow/tfx/issues/4295.

Not yet tested. Unsure if the changes in https://github.com/tensorflow/tfx/pull/3992 to remove extra node information are still necessary.