### PR TITLE
added correctly using gpu types in vertex pipeline training notebook

### DIFF
--- a/docs/tutorials/tfx/gcp/vertex_pipelines_vertex_training.ipynb
+++ b/docs/tutorials/tfx/gcp/vertex_pipelines_vertex_training.ipynb
@@ -45,16 +45,16 @@
         "id": "_445qeKq8e3-"
       },
       "source": [
-        "\u003cdiv class=\"devsite-table-wrapper\"\u003e\u003ctable class=\"tfo-notebook-buttons\" align=\"left\"\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/tfx/gcp/vertex_pipelines_vertex_training\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/tf_logo_32px.png\"/\u003eView on TensorFlow.org\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/tfx/gcp/vertex_pipelines_vertex_training.ipynb\"\u003e\n",
-        "\u003cimg src=\"https://www.tensorflow.org/images/colab_logo_32px.png\"\u003eRun in Google Colab\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca target=\"_blank\" href=\"https://github.com/tensorflow/tfx/tree/master/docs/tutorials/tfx/gcp/vertex_pipelines_vertex_training.ipynb\"\u003e\n",
-        "\u003cimg width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\"\u003eView source on GitHub\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca href=\"https://storage.googleapis.com/tensorflow_docs/tfx/docs/tutorials/tfx/gcp/vertex_pipelines_vertex_training.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eDownload notebook\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003ctd\u003e\u003ca href=\"https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ftensorflow%252Ftfx%252Fmaster%252Fdocs%252Ftutorials%252Ftfx%252Fgcp%252Fvertex_pipelines_vertex_training.ipynb\"\u003e\u003cimg src=\"https://www.tensorflow.org/images/download_logo_32px.png\" /\u003eRun in Google Cloud AI Platform Notebook\u003c/a\u003e\u003c/td\u003e\n",
-        "\u003c/table\u003e\u003c/div\u003e\n"
+        "<div class=\"devsite-table-wrapper\"><table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "<td><a target=\"_blank\" href=\"https://www.tensorflow.org/tfx/tutorials/tfx/gcp/vertex_pipelines_vertex_training\">\n",
+        "<img src=\"https://www.tensorflow.org/images/tf_logo_32px.png\"/>View on TensorFlow.org</a></td>\n",
+        "<td><a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/tfx/blob/master/docs/tutorials/tfx/gcp/vertex_pipelines_vertex_training.ipynb\">\n",
+        "<img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\">Run in Google Colab</a></td>\n",
+        "<td><a target=\"_blank\" href=\"https://github.com/tensorflow/tfx/tree/master/docs/tutorials/tfx/gcp/vertex_pipelines_vertex_training.ipynb\">\n",
+        "<img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\">View source on GitHub</a></td>\n",
+        "<td><a href=\"https://storage.googleapis.com/tensorflow_docs/tfx/docs/tutorials/tfx/gcp/vertex_pipelines_vertex_training.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a></td>\n",
+        "<td><a href=\"https://console.cloud.google.com/mlengine/notebooks/deploy-notebook?q=download_url%3Dhttps%253A%252F%252Fraw.githubusercontent.com%252Ftensorflow%252Ftfx%252Fmaster%252Fdocs%252Ftutorials%252Ftfx%252Fgcp%252Fvertex_pipelines_vertex_training.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Run in Google Cloud AI Platform Notebook</a></td>\n",
+        "</table></div>\n"
       ]
     },
     {
@@ -141,7 +141,7 @@
         "\n",
         "If you are using Google Colab, the first time that you run\n",
         "the cell above, you must restart the runtime by clicking\n",
-        "above \"RESTART RUNTIME\" button or using \"Runtime \u003e Restart\n",
+        "above \"RESTART RUNTIME\" button or using \"Runtime > Restart\n",
         "runtime ...\" menu. This is because of the way that Colab\n",
         "loads packages."
       ]
@@ -207,7 +207,7 @@
         "```sh\n",
         "gcloud auth login\n",
         "```\n",
-        "**in the Terminal window** (which you can open via **File** \u003e **New** in the\n",
+        "**in the Terminal window** (which you can open via **File** > **New** in the\n",
         "menu). You only need to do this once per notebook instance."
       ]
     },
