### PR TITLE
Use extra index url flag when pip installing nightly.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ export TFX_DEPENDENCY_SELECTOR=NIGHTLY
 # orchestrator only, use [airflow] or [kfp]. (Beam and Local orchestators can
 # be run without any extra dependency.) For example,
 # $ pip install -e .[kfp] -i https://pypi-nightly.tensorflow.org/simple
-pip install -e . -i https://pypi-nightly.tensorflow.org/simple
+pip install -e . --extra-index-url https://pypi-nightly.tensorflow.org/simple
 ```
 
 Alternatively, you can also build all TFX family libraries from github source


### PR DESCRIPTION
Updates the pip command in the contributing guide to use `--extra-index-url` when installing the nightly. Follows up on https://github.com/tensorflow/tfx/commit/d51cdbb6153540c08b9f590a4dbd3dadb4f68926.