### PR TITLE
Update tft.md

### DIFF
--- a/docs/guide/tft.md
+++ b/docs/guide/tft.md
@@ -2,7 +2,7 @@
 
 Transform is available as a standalone library.
 
--   [Getting Started with TensorFlow Transform](/tfx/transform/get_started)
+-   [Getting Started with TensorFlow Transform](https://www.tensorflow.org/tfx/transform/get_started)
 -   [TensorFlow Transform API Reference](/tfx/transform/api_docs/python/tft)
 
 The `tft` module documentation is the only module that is relevant to TFX users.


### PR DESCRIPTION
The hyperlink of the page "https://github.com/tensorflow/tfx/blob/master/tfx/transform/get_started" results in 404 error and so modifying it to point the correct link "https://www.tensorflow.org/tfx/transform/get_started"