### PR TITLE
Update rest_simple.ipynb

### DIFF
--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -67,7 +67,7 @@
         "id": "FbVhjPpzn6BM"
       },
       "source": [
-        "This guide trains a neural network model to classify [images of clothing, like sneakers and shirts](https://github.com/zalandoresearch/fashion-mnist), saves the trained model, and then serves it with [TensorFlow Serving](https://www.tensorflow.org/serving/).  The focus is on TensorFlow Serving, rather than the modeling and training in TensorFlow, so for a complete example which focuses on the modeling and training see the [Basic Classification example](https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/keras/basic_classification.ipynb).\n",
+        "This guide trains a neural network model to classify [images of clothing, like sneakers and shirts](https://github.com/zalandoresearch/fashion-mnist), saves the trained model, and then serves it with [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving).  The focus is on TensorFlow Serving, rather than the modeling and training in TensorFlow, so for a complete example which focuses on the modeling and training see the [Basic Classification example](https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/keras/basic_classification.ipynb).\n",
         "\n",
         "This guide uses [tf.keras](https://github.com/tensorflow/docs/blob/master/site/en/r1/guide/keras.ipynb), a high-level API to build and train models in TensorFlow."
       ]


### PR DESCRIPTION
Fixing a broken link for the TensorFlow Serving guide in this [section](https://www.tensorflow.org/tfx/tutorials/serving/rest_simple) with the correct URL(https://www.tensorflow.org/tfx/guide/serving)