### PR TITLE
Make Importer output key configurable

### DIFF
--- a/tfx/dsl/components/common/importer_test.py
+++ b/tfx/dsl/components/common/importer_test.py
@@ -37,14 +37,16 @@ class ImporterTest(tf.test.TestCase):
             'str_custom_property': 'abc',
             'int_custom_property': 123,
         },
-        artifact_type=standard_artifacts.Examples).with_id('my_importer')
+        artifact_type=standard_artifacts.Examples,
+        output_key='examples').with_id('my_importer')
     self.assertDictEqual(
         impt.exec_properties, {
             importer.SOURCE_URI_KEY: 'm/y/u/r/i',
             importer.REIMPORT_OPTION_KEY: 0,
+            importer.OUTPUT_KEY_KEY: 'examples',
         })
     self.assertEmpty(impt.inputs)
-    output_channel = impt.outputs[importer.IMPORT_RESULT_KEY]
+    output_channel = impt.outputs[impt.exec_properties[importer.OUTPUT_KEY_KEY]]
     self.assertEqual(output_channel.type, standard_artifacts.Examples)
     # Tests properties in channel.
     self.assertEqual(output_channel.additional_properties, {
@@ -127,6 +129,7 @@ class ImporterDriverTest(tf.test.TestCase):
           exec_properties={
               importer.SOURCE_URI_KEY: self.source_uri,
               importer.REIMPORT_OPTION_KEY: int(reimport),
+              importer.OUTPUT_KEY_KEY: importer.IMPORT_RESULT_KEY,
           })
       self.assertFalse(execution_result.use_cached_results)
       self.assertEmpty(execution_result.input_dict)

--- a/tfx/orchestration/experimental/core/task_schedulers/importer_task_scheduler.py
+++ b/tfx/orchestration/experimental/core/task_schedulers/importer_task_scheduler.py
@@ -33,7 +33,8 @@ class ImporterTaskScheduler(task_scheduler.TaskScheduler[task_lib.ExecNodeTask]
       return {k: data_types_utils.get_value(v) for k, v in proto_map.items()}
 
     pipeline_node = self.task.get_pipeline_node()
-    output_spec = pipeline_node.outputs.outputs[importer.IMPORT_RESULT_KEY]
+    output_key = str(self.task.exec_properties[importer.OUTPUT_KEY_KEY])
+    output_spec = pipeline_node.outputs.outputs[output_key]
     properties = _as_dict(output_spec.artifact_spec.additional_properties)
     custom_properties = _as_dict(
         output_spec.artifact_spec.additional_custom_properties)
@@ -46,7 +47,8 @@ class ImporterTaskScheduler(task_scheduler.TaskScheduler[task_lib.ExecNodeTask]
         reimport=bool(self.task.exec_properties[importer.REIMPORT_OPTION_KEY]),
         output_artifact_class=types.Artifact(
             output_spec.artifact_spec.type).type,
-        mlmd_artifact_type=output_spec.artifact_spec.type)
+        mlmd_artifact_type=output_spec.artifact_spec.type,
+        output_key=output_key)
 
     return task_scheduler.TaskSchedulerResult(
         status=status_lib.Status(code=status_lib.Code.OK),

--- a/tfx/orchestration/experimental/core/task_schedulers/importer_task_scheduler_test.py
+++ b/tfx/orchestration/experimental/core/task_schedulers/importer_task_scheduler_test.py
@@ -140,6 +140,12 @@ class ImporterTaskSchedulerTest(test_utils.TfxTest):
             }
           }
           custom_properties {
+            key: "output_key"
+            value {
+              string_value: "result"
+            }
+          }
+          custom_properties {
             key: "reimport"
             value {
               int_value: 1

--- a/tfx/orchestration/kubeflow/v2/step_builder.py
+++ b/tfx/orchestration/kubeflow/v2/step_builder.py
@@ -488,7 +488,8 @@ class StepBuilder:
   def _build_importer_spec(self) -> ImporterSpec:
     """Builds ImporterSpec."""
     assert isinstance(self._node, importer.Importer)
-    output_channel = self._node.outputs[importer.IMPORT_RESULT_KEY]
+    output_key = str(self._exec_properties[importer.OUTPUT_KEY_KEY])
+    output_channel = self._node.outputs[output_key]
     result = ImporterSpec()
 
     # Importer's output channel contains one artifact instance with

--- a/tfx/orchestration/kubeflow/v2/testdata/expected_importer_component.pbtxt
+++ b/tfx/orchestration/kubeflow/v2/testdata/expected_importer_component.pbtxt
@@ -9,6 +9,12 @@ input_definitions {
     }
   }
   parameters {
+    key: "output_key"
+    value {
+      type: STRING
+    }
+  }
+  parameters {
     key: "reimport"
     value {
       type: INT

--- a/tfx/orchestration/kubeflow/v2/testdata/expected_importer_component_with_runtime_param.pbtxt
+++ b/tfx/orchestration/kubeflow/v2/testdata/expected_importer_component_with_runtime_param.pbtxt
@@ -9,6 +9,12 @@ input_definitions {
     }
   }
   parameters {
+    key: "output_key"
+    value {
+      type: STRING
+    }
+  }
+  parameters {
     key: "reimport"
     value {
       type: INT

--- a/tfx/orchestration/kubeflow/v2/testdata/expected_importer_task.pbtxt
+++ b/tfx/orchestration/kubeflow/v2/testdata/expected_importer_task.pbtxt
@@ -16,6 +16,16 @@ inputs {
     }
   }
   parameters {
+    key: "output_key"
+    value {
+      runtime_value {
+        constant_value {
+          string_value: "result"
+        }
+      }
+    }
+  }
+  parameters {
     key: "reimport"
     value {
       runtime_value {

--- a/tfx/orchestration/kubeflow/v2/testdata/expected_importer_task_with_runtime_param.pbtxt
+++ b/tfx/orchestration/kubeflow/v2/testdata/expected_importer_task_with_runtime_param.pbtxt
@@ -12,6 +12,16 @@ inputs {
     }
   }
   parameters {
+    key: "output_key"
+    value {
+      runtime_value {
+        constant_value {
+          string_value: "result"
+        }
+      }
+    }
+  }
+  parameters {
     key: "reimport"
     value {
       runtime_value {

--- a/tfx/orchestration/portable/importer_node_handler.py
+++ b/tfx/orchestration/portable/importer_node_handler.py
@@ -30,11 +30,12 @@ from tfx.proto.orchestration import pipeline_pb2
 
 
 def _is_artifact_reimported(
-    output_artifacts: Dict[str, List[types.Artifact]]) -> bool:
+    output_artifacts: Dict[str, List[types.Artifact]],
+    output_key: str) -> bool:
   # The artifacts are reimported only when there are artifacts in the output
   # dict and ids has been assign to them.
-  return (bool(output_artifacts[importer.IMPORT_RESULT_KEY]) and all(
-      (bool(a.id) for a in output_artifacts[importer.IMPORT_RESULT_KEY])))
+  return (bool(output_artifacts[output_key]) and all(
+      (bool(a.id) for a in output_artifacts[output_key])))
 
 
 class ImporterNodeHandler(system_node_handler.SystemNodeHandler):
@@ -86,7 +87,8 @@ class ImporterNodeHandler(system_node_handler.SystemNodeHandler):
           exec_properties=exec_properties)
 
       # 4. Generate output artifacts to represent the imported artifacts.
-      output_spec = pipeline_node.outputs.outputs[importer.IMPORT_RESULT_KEY]
+      output_key = str(exec_properties[importer.OUTPUT_KEY_KEY])
+      output_spec = pipeline_node.outputs.outputs[output_key]
       properties = self._extract_proto_map(
           output_spec.artifact_spec.additional_properties)
       custom_properties = self._extract_proto_map(
@@ -100,7 +102,8 @@ class ImporterNodeHandler(system_node_handler.SystemNodeHandler):
           custom_properties=custom_properties,
           reimport=bool(exec_properties[importer.REIMPORT_OPTION_KEY]),
           output_artifact_class=output_artifact_class,
-          mlmd_artifact_type=output_spec.artifact_spec.type)
+          mlmd_artifact_type=output_spec.artifact_spec.type,
+          output_key=output_key)
 
       result = data_types.ExecutionInfo(
           execution_id=execution.id,
@@ -117,7 +120,7 @@ class ImporterNodeHandler(system_node_handler.SystemNodeHandler):
 
       # 5. Publish the output artifacts. If artifacts are reimported, the
       # execution is published as CACHED. Otherwise it is published as COMPLETE.
-      if _is_artifact_reimported(output_artifacts):
+      if _is_artifact_reimported(output_artifacts, output_key):
         execution_publish_utils.publish_cached_execution(
             metadata_handler=m,
             contexts=contexts,

--- a/tfx/orchestration/portable/importer_node_handler_test.py
+++ b/tfx/orchestration/portable/importer_node_handler_test.py
@@ -110,6 +110,12 @@ class ImporterNodeHandlerTest(test_case_utils.TfxTest):
             }
           }
           custom_properties {
+            key: "output_key"
+            value {
+              string_value: "result"
+            }
+          }
+          custom_properties {
             key: "reimport"
             value {
               int_value: 1
@@ -166,6 +172,12 @@ class ImporterNodeHandlerTest(test_case_utils.TfxTest):
             key: "artifact_uri"
             value {
               string_value: "my_url"
+            }
+          }
+          custom_properties {
+            key: "output_key"
+            value {
+              string_value: "result"
             }
           }
           custom_properties {
@@ -232,6 +244,12 @@ class ImporterNodeHandlerTest(test_case_utils.TfxTest):
             }
           }
           custom_properties {
+            key: "output_key"
+            value {
+              string_value: "result"
+            }
+          }
+          custom_properties {
             key: "reimport"
             value {
               int_value: 0
@@ -263,6 +281,12 @@ class ImporterNodeHandlerTest(test_case_utils.TfxTest):
             key: "artifact_uri"
             value {
               string_value: "my_url"
+            }
+          }
+          custom_properties {
+            key: "output_key"
+            value {
+              string_value: "result"
             }
           }
           custom_properties {

--- a/tfx/orchestration/portable/testdata/pipeline_for_launcher_test.pbtxt
+++ b/tfx/orchestration/portable/testdata/pipeline_for_launcher_test.pbtxt
@@ -371,6 +371,14 @@ nodes {
         }
       }
       parameters {
+        key: "output_key"
+        value {
+          field_value {
+            string_value: "result"
+          }
+        }
+      }
+      parameters {
         key: "reimport"
         value {
           field_value {


### PR DESCRIPTION
Currently, the Importer's output key is hard-coded as "result". This change will allow users to configure the ouput key using an `output_key` argument, making it is easier to use the Importer and the original component that generated the artifact interchangeably. Resolves  #4251.

Example Usage:
```
from tfx.components import StatisticsGen
from tfx.dsl.components.common.importer import Importer
from tfx.types import standard_artifacts

import_examples = Importer(
  source_uri='path/to/examples',
  properties={'split_names': '["train", "eval"]'},
  artifact_type=standard_artifacts.Examples,
  output_key='examples'
).with_id('import_examples')

statistics_gen = StatisticsGen(
  examples=import_examples.outputs['examples'])
```