### PR TITLE
Extend tfxio factory to use parquet-tfxio

### DIFF
--- a/tfx/components/util/tfxio_utils.py
+++ b/tfx/components/util/tfxio_utils.py
@@ -32,7 +32,7 @@ from tfx_bsl.tfxio import tfxio
 from tensorflow_metadata.proto.v0 import schema_pb2
 
 
-_SUPPORTED_PAYLOAD_FORMATS = ['parquet', 'tfrecords_gzip']
+_SUPPORTED_FILE_FORMATS = {example_gen_pb2.FileFormat.FORMAT_PARQUET, example_gen_pb2.FileFormat.FORMAT_TFRECORDS_GZIP}
 # TODO(b/162532479): switch to support List[str] exclusively, once tfx-bsl
 # post-0.22 is released.
 OneOrMorePatterns = Union[str, List[str]]
@@ -245,12 +245,12 @@ def get_data_view_decode_fn_from_artifact(
 def make_tfxio(
     file_pattern: OneOrMorePatterns,
     telemetry_descriptors: List[str],
-    payload_format: Union[str, int],
+    payload_format: Union[example_gen_pb2.PayloadFormat, int],
     data_view_uri: Optional[str] = None,
     schema: Optional[schema_pb2.Schema] = None,
     read_as_raw_records: bool = False,
     raw_record_column_name: Optional[str] = None,
-    file_format: Optional[Union[str, List[str]]] = None) -> tfxio.TFXIO:
+    file_format: Optional[Union[example_gen_pb2.FileFormat, List[example_gen_pb2.FileFormat]]] = None) -> tfxio.TFXIO:
   """Creates a TFXIO instance that reads `file_pattern`.
 
   Args:
@@ -274,7 +274,7 @@ def make_tfxio(
       that column will be the raw records. Note that not all TFXIO supports this
       option, and an error will be raised in that case. Required if
       read_as_raw_records == True.
-    file_format: file format string for each file_pattern. Only 'tfrecords_gzip'
+    file_format: file format for each file_pattern. Only 'tfrecords_gzip'
       and 'parquet' are supported for now.
 
   Returns:
@@ -294,10 +294,10 @@ def make_tfxio(
             f'The length of file_pattern and file_formats should be the same.'
             f'Given: file_pattern={file_pattern}, file_format={file_format}')
       else:
-        if any(item in _SUPPORTED_PAYLOAD_FORMATS for item in file_format):
+        if any(item in _SUPPORTED_FILE_FORMATS for item in file_format):
           raise NotImplementedError(f'{file_format} is not supported yet.')
     else:  # file_format is str type.
-      if file_format in _SUPPORTED_PAYLOAD_FORMATS:
+      if file_format in _SUPPORTED_FILE_FORMATS:
         raise NotImplementedError(f'{file_format} is not supported yet.')
 
   if read_as_raw_records:

--- a/tfx/components/util/tfxio_utils.py
+++ b/tfx/components/util/tfxio_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """TFXIO (standardized TFX inputs) related utilities."""
+from __future__ import annotations
 
 from typing import Any, Callable, Dict, List, Iterator, Optional, Tuple, Union
 

--- a/tfx/components/util/tfxio_utils.py
+++ b/tfx/components/util/tfxio_utils.py
@@ -32,7 +32,7 @@ from tfx_bsl.tfxio import tfxio
 from tensorflow_metadata.proto.v0 import schema_pb2
 
 
-_SUPPORTED_FILE_FORMATS = {example_gen_pb2.FileFormat.FORMAT_PARQUET, example_gen_pb2.FileFormat.FORMAT_TFRECORDS_GZIP}
+_SUPPORTED_FILE_FORMATS = (example_gen_pb2.FileFormat.FORMAT_PARQUET, example_gen_pb2.FileFormat.FORMAT_TFRECORDS_GZIP)
 # TODO(b/162532479): switch to support List[str] exclusively, once tfx-bsl
 # post-0.22 is released.
 OneOrMorePatterns = Union[str, List[str]]
@@ -294,10 +294,10 @@ def make_tfxio(
             f'The length of file_pattern and file_formats should be the same.'
             f'Given: file_pattern={file_pattern}, file_format={file_format}')
       else:
-        if any(item in _SUPPORTED_FILE_FORMATS for item in file_format):
+        if any(item not in _SUPPORTED_FILE_FORMATS for item in file_format):
           raise NotImplementedError(f'{file_format} is not supported yet.')
     else:  # file_format is str type.
-      if file_format in _SUPPORTED_FILE_FORMATS:
+      if file_format not in _SUPPORTED_FILE_FORMATS:
         raise NotImplementedError(f'{file_format} is not supported yet.')
 
   if read_as_raw_records:

--- a/tfx/components/util/tfxio_utils.py
+++ b/tfx/components/util/tfxio_utils.py
@@ -32,7 +32,10 @@ from tfx_bsl.tfxio import tfxio
 from tensorflow_metadata.proto.v0 import schema_pb2
 
 
-_SUPPORTED_FILE_FORMATS = (example_gen_pb2.FileFormat.FORMAT_PARQUET, example_gen_pb2.FileFormat.FORMAT_TFRECORDS_GZIP)
+_SUPPORTED_FILE_FORMATS = (
+    example_gen_pb2.FileFormat.FILE_FORMAT_PARQUET,
+    example_gen_pb2.FileFormat.FORMAT_TFRECORDS_GZIP
+)
 # TODO(b/162532479): switch to support List[str] exclusively, once tfx-bsl
 # post-0.22 is released.
 OneOrMorePatterns = Union[str, List[str]]

--- a/tfx/components/util/tfxio_utils_test.py
+++ b/tfx/components/util/tfxio_utils_test.py
@@ -26,6 +26,7 @@ from tfx.components.util import tfxio_utils
 from tfx.proto import example_gen_pb2
 from tfx.types import standard_artifacts
 from tfx_bsl.coders import tf_graph_record_decoder
+from tfx_bsl.tfxio import parquet_tfxio
 from tfx_bsl.tfxio import raw_tf_record
 from tfx_bsl.tfxio import record_based_tfxio
 from tfx_bsl.tfxio import record_to_tensor_tfxio
@@ -70,6 +71,10 @@ _MAKE_TFXIO_TEST_CASES = [
         read_as_raw_records=True,
         raw_record_column_name=_RAW_RECORD_COLUMN_NAME,
         expected_tfxio_type=raw_tf_record.RawTfRecordTFXIO),
+    dict(
+      testcase_name='parquet_payload_format',
+      payload_format=example_gen_pb2.PayloadFormat.FORMAT_PARQUET,
+      expected_tfxio_type=parquet_tfxio.ParquetTFXIO),
 ]
 
 _RESOLVE_TEST_CASES = [
@@ -181,11 +186,9 @@ class TfxioUtilsTest(tf.test.TestCase, parameterized.TestCase):
         _FAKE_FILE_PATTERN, _TELEMETRY_DESCRIPTORS, payload_format,
         data_view_uri, _SCHEMA, read_as_raw_records, raw_record_column_name)
     self.assertIsInstance(tfxio, expected_tfxio_type)
-    # We currently only create RecordBasedTFXIO and the check below relies on
-    # that.
-    self.assertIsInstance(tfxio, record_based_tfxio.RecordBasedTFXIO)
     self.assertEqual(tfxio.telemetry_descriptors, _TELEMETRY_DESCRIPTORS)
-    self.assertEqual(tfxio.raw_record_column_name, raw_record_column_name)
+    if isinstance(tfxio, record_based_tfxio.RecordBasedTFXIO):
+      self.assertEqual(tfxio.raw_record_column_name, raw_record_column_name)
     # Since we provide a schema, ArrowSchema() should not raise.
     _ = tfxio.ArrowSchema()
 
@@ -219,11 +222,9 @@ class TfxioUtilsTest(tf.test.TestCase, parameterized.TestCase):
         raw_record_column_name)
     tfxio = tfxio_factory(_FAKE_FILE_PATTERN)
     self.assertIsInstance(tfxio, expected_tfxio_type)
-    # We currently only create RecordBasedTFXIO and the check below relies on
-    # that.
-    self.assertIsInstance(tfxio, record_based_tfxio.RecordBasedTFXIO)
     self.assertEqual(tfxio.telemetry_descriptors, _TELEMETRY_DESCRIPTORS)
-    self.assertEqual(tfxio.raw_record_column_name, raw_record_column_name)
+    if isinstance(tfxio, record_based_tfxio.RecordBasedTFXIO):
+      self.assertEqual(tfxio.raw_record_column_name, raw_record_column_name)
     # Since we provide a schema, ArrowSchema() should not raise.
     _ = tfxio.ArrowSchema()
 

--- a/tfx/components/util/tfxio_utils_test.py
+++ b/tfx/components/util/tfxio_utils_test.py
@@ -307,7 +307,7 @@ class TfxioUtilsTest(tf.test.TestCase, parameterized.TestCase):
     dataset_factory = tfxio_utils.get_tf_dataset_factory_from_artifact(
         [examples], _TELEMETRY_DESCRIPTORS)
     self.assertIsInstance(dataset_factory, Callable)
-    self.assertEqual(tf.data.Dataset,
+    self.assertEqual('tf.data.Dataset',
                      inspect.signature(dataset_factory).return_annotation)
 
   def test_get_record_batch_factory_from_artifact(self):
@@ -318,7 +318,7 @@ class TfxioUtilsTest(tf.test.TestCase, parameterized.TestCase):
     record_batch_factory = tfxio_utils.get_record_batch_factory_from_artifact(
         [examples], _TELEMETRY_DESCRIPTORS)
     self.assertIsInstance(record_batch_factory, Callable)
-    self.assertEqual(Iterator[pa.RecordBatch],
+    self.assertEqual('Iterator[pa.RecordBatch]',
                      inspect.signature(record_batch_factory).return_annotation)
 
   def test_raise_if_data_view_uri_not_available(self):

--- a/tfx/proto/example_gen.proto
+++ b/tfx/proto/example_gen.proto
@@ -126,6 +126,7 @@ enum FileFormat {
   FORMAT_TFRECORDS_GZIP = 5;
 
   // Indicates parquet format files in any of the supported compressions.
+  // protolint:disable MAX_LINE_LENGTH
   // https://arrow.apache.org/docs/python/parquet.html#compression-encoding-and-file-compatibility
   FILE_FORMAT_PARQUET = 16;
 

--- a/tfx/proto/example_gen.proto
+++ b/tfx/proto/example_gen.proto
@@ -111,7 +111,10 @@ enum PayloadFormat {
   // Serialized any protocol buffer.
   FORMAT_PROTO = 11;
 
-  reserved 1 to 5, 8 to 10, 12 to max;
+  // Serialized parquet messages.
+  FORMAT_PARQUET = 12;
+
+  reserved 1 to 5, 8 to 10, 13 to max;
 }
 
 // Enum to indicate file format that ExampleGen produces.

--- a/tfx/proto/example_gen.proto
+++ b/tfx/proto/example_gen.proto
@@ -112,9 +112,9 @@ enum PayloadFormat {
   FORMAT_PROTO = 11;
 
   // Serialized parquet messages.
-  FORMAT_PARQUET = 12;
+  FORMAT_PARQUET = 15;
 
-  reserved 1 to 5, 8 to 10, 13 to max;
+  reserved 1 to 5, 8 to 10, 12 to 14, 16 to max;
 }
 
 // Enum to indicate file format that ExampleGen produces.
@@ -127,9 +127,9 @@ enum FileFormat {
 
   // Indicates parquet format files in any of the supported compressions.
   // https://arrow.apache.org/docs/python/parquet.html#compression-encoding-and-file-compatibility
-  FORMAT_PARQUET = 6;
+  FORMAT_PARQUET = 16;
 
-  reserved 1 to 4, 7 to max;
+  reserved 1 to 4, 7 to 15, 17 to max;
 }
 
 // Specification of the output of the example gen.

--- a/tfx/proto/example_gen.proto
+++ b/tfx/proto/example_gen.proto
@@ -125,7 +125,11 @@ enum FileFormat {
   // Indicates TFRecords format files with gzip compression.
   FORMAT_TFRECORDS_GZIP = 5;
 
-  reserved 1 to 4, 6 to max;
+  // Indicates parquet format files in any of the supported compressions.
+  // https://arrow.apache.org/docs/python/parquet.html#compression-encoding-and-file-compatibility
+  FORMAT_PARQUET = 6;
+
+  reserved 1 to 4, 7 to max;
 }
 
 // Specification of the output of the example gen.

--- a/tfx/proto/example_gen.proto
+++ b/tfx/proto/example_gen.proto
@@ -127,7 +127,7 @@ enum FileFormat {
 
   // Indicates parquet format files in any of the supported compressions.
   // https://arrow.apache.org/docs/python/parquet.html#compression-encoding-and-file-compatibility
-  FORMAT_PARQUET = 16;
+  FILE_FORMAT_PARQUET = 16;
 
   reserved 1 to 4, 7 to 15, 17 to max;
 }


### PR DESCRIPTION
This PR depends on https://github.com/tensorflow/tfx-bsl/pull/53 and https://github.com/tensorflow/tfx-bsl/pull/54 being released.

Extend the `make_tfxio` factory to use `ParquetTFXIO` if the `payload_format` is `FORMAT_PARQUET`.