### PR TITLE
fix missing values problem in PrestoExampleGen executor

### DIFF
--- a/tfx/examples/custom_components/presto_example_gen/presto_component/executor.py
+++ b/tfx/examples/custom_components/presto_example_gen/presto_component/executor.py
@@ -44,8 +44,8 @@ class _ReadPrestoDoFn(beam.DoFn):
       query: A SQL query used to return results from Presto table.
 
     Yields:
-      One row from the query result, represented by a tuple of tuples. Each tuple
-      contains information on column name, column data type, data.
+      One row from the query result, represented by a tuple of tuples.
+      Each tuple contains information on column name, column data type, data.
     """
     self.cursor.execute(query)
     rows = self.cursor.fetchall()

--- a/tfx/examples/custom_components/presto_example_gen/presto_component/executor.py
+++ b/tfx/examples/custom_components/presto_example_gen/presto_component/executor.py
@@ -14,7 +14,7 @@
 """Generic TFX PrestoExampleGen executor."""
 
 import datetime
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Dict, Tuple
 
 import apache_beam as beam
 import prestodb
@@ -37,14 +37,14 @@ class _ReadPrestoDoFn(beam.DoFn):
   def __init__(self, client: prestodb.dbapi.Connection):
     self.cursor = client.cursor()
 
-  def process(self, query: str) -> Iterable[Tuple[str, str, Any]]:
+  def process(self, query: str) -> Tuple[Tuple[str, str, Any]]:
     """Yields rows from query results.
 
     Args:
       query: A SQL query used to return results from Presto table.
 
     Yields:
-      One row from the query result, represented by a list of tuples. Each tuple
+      One row from the query result, represented by a tuple of tuples. Each tuple
       contains information on column name, column data type, data.
     """
     self.cursor.execute(query)
@@ -59,7 +59,7 @@ class _ReadPrestoDoFn(beam.DoFn):
         col_types.append(metadata[1])
 
       for r in rows:
-        yield zip(cols, col_types, r)
+        yield tuple(zip(cols, col_types, r))
 
   def teardown(self):
     if self.cursor:
@@ -126,7 +126,7 @@ def _deserialize_auth_config(
 
 
 def _row_to_example(
-    instance: Iterable[Tuple[str, str, Any]]) -> tf.train.Example:
+    instance: Tuple[Tuple[str, str, Any]]) -> tf.train.Example:
   """Convert presto result row to tf example."""
   feature = {}
   for key, data_type, value in instance:

--- a/tfx/examples/custom_components/presto_example_gen/presto_component/executor.py
+++ b/tfx/examples/custom_components/presto_example_gen/presto_component/executor.py
@@ -14,7 +14,7 @@
 """Generic TFX PrestoExampleGen executor."""
 
 import datetime
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
 import apache_beam as beam
 import prestodb
@@ -37,7 +37,7 @@ class _ReadPrestoDoFn(beam.DoFn):
   def __init__(self, client: prestodb.dbapi.Connection):
     self.cursor = client.cursor()
 
-  def process(self, query: str) -> Tuple[Tuple[str, str, Any]]:
+  def process(self, query: str) -> Iterable[Tuple[str, str, Any]]:
     """Yields rows from query results.
 
     Args:
@@ -126,7 +126,7 @@ def _deserialize_auth_config(
 
 
 def _row_to_example(
-    instance: Tuple[Tuple[str, str, Any]]) -> tf.train.Example:
+    instance: Iterable[Tuple[str, str, Any]]) -> tf.train.Example:
   """Convert presto result row to tf example."""
   feature = {}
   for key, data_type, value in instance:


### PR DESCRIPTION
### Reference issue: [#5040 ](https://github.com/tensorflow/tfx/issues/5040)
Since zip returns a lazy iterable, some rows of data will be lost with the current implementation of beam pipeline in PrestoExampleGen.

![screenshot](https://user-images.githubusercontent.com/36539586/179362652-06747ae6-8b4f-4866-a601-bac54dedcce6.png)

