### PR TITLE
[Cherry-pick] Temporarily pin opencv-python-headless version to avoid a problematic…

### DIFF
--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -162,6 +162,9 @@ def make_extra_packages_tf_ranking():
   # Packages needed for tf-ranking which is used in tfx/examples/ranking.
   return [
       'tensorflow-ranking>=0.3.3,<0.4',
+      # TODO(b/203793924): Remove temporarily pinned version of
+      # opencv-python-headless to avoid a build issue.
+      'opencv-python-headless<4.5.4; platform_system=="Darwin"',
       'struct2tensor' + select_constraint(
           default='>=0.34,<0.35',
           nightly='>=0.35.0.dev',


### PR DESCRIPTION
… version(4.5.4.58) which makes a compiling error in macos.

opencv-python-headless is required by 'tensorflow-ranking -> tf-models-official -> opencv-python-headless'.

PiperOrigin-RevId: 406040111
(cherry picked from commit c0c8979e6ca4480d89613b0524d11118bd933806)