### PR TITLE
Revert "Introducing `RecordBatchToExamplesEncoder` to encode nested l…

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,8 +13,6 @@
     pre-defined schema file. ImportSchemaGen will replace `Importer` with
     simpler syntax and less constraints. You have to pass the file path to the
     schema file instead of the parent directory unlike `Importer`.
-*   Added support for outputting and encoding `tf.RaggedTensor`s in TFX
-    Transform component.
 
 ## Breaking Changes
 


### PR DESCRIPTION
…ists representing `tf.RaggedTensor` as tf.Examples."

This reverts commit f6beebfc6b542115e802b56c33308a5576aa33b4.

===

This commit should not be included in 1.3.0 release.