### PR TITLE
Fixing broken link on index.md

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -280,7 +280,7 @@ model in production, or exporting a trained model for a native mobile or
 JavaScript application. For example, to turn a model into a REST service for
 making predictions, you can serialize the model as a SavedModel and serve it
 using TensorFlow Serving. See [Serving a TensorFlow
-Model](https://www.tensorflow.org/serving/tutorials/Serving_REST_simple) for
+Model](https://www.tensorflow.org/tfx/serving/serving_basic) for
 more information.
 
 ### Schema


### PR DESCRIPTION
Fixing broken link for `Serving a TensorFlow Model` in [this section](https://www.tensorflow.org/tfx/guide#savedmodel).