### PR TITLE
fix typo in `tfx/components/evalutor/component.py`

### DIFF
--- a/tfx/components/evaluator/component.py
+++ b/tfx/components/evaluator/component.py
@@ -36,7 +36,7 @@ class Evaluator(base_beam_component.BaseBeamComponent):
    - `evaluation`: Channel of type `standard_artifacts.ModelEvaluation` to
    store
                    the evaluation results.
-   - `blessing`: Channel of type `standard_artifacts.ModelBlessing' that
+   - `blessing`: Channel of type `standard_artifacts.ModelBlessing` that
                  contains the blessing result.
 
   See [the Evaluator guide](https://www.tensorflow.org/tfx/guide/evaluator) for


### PR DESCRIPTION
Fix typo in `tfx/components/evalutor/component.py`.

* Docs link: https://www.tensorflow.org/tfx/api_docs/python/tfx/v1/components/Evaluator
