### PR TITLE
fix penguin_simple docs: correct for improved readability

### DIFF
--- a/docs/tutorials/tfx/penguin_simple.ipynb
+++ b/docs/tutorials/tfx/penguin_simple.ipynb
@@ -560,7 +560,7 @@
         "Python package and runs pipelines on local environment.\n",
         "We often call TFX pipelines \"DAGs\" which stands for directed acyclic graph.\n",
         "\n",
-        "`LocalDagRunner` provides fast iterations for developemnt and debugging.\n",
+        "`LocalDagRunner` provides fast iterations for development and debugging.\n",
         "TFX also supports other orchestrators including Kubeflow Pipelines and Apache\n",
         "Airflow which are suitable for production use cases.\n",
         "\n",

--- a/docs/tutorials/tfx/penguin_simple.ipynb
+++ b/docs/tutorials/tfx/penguin_simple.ipynb
@@ -320,7 +320,7 @@
         "train a model and save it in a _saved_model_ format.\n",
         "- Pusher: Copies the trained model outside of the TFX pipeline.\n",
         "[Pusher component](https://www.tensorflow.org/tfx/guide/pusher) can be thought\n",
-        "of an deployment process of the trained ML model.\n",
+        "of as a deployment process of the trained ML model.\n",
         "\n",
         "Before actually define the pipeline, we need to write a model code for the\n",
         "Trainer component first."

--- a/docs/tutorials/tfx/penguin_simple.ipynb
+++ b/docs/tutorials/tfx/penguin_simple.ipynb
@@ -499,7 +499,7 @@
         "### Write a pipeline definition\n",
         "\n",
         "We define a function to create a TFX pipeline. A `Pipeline` object\n",
-        "represents a TFX pipeline which can be run using one of pipeline\n",
+        "represents a TFX pipeline which can be run using one of the pipeline\n",
         "orchestration systems that TFX supports.\n"
       ]
     },


### PR DESCRIPTION
After this change, the phrase  "... thought of an deployment process ..." becomes "... thought of as a deployment process ..."