### PR TITLE
[Cherry-pick] Fixes missing py.typed file for python type information.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,7 @@
 ## Bug Fixes and Other Changes
 
 *   Added support for a custom metadata-ui-json filename in KubeflowDagRunner.
+*   Fixed missing type information marker file 'py.typed'.
 
 ## Documentation Updates
 

--- a/tfx/py.typed
+++ b/tfx/py.typed
@@ -1,0 +1,13 @@
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
I read mypy result using cached result wrongly. And the type information was not populated properly.

PiperOrigin-RevId: 398501747
(cherry picked from commit 1cbbae9f8299bde775c63545f0b0b8798b50df6b)