### PR TITLE
Typo fix

### DIFF
--- a/docs/tutorials/tfx/penguin_simple.ipynb
+++ b/docs/tutorials/tfx/penguin_simple.ipynb
@@ -560,7 +560,7 @@
         "Python package and runs pipelines on local environment.\n",
         "We often call TFX pipelines \"DAGs\" which stands for directed acyclic graph.\n",
         "\n",
-        "`LocalDagRunner` provides fast iterations for developemnt and debugging.\n",
+        "`LocalDagRunner` provides fast iterations for development and debugging.\n",
         "TFX also supports other orchestrators including Kubeflow Pipelines and Apache\n",
         "Airflow which are suitable for production use cases.\n",
         "\n",


### PR DESCRIPTION
Changed `developemnt` to `development`

Fixes: https://github.com/tensorflow/tensorflow/issues/55282