### PR TITLE
Fixed a markdown bug

### DIFF
--- a/tfx/examples/penguin/README.md
+++ b/tfx/examples/penguin/README.md
@@ -55,7 +55,7 @@ To compile the pipeline:
 
 <pre class="devsite-terminal devsite-click-to-copy">
 python penguin_pipeline_kubeflow.py --use_gcp=True
-<pre>
+</pre>
 
 KubeflowDagRunner supports the pipeline with normal components(usually running
 on prem) and with Cloud extended components(usually running on GCP).


### PR DESCRIPTION
Everything below the line `python penguin_pipeline_kubeflow.py --use_gcp=True` was included as "devsite-terminal", which is not the case. This also falsely gives the impression that every title below the title "Instructions for using Kubeflow V1" are subtitles or subcategories, instead of being separate titles themselves.