### PR TITLE
Update components_keras.ipynb

### DIFF
--- a/docs/tutorials/tfx/components_keras.ipynb
+++ b/docs/tutorials/tfx/components_keras.ipynb
@@ -1096,7 +1096,7 @@
         "  model = tf.keras.Model(input_layers, output)\n",
         "  model.compile(\n",
         "      loss=tf.keras.losses.BinaryCrossentropy(from_logits=True),\n",
-        "      optimizer=tf.keras.optimizers.Adam(lr=0.001),\n",
+        "      optimizer=tf.keras.optimizers.Adam(learning_rate=0.001),\n",
         "      metrics=[tf.keras.metrics.BinaryAccuracy()])\n",
         "  model.summary(print_fn=absl.logging.info)\n",
         "  return model\n",


### PR DESCRIPTION
Changed `lr` to `learning_rate`, which removes a deprecation warning.