### PR TITLE
Update tfma_basic.ipynb

### DIFF
--- a/docs/tutorials/model_analysis/tfma_basic.ipynb
+++ b/docs/tutorials/model_analysis/tfma_basic.ipynb
@@ -237,7 +237,7 @@
       "source": [
         "## Parse the Schema\n",
         "\n",
-        "Among the things we downloaded was a schema for our data that was created by [TensorFlow Data Validation](https://www.tensorflow.org/tfx/data_validation/).  Let's parse that now so that we can use it with TFMA."
+        "Among the things we downloaded was a schema for our data that was created by [TensorFlow Data Validation](https://www.tensorflow.org/tfx/data_validation/get_started/).  Let's parse that now so that we can use it with TFMA."
       ]
     },
     {


### PR DESCRIPTION
tfma_basic.ipynb has a broken link, updated with the correct link
(https://www.tensorflow.org/tfx/data_validation/get_started)