@@ -265,9 +265,9 @@
       },
       "outputs": [],
       "source": [
-        "GOOGLE_CLOUD_PROJECT = ''     # \u003c--- ENTER THIS\n",
-        "GOOGLE_CLOUD_REGION = ''      # \u003c--- ENTER THIS\n",
-        "GCS_BUCKET_NAME = ''          # \u003c--- ENTER THIS\n",
+        "GOOGLE_CLOUD_PROJECT = ''     # <--- ENTER THIS\n",
+        "GOOGLE_CLOUD_REGION = ''      # <--- ENTER THIS\n",
+        "GCS_BUCKET_NAME = ''          # <--- ENTER THIS\n",
         "\n",
         "if not (GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_REGION and GCS_BUCKET_NAME):\n",
         "    from absl import logging\n",
@@ -474,7 +474,7 @@
         "def _input_fn(file_pattern: List[str],\n",
         "              data_accessor: tfx.components.DataAccessor,\n",
         "              schema: schema_pb2.Schema,\n",
-        "              batch_size: int) -\u003e tf.data.Dataset:\n",
+        "              batch_size: int) -> tf.data.Dataset:\n",
         "  \"\"\"Generates features and label for training.\n",
         "\n",
         "  Args:\n",
@@ -495,7 +495,7 @@
         "      schema=schema).repeat()\n",
         "\n",
         "\n",
-        "def _make_keras_model() -\u003e tf.keras.Model:\n",
+        "def _make_keras_model() -> tf.keras.Model:\n",
         "  \"\"\"Creates a DNN Keras model for classifying penguin data.\n",
         "\n",
         "  Returns:\n",
@@ -613,7 +613,22 @@
         "`Trainer`, but it just moves the computation for the model training to cloud.\n",
         "It launches a custom job in Vertex AI Training service and the trainer\n",
         "component in the orchestration system will just wait until the Vertex AI\n",
-        "Training job completes.\n"
+        "Training job completes.\n",
+        "\n",
+        "#### Setting up different GPU types\n",
+        "\n",
+        "In this notebook, we use the string `NVIDIA_TESLA_K80` as the accelerator_type. However, when setting other GPU types, we must use the enum int value instead. The reason for this is that the current tfx version uses python-aiplatform version 0.7.1, which does not contain the string to enum translation for the other GPU types. That is done in in python-aiplatform v1.2.0 and will be supported with tfx in the future when the library is updated.\n",
+        "\n",
+        "As a work around, set the accelerator_type via the enum int value, for example:\n",
+        "\n",
+        "```python\n",
+        "'accelerator_type': 8, #'NVIDIA_TESLA_A100'\n",
+        "```\n",
+        "\n",
+        "Please see the documentation for machine type, accelerator type compatibility https://cloud.google.com/vertex-ai/docs/training/configure-compute#specifying_gpus\n",
+        "\n",
+        "For accelerator_type values please see https://github.com/googleapis/python-aiplatform/blob/main/google/cloud/aiplatform_v1/types/accelerator_type.py\n",
+        "\n"
       ]
     },
     {
@@ -626,7 +641,7 @@
       "source": [
         "def _create_pipeline(pipeline_name: str, pipeline_root: str, data_root: str,\n",
         "                     module_file: str, serving_model_dir: str, project_id: str,\n",
-        "                     region: str, use_gpu: bool) -\u003e tfx.dsl.Pipeline:\n",
+        "                     region: str, use_gpu: bool) -> tfx.dsl.Pipeline:\n",
         "  \"\"\"Implements the penguin pipeline with TFX.\"\"\"\n",
         "  # Brings data into the pipeline or otherwise joins/converts training data.\n",
         "  example_gen = tfx.components.CsvExampleGen(input_base=data_root)\n",
@@ -765,7 +780,7 @@
       },
       "source": [
         "Now you can visit the link in the output above or visit\n",
-        "'Vertex AI \u003e Pipelines' in\n",
+        "'Vertex AI > Pipelines' in\n",
         "[Google Cloud Console](https://console.cloud.google.com/) to see the\n",
         "progress."
       ]
@@ -831,7 +846,7 @@
       },
       "source": [
         "Now you can visit the link in the output above or visit\n",
-        "'Vertex AI \u003e Pipelines' in\n",
+        "'Vertex AI > Pipelines' in\n",
         "[Google Cloud Console](https://console.cloud.google.com/) to see the\n",
         "progress."
       ]


### PR DESCRIPTION
There is an issue with tfx v1.2.0 and below where using the GPU accelerator type enum string is not recognized when running the training job in vertex ai. This is because tfx v1.2.0 and below uses a lower version of the python-aiplatform library which does not do the translation from string to enum value. It only does it for the K80 GPU which is what's displayed in this example.

So in order to use other GPU types, we must insert the actual enum value. This pr is to update the documentation so that others are aware of this work around.