### PR TITLE
Update tft.md

### DIFF
--- a/docs/guide/tft.md
+++ b/docs/guide/tft.md
@@ -2,7 +2,7 @@
 
 Transform is available as a standalone library.
 
--   [Getting Started with TensorFlow Transform](/tfx/transform/get_started)
+-   [Getting Started with TensorFlow Transform](https://www.tensorflow.org/tfx/data_validation/get_started/)
 -   [TensorFlow Transform API Reference](https://www.tensorflow.org/tfx/transform/api_docs/python/tft)
 
 The `tft` module documentation is the only module that is relevant to TFX users.

--- a/docs/guide/tft.md
+++ b/docs/guide/tft.md
@@ -2,7 +2,7 @@
 
 Transform is available as a standalone library.
 
--   [Getting Started with TensorFlow Transform](https://www.tensorflow.org/tfx/data_validation/get_started/)
+-   [Getting Started with TensorFlow Transform](https://www.tensorflow.org/tfx/transform/get_started)
 -   [TensorFlow Transform API Reference](https://www.tensorflow.org/tfx/transform/api_docs/python/tft)
 
 The `tft` module documentation is the only module that is relevant to TFX users.


### PR DESCRIPTION
tft.md has a broken link, updated with the correct link
(https://www.tensorflow.org/tfx/transform/get_started)