### PR TITLE
fix broken tft.md link

### DIFF
--- a/docs/guide/tft.md
+++ b/docs/guide/tft.md
@@ -3,7 +3,7 @@
 Transform is available as a standalone library.
 
 -   [Getting Started with TensorFlow Transform](/tfx/transform/get_started)
--   [TensorFlow Transform API Reference](/tfx/transform/api_docs/python/tft)
+-   [TensorFlow Transform API Reference](https://www.tensorflow.org/tfx/transform/api_docs/python/tft)
 
 The `tft` module documentation is the only module that is relevant to TFX users.
 The `tft_beam` module is relevant only when using Transform as a standalone library. Typically, a TFX user constructs a `preprocessing_fn`, and the rest of the


### PR DESCRIPTION
Broken link in tft.md file and updated with the correct [link] (https://www.tensorflow.org/tfx/transform/api_docs/python/tft)