### PR TITLE
Update airflow_workshop.md

### DIFF
--- a/docs/tutorials/tfx/airflow_workshop.md
+++ b/docs/tutorials/tfx/airflow_workshop.md
@@ -276,7 +276,7 @@ airflow webserver -p 7070
 
 #### Airflow CLI
 
-You can also use the [Airflow CLI](https://airflow.apache.org/cli.html) to
+You can also use the [Airflow CLI](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html) to
 enable and trigger your DAGs:
 
 ```bash


### PR DESCRIPTION
airflow_workshop.md has a broken link, updated with the correct link
(https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html)