### PR TITLE
fix typo in kubeflow_dag_runner_test

### DIFF
--- a/tfx/orchestration/kubeflow/kubeflow_dag_runner_test.py
+++ b/tfx/orchestration/kubeflow/kubeflow_dag_runner_test.py
@@ -220,7 +220,7 @@ class KubeflowDagRunnerTest(test_case_utils.TfxTest):
       self.assertEqual('/secret/gcp-credentials/user-gcp-sa.json',
                        env[0]['value'])
 
-      container_1 = containers[0]
+      container_1 = containers[1]
       env = [
           env for env in container_1['container']['env']
           if env['name'] == 'GOOGLE_APPLICATION_CREDENTIALS'


### PR DESCRIPTION
I think this line should be `container_1 = containers[1]`, since above comment says `Check that each container has default GCP credentials.`