### PR TITLE
Broken link in index.md

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -399,8 +399,7 @@ You will first query
 [**ML Metadata (MLMD)**](mlmd.md) to locate the results of these executions
 of these components, and then use the visualization support API in TFDV to
 create
-the visualizations in your notebook.  This includes [tfdv.load_statistics()](
-`tfdv.load_statistics`)
+the visualizations in your notebook.  This includes [tfdv.load_statistics()](https://www.tensorflow.org/tfx/data_validation/api_docs/python/tfdv/load_statistics)
 and [tfdv.visualize_statistics()](`tfdv.visualize_statistics`)
 Using this visualization you can better understand the characteristics of your
 dataset, and if necessary modify as required.


### PR DESCRIPTION
In index.md file tfdv.load_statistics() hyper link throwing [404](https://www.tensorflow.org/tfx/guide/a%20href=%22https:/www.tensorflow.org/tfx/data_validation/api_docs/python/tfdv/load_statistics%22%3E%3Ccode%3Etfdv.load_statistics%3C/code%3E%3C/a) error and updated with the correct hyper [link](https://www.tensorflow.org/tfx/data_validation/api_docs/python/tfdv/load_statistics) 