### PR TITLE
Allow google-api-python-client < 3

### DIFF
--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -63,7 +63,7 @@ def make_pipeline_sdk_required_install_packages():
       'protobuf>=3.13,<4',
       'docker>=4.1,<5',
       'google-apitools>=0.5,<1',
-      'google-api-python-client>=1.8,<2',
+      'google-api-python-client>=1.8,<3',
       # TODO(b/176812386): Deprecate usage of jinja2 for placeholders.
       'jinja2>=2.7.3,<4',
   ]


### PR DESCRIPTION
https://github.com/googleapis/google-api-python-client/blob/main/UPGRADING.md has a full list of changes between google-api-python-client 1 and 2. 

The main changes are that:
* only Python 3.6+ is supported
* discovery documents are cached in the library package (as opposed to documents being fetched at runtime).  

It looks like this library only accessed public APIs through `google-api-python-client`, so there should be no breaking changes visible to the end user. The widened pin will help reduce diamond dependency conflicts for folks using multiple Google libraries.