### PR TITLE
Update vertex_pipelines_bq.ipynb

### DIFF
--- a/docs/tutorials/tfx/gcp/vertex_pipelines_bq.ipynb
+++ b/docs/tutorials/tfx/gcp/vertex_pipelines_bq.ipynb
@@ -375,7 +375,7 @@
         "[Simple TFX Pipeline for Vertex Pipelines Tutorial](https://www.tensorflow.org/tfx/tutorials/tfx/gcp/vertex_pipelines_simple).\n",
         "We previously used `CsvExampleGen` which reads data from a CSV file. In this\n",
         "tutorial, we will use\n",
-        "[`BigQueryExampleGen`](https://www.tensorflow.org/tfx/api_docs/python/tfx/extensions/google_cloud_big_query/example_gen/component/BigQueryExampleGen)\n",
+        "[`BigQueryExampleGen`](https://tensorflow.google.cn/tfx/api_docs/python/tfx/v1/extensions/google_cloud_big_query/BigQueryExampleGen)\n",
         "component which reads data from BigQuery.\n"
       ]
     },

--- a/docs/tutorials/tfx/gcp/vertex_pipelines_bq.ipynb
+++ b/docs/tutorials/tfx/gcp/vertex_pipelines_bq.ipynb
@@ -375,7 +375,7 @@
         "[Simple TFX Pipeline for Vertex Pipelines Tutorial](https://www.tensorflow.org/tfx/tutorials/tfx/gcp/vertex_pipelines_simple).\n",
         "We previously used `CsvExampleGen` which reads data from a CSV file. In this\n",
         "tutorial, we will use\n",
-        "[`BigQueryExampleGen`](https://tensorflow.google.cn/tfx/api_docs/python/tfx/v1/extensions/google_cloud_big_query/BigQueryExampleGen)\n",
+        "[`BigQueryExampleGen`](https://www.tensorflow.org/tfx/api_docs/python/tfx/v1/extensions/google_cloud_big_query/BigQueryExampleGen)\n",
         "component which reads data from BigQuery.\n"
       ]
     },


### PR DESCRIPTION
Fixing broken link for BigQuery ExampleGen, Updated with correct link
(https://www.tensorflow.org/tfx/api_docs/python/tfx/v1/extensions/google_cloud_big_query/BigQueryExampleGen)