### PR TITLE
Update vertex_pipelines_bq.ipynb

### DIFF
--- a/docs/tutorials/tfx/gcp/vertex_pipelines_bq.ipynb
+++ b/docs/tutorials/tfx/gcp/vertex_pipelines_bq.ipynb
@@ -76,7 +76,7 @@
         "[BigQuery](https://cloud.google.com/bigquery) is serverless, highly scalable,\n",
         "and cost-effective multi-cloud data warehouse designed for business agility.\n",
         "TFX can be used to read training data from BigQuery and to\n",
-        "[publish the trained model](https://www.tensorflow.org/tfx/api_docs/python/tfx/extensions/google_cloud_big_query/pusher/executor/Executor)\n",
+        "[publish the trained model](https://www.tensorflow.org/tfx/api_docs/python/tfx/v1/extensions/google_cloud_big_query/Pusher)\n",
         "to BigQuery.\n",
         "\n",
         "In this tutorial, we will use the `BigQueryExampleGen` component which reads\n",


### PR DESCRIPTION
Fixing the broken link in this [section](https://www.tensorflow.org/tfx/tutorials/tfx/gcp/vertex_pipelines_bq#:~:text=to%20publish%20the%20trained%20model%20to%20BigQuery.) with the correct URL.