### PR TITLE
Bugfix in regular expresion for paths in windows

### DIFF
--- a/tfx/components/example_gen/utils.py
+++ b/tfx/components/example_gen/utils.py
@@ -241,10 +241,11 @@ def make_default_output_config(
 def _glob_to_regex(glob_pattern: str) -> str:
   """Changes glob pattern to regex pattern."""
   regex_pattern = glob_pattern
+  regex_pattern = regex_pattern.replace('\\', '\\\\')  
   regex_pattern = regex_pattern.replace('.', '\\.')
   regex_pattern = regex_pattern.replace('+', '\\+')
-  regex_pattern = regex_pattern.replace('*', '[^/]*')
-  regex_pattern = regex_pattern.replace('?', '[^/]')
+  regex_pattern = regex_pattern.replace('*', '[^\\\\/]*')
+  regex_pattern = regex_pattern.replace('?', '[^\\\\/]')
   regex_pattern = regex_pattern.replace('(', '\\(')
   regex_pattern = regex_pattern.replace(')', '\\)')
   return regex_pattern


### PR DESCRIPTION
The regex must deal with windows paths, divided with backslashes