### PR TITLE
tfx/blob/master/docs/guide/index.md  has 404 broken link

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -280,7 +280,7 @@ model in production, or exporting a trained model for a native mobile or
 JavaScript application. For example, to turn a model into a REST service for
 making predictions, you can serialize the model as a SavedModel and serve it
 using TensorFlow Serving. See [Serving a TensorFlow
-Model](https://www.tensorflow.org/serving/tutorials/Serving_REST_simple) for
+Model](https://www.tensorflow.org/tfx/tutorials/serving/rest_simple) for
 more information.
 
 ### Schema


### PR DESCRIPTION
Could you please update with the correct link(https://www.tensorflow.org/tfx/tutorials/serving/rest_simple) in tfx user guide - #SavedModel