### PR TITLE
Extend example gen to read and write parquet

### DIFF
--- a/tfx/components/example_gen/base_example_gen_executor.py
+++ b/tfx/components/example_gen/base_example_gen_executor.py
@@ -16,6 +16,7 @@
 import abc
 import bisect
 import hashlib
+import pickle
 from typing import Any, Dict, List, Union
 
 from absl import logging
@@ -43,7 +44,7 @@ def _GeneratePartitionKey(record: Union[tf.train.Example,
     if isinstance(record, bytes):
       return record
     if isinstance(record, dict):
-      return pa.serialize(record).to_buffer().to_pybytes()
+      return pickle.dumps(record)
     return record.SerializeToString(deterministic=True)
 
   if isinstance(record, tf.train.Example):

--- a/tfx/components/example_gen/base_example_gen_executor.py
+++ b/tfx/components/example_gen/base_example_gen_executor.py
@@ -42,16 +42,12 @@ def _GeneratePartitionKey(record: Union[tf.train.Example,
   if not split_config.HasField('partition_feature_name'):
     if isinstance(record, bytes):
       return record
-    if isinstance(record, dict):
-      return json.dumps(record).encode('utf-8')
     return record.SerializeToString(deterministic=True)
 
   if isinstance(record, tf.train.Example):
     features = record.features.feature  # pytype: disable=attribute-error
   elif isinstance(record, tf.train.SequenceExample):
     features = record.context.feature  # pytype: disable=attribute-error
-  elif isinstance(record, dict):
-    return bytes(record[split_config.partition_feature_name])
   else:
     raise RuntimeError('Split by `partition_feature_name` is only supported '
                        'for FORMAT_TF_EXAMPLE and FORMAT_TF_SEQUENCE_EXAMPLE '
@@ -288,7 +284,7 @@ class BaseExampleGenExecutor(base_beam_executor.BaseBeamExecutor, abc.ABC):
          | 'WriteSplit[{}]'.format(split_name) >> write_split.WriteSplit(
              artifact_utils.get_split_uri(
                  output_dict[standard_component_specs.EXAMPLES_KEY],
-                 split_name), output_file_format, output_payload_format))
+                 split_name), output_file_format, exec_properties))
       # pylint: enable=expression-not-assigned, no-value-for-parameter
 
     output_payload_format = exec_properties.get(

--- a/tfx/components/example_gen/base_example_gen_executor.py
+++ b/tfx/components/example_gen/base_example_gen_executor.py
@@ -16,7 +16,6 @@
 import abc
 import bisect
 import hashlib
-import json
 from typing import Any, Dict, List, Union
 
 from absl import logging
@@ -34,8 +33,7 @@ from tfx.utils import proto_utils
 
 
 def _GeneratePartitionKey(record: Union[tf.train.Example,
-                                        tf.train.SequenceExample, bytes,
-                                        Dict[str, Any]],
+                                        tf.train.SequenceExample, bytes],
                           split_config: example_gen_pb2.SplitConfig) -> bytes:
   """Generates key for partition."""
 
@@ -68,7 +66,7 @@ def _GeneratePartitionKey(record: Union[tf.train.Example,
 
 
 def _PartitionFn(
-    record: Union[tf.train.Example, tf.train.SequenceExample, bytes, Dict[str, any]],
+    record: Union[tf.train.Example, tf.train.SequenceExample, bytes],
     num_partitions: int,
     buckets: List[int],
     split_config: example_gen_pb2.SplitConfig,

--- a/tfx/components/example_gen/base_example_gen_executor.py
+++ b/tfx/components/example_gen/base_example_gen_executor.py
@@ -35,14 +35,13 @@ from tfx.utils import proto_utils
 
 def _GeneratePartitionKey(record: Union[tf.train.Example,
                                         tf.train.SequenceExample, bytes,
-                                        pa.Table],
+                                        Dict[str, Any]],
                           split_config: example_gen_pb2.SplitConfig) -> bytes:
   """Generates key for partition."""
 
   if not split_config.HasField('partition_feature_name'):
     if isinstance(record, bytes):
       return record
-    # pyarrow tables are passed as dict to this funtion.
     if isinstance(record, dict):
       return pa.serialize(record).to_buffer().to_pybytes()
     return record.SerializeToString(deterministic=True)
@@ -71,7 +70,7 @@ def _GeneratePartitionKey(record: Union[tf.train.Example,
 
 
 def _PartitionFn(
-    record: Union[tf.train.Example, tf.train.SequenceExample, bytes, pa.Table],
+    record: Union[tf.train.Example, tf.train.SequenceExample, bytes, Dict[str, Any]],
     num_partitions: int,
     buckets: List[int],
     split_config: example_gen_pb2.SplitConfig,

--- a/tfx/components/example_gen/base_example_gen_executor.py
+++ b/tfx/components/example_gen/base_example_gen_executor.py
@@ -70,7 +70,10 @@ def _GeneratePartitionKey(record: Union[tf.train.Example,
 
 
 def _PartitionFn(
-    record: Union[tf.train.Example, tf.train.SequenceExample, bytes, Dict[str, Any]],
+    record: Union[tf.train.Example,
+                  tf.train.SequenceExample,
+                  bytes,
+                  Dict[str, Any]],
     num_partitions: int,
     buckets: List[int],
     split_config: example_gen_pb2.SplitConfig,

--- a/tfx/components/example_gen/import_example_gen/executor.py
+++ b/tfx/components/example_gen/import_example_gen/executor.py
@@ -83,7 +83,8 @@ class Executor(base_example_gen_executor.BaseExampleGenExecutor):
     @beam.ptransform_fn
     @beam.typehints.with_input_types(beam.Pipeline)
     @beam.typehints.with_output_types(Union[tf.train.Example,
-                                            tf.train.SequenceExample, bytes])
+                                            tf.train.SequenceExample, bytes,
+                                            pa.Table])
     def ImportRecord(pipeline: beam.Pipeline, exec_properties: Dict[str, Any],
                      split_pattern: str) -> beam.pvalue.PCollection:
       """PTransform to import records.
@@ -111,8 +112,7 @@ class Executor(base_example_gen_executor.BaseExampleGenExecutor):
       if output_payload_format == example_gen_pb2.PayloadFormat.FORMAT_PROTO:
         return serialized_records
       elif output_payload_format == example_gen_pb2.PayloadFormat.FORMAT_PARQUET:
-        return (serialized_records
-                | "TableToBytes" >> beam.Map(lambda table: pa.serialize(table).to_buffer().to_pybytes()))
+        return serialized_records
       elif (output_payload_format ==
             example_gen_pb2.PayloadFormat.FORMAT_TF_EXAMPLE):
         return (serialized_records

--- a/tfx/components/example_gen/import_example_gen/executor_test.py
+++ b/tfx/components/example_gen/import_example_gen/executor_test.py
@@ -56,8 +56,7 @@ class ExecutorTest(tf.test.TestCase):
               exec_properties={
                   standard_component_specs.INPUT_BASE_KEY: self._input_data_dir
               },
-              split_pattern='tfrecord/*',
-              output_payload_format=example_gen_pb2.PayloadFormat.FORMAT_TF_EXAMPLE)
+              split_pattern='tfrecord/*')
           | 'ToTFExample' >> beam.Map(tf.train.Example.FromString))
 
       def check_result(got):
@@ -94,10 +93,17 @@ class ExecutorTest(tf.test.TestCase):
         self.examples.split_names)
 
     # Check import_example_gen outputs.
-    train_output_file = os.path.join(self.examples.uri, 'Split-train',
-                                     'data_tfrecord-00000-of-00001.gz')
-    eval_output_file = os.path.join(self.examples.uri, 'Split-eval',
-                                    'data_tfrecord-00000-of-00001.gz')
+    if payload_format == example_gen_pb2.PayloadFormat.FORMAT_PARQUET:
+      train_output_file = os.path.join(self.examples.uri, 'Split-train',
+                                       'data-00000-of-00001.parquet')
+      eval_output_file = os.path.join(self.examples.uri, 'Split-eval',
+                                      'data-00000-of-00001.parquet')
+    else:
+      train_output_file = os.path.join(self.examples.uri, 'Split-train',
+                                       'data_tfrecord-00000-of-00001.gz')
+      eval_output_file = os.path.join(self.examples.uri, 'Split-eval',
+                                      'data_tfrecord-00000-of-00001.gz')
+
     self.assertTrue(fileio.exists(train_output_file))
     self.assertTrue(fileio.exists(eval_output_file))
     self.assertGreater(

--- a/tfx/components/example_gen/import_example_gen/executor_test.py
+++ b/tfx/components/example_gen/import_example_gen/executor_test.py
@@ -95,9 +95,9 @@ class ExecutorTest(tf.test.TestCase):
     # Check import_example_gen outputs.
     if payload_format == example_gen_pb2.PayloadFormat.FORMAT_PARQUET:
       train_output_file = os.path.join(self.examples.uri, 'Split-train',
-                                       'data-00000-of-00001.parquet')
+                                       'data_parquet-00000-of-00001.parquet')
       eval_output_file = os.path.join(self.examples.uri, 'Split-eval',
-                                      'data-00000-of-00001.parquet')
+                                      'data_parquet-00000-of-00001.parquet')
     else:
       train_output_file = os.path.join(self.examples.uri, 'Split-train',
                                        'data_tfrecord-00000-of-00001.gz')

--- a/tfx/components/example_gen/write_split.py
+++ b/tfx/components/example_gen/write_split.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """PTransform for write split."""
-import json
 import os
 from typing import Union, Dict, Any
 

--- a/tfx/components/example_gen/write_split.py
+++ b/tfx/components/example_gen/write_split.py
@@ -32,7 +32,7 @@ METRICS_NAMESPACE = util.MakeTfxNamespace(['ExampleGen'])
 
 
 @beam.typehints.with_input_types(
-    Union[tf.train.Example, tf.train.SequenceExample, bytes, pa.Table])
+    Union[tf.train.Example, tf.train.SequenceExample, bytes])
 @beam.typehints.with_output_types(bytes)
 class MaybeSerialize(beam.DoFn):
   """Serializes the proto if needed."""
@@ -73,7 +73,7 @@ def WriteSplit(
     return (example_split
             # TODO(jyzhao): make shuffle optional.
             | 'Shuffle' >> beam.transforms.Reshuffle()
-            | "Write Parquet" >> beam.io.WriteToParquet(
+            | 'WriteParquet' >> beam.io.WriteToParquet(
               os.path.join(output_split_path, DEFAULT_PARQUET_FILE_NAME),
               schema, file_name_suffix=".parquet", codec='snappy'))
 

--- a/tfx/components/example_gen/write_split.py
+++ b/tfx/components/example_gen/write_split.py
@@ -24,7 +24,7 @@ from tfx_bsl.telemetry import util
 # Default file name for TFRecord output file prefix.
 from tfx.types import standard_component_specs
 
-DEFAULT_PARQUET_FILE_NAME = 'data'
+DEFAULT_PARQUET_FILE_NAME = 'data_parquet'
 DEFAULT_TF_RECORD_FILE_NAME = 'data_tfrecord'
 
 # Metrics namespace for ExampleGen.
@@ -52,14 +52,16 @@ class MaybeSerialize(beam.DoFn):
 
 @beam.ptransform_fn
 @beam.typehints.with_input_types(
-    Union[tf.train.Example, tf.train.SequenceExample, bytes])
+    Union[tf.train.Example, tf.train.SequenceExample, bytes, Dict[str, Any]])
 def WriteSplit(
     example_split: beam.pvalue.PCollection,
     output_split_path: str,
     output_format: str,
     exec_properties: Dict[str, Any]
 ) -> beam.pvalue.PDone:
-  """Shuffles and writes output split as serialized records in TFRecord or Parquet."""
+  """
+  Shuffles and writes output split as serialized records in TFRecord or Parquet
+  """
   del output_format
 
   output_payload_format = exec_properties.get(

--- a/tfx/components/example_gen/write_split_test.py
+++ b/tfx/components/example_gen/write_split_test.py
@@ -18,9 +18,11 @@ import apache_beam as beam
 from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.runners.direct import direct_runner
 import tensorflow as tf
+import pyarrow as pa
 from tfx.components.example_gen import write_split
 from tfx.dsl.io import fileio
 from tfx.proto import example_gen_pb2
+from tfx.types import standard_component_specs
 
 
 class WriteSplitTest(tf.test.TestCase):
@@ -33,6 +35,7 @@ class WriteSplitTest(tf.test.TestCase):
 
   def testWriteSplitCounter_WithFormatUnspecified(self):
     count = 10
+    exec_properties = {}
 
     def Pipeline(root):
       data = [tf.train.Example()] * count
@@ -40,7 +43,8 @@ class WriteSplitTest(tf.test.TestCase):
           root
           | beam.Create(data)
           | write_split.WriteSplit(self._output_data_dir,
-                                   example_gen_pb2.FILE_FORMAT_UNSPECIFIED))
+                                   example_gen_pb2.FILE_FORMAT_UNSPECIFIED,
+                                   exec_properties))
 
     run_result = direct_runner.DirectRunner().run(Pipeline)
     run_result.wait_until_finish()
@@ -58,6 +62,10 @@ class WriteSplitTest(tf.test.TestCase):
 
   def testWriteSplitCounter_WithTFRECORDS_GZIP(self):
     count = 10
+    exec_properties = {
+      standard_component_specs.OUTPUT_DATA_FORMAT_KEY:
+        example_gen_pb2.PayloadFormat.FORMAT_TF_EXAMPLE
+    }
 
     def Pipeline(root):
       data = [tf.train.Example()] * count
@@ -65,7 +73,8 @@ class WriteSplitTest(tf.test.TestCase):
           root
           | beam.Create(data)
           | write_split.WriteSplit(self._output_data_dir,
-                                   example_gen_pb2.FORMAT_TFRECORDS_GZIP))
+                                   example_gen_pb2.FORMAT_TFRECORDS_GZIP,
+                                   exec_properties))
 
     run_result = direct_runner.DirectRunner().run(Pipeline)
     run_result.wait_until_finish()
@@ -80,6 +89,31 @@ class WriteSplitTest(tf.test.TestCase):
     self.assertTrue(num_instances['counters'])
     self.assertEqual(len(num_instances['counters']), 1)
     self.assertEqual(num_instances['counters'][0].result, count)
+
+  def testWriteSplitCounter_WithParquet(self):
+    count = 10
+    exec_properties = {
+      standard_component_specs.OUTPUT_DATA_FORMAT_KEY:
+        example_gen_pb2.PayloadFormat.FORMAT_PARQUET,
+      "pyarrow_schema": pa.schema([pa.field("feature", pa.string())])
+    }
+
+    def Pipeline(root):
+      data = [{"feature": "value"}] * count
+      _ = (
+          root
+          | beam.Create(data)
+          | write_split.WriteSplit(self._output_data_dir,
+                                   example_gen_pb2.FILE_FORMAT_PARQUET,
+                                   exec_properties))
+
+    run_result = direct_runner.DirectRunner().run(Pipeline)
+    run_result.wait_until_finish()
+
+    self.assertTrue(
+        fileio.exists(
+            os.path.join(self._output_data_dir,
+                         'data_parquet-00000-of-00001.parquet')))
 
 
 if __name__ == '__main__':

--- a/tfx/dsl/io/fileio.py
+++ b/tfx/dsl/io/fileio.py
@@ -32,7 +32,6 @@ def _get_filesystem(path) -> Type[filesystem.Filesystem]:
   return (filesystem_registry.DEFAULT_FILESYSTEM_REGISTRY
           .get_filesystem_for_path(path))
 
-
 def open(path: PathType, mode: str = 'r'):  # pylint: disable=redefined-builtin
   """Open a file at the given path."""
   return _get_filesystem(path).open(path, mode=mode)


### PR DESCRIPTION
This PR extends the example gen to allow for reading parquet files, split them, and write parquet files again, outputting an example artifact.

There's a few open questions in the implementation that I will leave inline comments

cc @iindyk @rcrowe-google @1025KB 