### PR TITLE
Add remote flag for remote @component decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,5 @@ dmypy.json
 # Bazel generated files
 bazel-*
 **/*_pb2.py
+**/*_pb2_grpc.py
 # LINT.ThenChange(.dockerignore)

--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -61,6 +61,7 @@ def make_pipeline_sdk_required_install_packages():
       'packaging>=20,<21',
       'portpicker>=1.3.1,<2',
       'protobuf>=3.13,<4',
+      'strip-hints>=0.1.0<1',
       'docker>=4.1,<5',
       'google-apitools>=0.5,<1',
       'google-api-python-client>=1.8,<2',


### PR DESCRIPTION
Add a way for TFX `@component` to run on remote environments (aka KFP or Vertex) without having to rebuild the container image to have the function importable.

This mode still requires the image to have TFX installed, but allows for components to be defined in an environment and then sent to the remote environment fully serialized.

Next up: 
- Test internally to make sure this works fine.
- Address pylint issues and format/import sorting.

Duplicate of https://github.com/tensorflow/tfx/pull/4144

CC @charlesccychen 