### PR TITLE
Do not depends on TF 2.7 'tensorflow>=1.15.2,!=2.0.*,!=2.1.*,!=2.2.*,…

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Version 1.3.2
+# Version 1.3.3
 
 ## Major Features and Improvements
 
@@ -18,7 +18,7 @@
 
 ## Bug Fixes and Other Changes
 
-*  Fixed endless waiting for Vertex Trainer.
+*   Depends on `tensorflow>=1.15.2,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,<2.7`.
 
 ## Documentation Updates
 

--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -86,7 +86,11 @@ def make_required_install_packages():
       'numpy>=1.16,<1.20',
       'pyarrow>=1,<3',
       'pyyaml>=3.12,<6',
-      'tensorflow>=1.15.2,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,<3',
+      # Keep the TF version same as TFT to help Pip version resolution.
+      # Pip might stuck in a TF 1.15 dependency although there is a working
+      # dependency set with TF 2.x without the sync.
+      'tensorflow' + select_constraint(
+          '>=1.15.2,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,<2.7'),
       'tensorflow-hub>=0.9.0,<0.13',
       'tensorflow-data-validation' + select_constraint(
           default='>=1.3.0,<1.4.0',


### PR DESCRIPTION
…!=2.3.*,!=2.4.*,!=2.5.*,<2.7'.

PiperOrigin-RevId: 408252343
(cherry picked from commit 8e74ef5a805e2c851fa891010420e2a79589bc26)