### PR TITLE
Upload wheels to GH release

### DIFF
--- a/.github/workflows/wheel-in-release.yml
+++ b/.github/workflows/wheel-in-release.yml
@@ -1,0 +1,30 @@
+name: Add wheels to release
+ 
+on:
+  release:
+    types:
+      - published
+
+jobs:
+ dist_linux:
+    runs-on: ubuntu-latest
+    container:
+      image: gcr.io/tfx-oss-public/tfx_base:py37-20200729
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build wheels
+      run: |
+        bash -x package_build/initialize.sh; \
+        CFLAGS=$(/usr/bin/python-config --cflags) \
+          python package_build/ml-pipelines-sdk/setup.py bdist_wheel; \
+        CFLAGS=$(/usr/bin/python-config --cflags) \
+          python package_build/tfx/setup.py bdist_wheel; \
+        MLSDK_WHEEL=$(find dist -name "ml_pipelines_sdk-*.whl"); \
+        TFX_WHEEL=$(find dist -name "tfx-*.whl"); \
+        
+    - name: Upload
+      uses: shogo82148/actions-upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: dist/*.whl


### PR DESCRIPTION
Mostly wanted to contribute this back since I found it useful to have for patch releases. This builds the wheel and appends them to a GitHub release.