### PR TITLE
Caps the apache-airflow version to 2.2.x.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,8 @@
 
 ## Bug Fixes and Other Changes
 
-*   Uses apache-beam==2.38 in the tfx container image.
+* Temporarily capped `apache-airflow` version to 2.2.x to avoid dependency
+  conflict. We will rollback this change once `kfp` releases a new version.
 
 ## Dependency Updates
 

--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -116,7 +116,9 @@ def make_required_install_packages():
 def make_extra_packages_airflow():
   """Prepare extra packages needed for Apache Airflow orchestrator."""
   return [
-      'apache-airflow[mysql]>=1.10.14,<3',
+      # TODO(b/230996502): Rollback the upper version cap to 3 after kfp
+      # releases a new version.
+      'apache-airflow[mysql]>=1.10.14,<2.3',
   ]
 
 


### PR DESCRIPTION
There is a conflicting dependency in apache-airflow 2.3.0
- apache-airflow 1.23.0 -> rich '12.3.0' -> typing-extensions (>=4.0.0,<5.0); python_version < "3.9"
- kfp 1.8.12 -> typing-extensions (<4,>=3.7.4); python_version < "3.9"

This issue will be resolved when kfp releases a new version because kfp already changed the cap in https://github.com/kubeflow/pipelines/pull/7632.

PiperOrigin-RevId: 446236647
(cherry picked from commit 2df92b32b4638747a1e93c639f429982babca679)