### PR TITLE
Verify output artifacts as found from cache before making execution decision

### DIFF
--- a/tfx/dsl/components/base/base_driver.py
+++ b/tfx/dsl/components/base/base_driver.py
@@ -41,8 +41,8 @@ def _generate_output_uri(base_output_dir: str,
 def _prepare_output_paths(artifact: types.Artifact):
   """Create output directories for output artifact."""
   if fileio.exists(artifact.uri):
-    msg = 'Output artifact uri %s already exists' % artifact.uri
-    absl.logging.warning(msg)
+    absl.logging.warning(
+      'Output artifact uri %s already exists', artifact.uri)
     # TODO(b/158689199): We currently simply return as a short-term workaround
     # to unblock execution retires. A comprehensive solution to guarantee
     # idempotent executions is needed.
@@ -88,9 +88,9 @@ class BaseDriver:
     for single_artifacts_list in artifacts_dict.values():
       for artifact in single_artifacts_list:
         if not artifact.uri:
-          raise RuntimeError('Artifact %s does not have uri' % artifact)
+          raise RuntimeError(f'Artifact {artifact} does not have uri')
         if not fileio.exists(artifact.uri):
-          raise RuntimeError('Artifact uri %s is missing' % artifact.uri)
+          raise RuntimeError(f'Artifact uri {artifact.uri} is missing')
 
   def _log_properties(self, input_dict: Dict[str, List[types.Artifact]],
                       output_dict: Dict[str, List[types.Artifact]],
@@ -145,11 +145,11 @@ class BaseDriver:
             # 0.
             if not artifact.uri or not artifact.id:
               raise ValueError((
-                  'Unresolved input channel %r for input %r was passed in '
+                  'Unresolved input channel {repr(artifact)} for input {repr(name)} was passed in '
                   'interactive mode. When running in interactive mode, upstream '
                   'components must first be run with '
                   '`interactive_context.run(component)` before their outputs can '
-                  'be used in downstream components.') % (artifact, name))
+                  'be used in downstream components.'))
             artifacts_by_id.update({a.id: a for a in artifacts})
         else:
           artifacts = self._metadata_handler.search_artifacts(
@@ -312,7 +312,8 @@ class BaseDriver:
           execution_state=metadata.EXECUTION_STATE_CACHED,
           contexts=contexts)
     else:
-      absl.logging.debug('Cached results not available, move on to new execution')
+      absl.logging.debug(
+        'Cached results not available, move on to new execution')
       # Step 4a. New execution is needed. Prepare output artifacts.
       output_artifacts = self._prepare_output_artifacts(
           input_artifacts=input_artifacts,

--- a/tfx/dsl/components/base/base_driver.py
+++ b/tfx/dsl/components/base/base_driver.py
@@ -139,12 +139,12 @@ class BaseDriver:
             # Note: when not initialized, artifact.uri is '' and artifact.id is
             # 0.
             if not artifact.uri or not artifact.id:
-              raise ValueError((
-                  'Unresolved input channel {repr(artifact)} for input {repr(name)} was passed in '
-                  'interactive mode. When running in interactive mode, upstream '
-                  'components must first be run with '
-                  '`interactive_context.run(component)` before their outputs can '
-                  'be used in downstream components.'))
+              raise ValueError(
+                f'Unresolved input channel {repr(artifact)} for input '
+                f'{repr(name)} was passed in interactive mode. When running '
+                'in interactive mode, upstream components must first be run '
+                'with `interactive_context.run(component)` before their '
+                'outputs can be used in downstream components.')
             artifacts_by_id.update({a.id: a for a in artifacts})
         else:
           artifacts = self._metadata_handler.search_artifacts(

--- a/tfx/dsl/components/base/base_driver.py
+++ b/tfx/dsl/components/base/base_driver.py
@@ -295,7 +295,8 @@ class BaseDriver:
           artifact_utils.verify_artifacts(output_artifacts)
           use_cached_results = True
         except RuntimeError:
-          absl.logging.debug('Cached results found but could not be verified to still exist')
+          absl.logging.debug(
+            'Cached results found but could not be verified to still exist')
 
     if use_cached_results:
       # If cache should be used, updates execution to reflect that. Note that

--- a/tfx/dsl/components/base/base_driver.py
+++ b/tfx/dsl/components/base/base_driver.py
@@ -297,7 +297,7 @@ class BaseDriver:
       # components
       if output_artifacts is not None:
         try:
-          self.verify_input_artifacts(output_artifacts)
+          self.verify_input_artifacts(artifacts_dict=output_artifacts)
           use_cached_results = True
         except RuntimeError:
           use_cached_results = False

--- a/tfx/dsl/components/base/base_driver.py
+++ b/tfx/dsl/components/base/base_driver.py
@@ -296,7 +296,11 @@ class BaseDriver:
       # Check that cached output artifacts will actually be considered a cache hit by downstream
       # components
       if output_artifacts is not None:
-        use_cached_results = self.verify_input_artifacts(output_artifacts)
+        try:
+          self.verify_input_artifacts(output_artifacts)
+          use_cached_results = True
+        except RuntimeError:
+          use_cached_results = False
 
     if use_cached_results:
       # If cache should be used, updates execution to reflect that. Note that

--- a/tfx/dsl/components/base/base_driver_test.py
+++ b/tfx/dsl/components/base/base_driver_test.py
@@ -206,17 +206,16 @@ class BaseDriverTest(tf.test.TestCase):
                           self._output_artifacts)
 
   @mock.patch(
-      'tfx.dsl.components.base.base_driver.BaseDriver.verify_input_artifacts')
+    'tfx.dsl.components.base.base_driver.artifact_utils.verify_artifacts'
+  )
+  @mock.patch(
+    'tfx.dsl.components.base.base_driver.BaseDriver.verify_input_artifacts')
   @mock.patch.object(types.ValueArtifact, 'read', fake_read)
-  def testPreExecutionCachedMissing(self, mock_verify_input_artifacts_fn):
+  def testPreExecutionCachedMissing(self, mock_verify_input_artifacts_fn, mock_artifact_utils_verify_artifacts_fn):
     """With cache enabled, if cached output artifacts are found but are missing, execution decision is to not use cache"""
 
-    # mock such that the input artifacts for the current component are present, but the output
-    # artifacts as pulled from cache are not present
-    mock_verify_input_artifacts_fn.side_effect = [
-        None,
-        RuntimeError(),
-    ]
+    # mock such that the output artifacts as pulled from cache are not present
+    mock_artifact_utils_verify_artifacts_fn.side_effect = RuntimeError()
 
     self._mock_metadata.search_artifacts.return_value = list(
         self._input_dict['input_string'].get())

--- a/tfx/dsl/components/base/base_driver_test.py
+++ b/tfx/dsl/components/base/base_driver_test.py
@@ -211,7 +211,9 @@ class BaseDriverTest(tf.test.TestCase):
   @mock.patch(
     'tfx.dsl.components.base.base_driver.BaseDriver.verify_input_artifacts')
   @mock.patch.object(types.ValueArtifact, 'read', fake_read)
-  def testPreExecutionCachedMissing(self, mock_verify_input_artifacts_fn, mock_artifact_utils_verify_artifacts_fn):
+  def testPreExecutionCachedMissing(
+    self, _, mock_artifact_utils_verify_artifacts_fn
+  ):
     """With cache enabled, if cached output artifacts are found but are missing, execution decision is to not use cache"""
 
     # mock such that the output artifacts as pulled from cache are not present

--- a/tfx/dsl/components/base/base_driver_test.py
+++ b/tfx/dsl/components/base/base_driver_test.py
@@ -214,8 +214,8 @@ class BaseDriverTest(tf.test.TestCase):
     # mock such that the input artifacts for the current component are present, but the output
     # artifacts as pulled from cache are not present
     mock_verify_input_artifacts_fn.side_effect = [
-        True,
-        False,
+        None,
+        RuntimeError(),
     ]
 
     self._mock_metadata.search_artifacts.return_value = list(

--- a/tfx/dsl/components/base/base_driver_test.py
+++ b/tfx/dsl/components/base/base_driver_test.py
@@ -26,7 +26,7 @@ from tfx.types import standard_artifacts
 from ml_metadata.proto import metadata_store_pb2
 
 # Mock value for string artifact.
-_STRING_VALUE = u'This is a string'
+_STRING_VALUE = 'This is a string'
 
 # Mock byte value for string artifact.
 _BYTE_VALUE = b'This is a string'
@@ -34,10 +34,10 @@ _BYTE_VALUE = b'This is a string'
 
 def fake_read(self):
   """Mock read method for ValueArtifact."""
-  if not self._has_value:
-    self._has_value = True
-    self._value = self.decode(_BYTE_VALUE)
-  return self._value
+  if not self._has_value:  # pylint: disable=protected-access
+    self._has_value = True  # pylint: disable=protected-access
+    self._value = self.decode(_BYTE_VALUE)  # pylint: disable=protected-access
+  return self._value  # pylint: disable=protected-access
 
 
 class _InputArtifact(types.Artifact):
@@ -104,7 +104,7 @@ class BaseDriverTest(tf.test.TestCase):
   @mock.patch(
       'tfx.dsl.components.base.base_driver.BaseDriver.verify_input_artifacts')
   @mock.patch.object(types.ValueArtifact, 'read', fake_read)
-  def testPreExecutionNewExecution(self, mock_verify_input_artifacts_fn):
+  def testPreExecutionNewExecution(self, _):
     self._mock_metadata.search_artifacts.return_value = list(
         self._input_dict['input_string'].get())
     self._mock_metadata.register_execution.side_effect = [self._execution]
@@ -178,7 +178,7 @@ class BaseDriverTest(tf.test.TestCase):
   @mock.patch(
       'tfx.dsl.components.base.base_driver.BaseDriver.verify_input_artifacts')
   @mock.patch.object(types.ValueArtifact, 'read', fake_read)
-  def testPreExecutionCached(self, mock_verify_input_artifacts_fn):
+  def testPreExecutionCached(self, _):
     """With cache enabled, if cached output artifacts are found, execution decision is to use cache"""
     self._mock_metadata.search_artifacts.return_value = list(
         self._input_dict['input_string'].get())

--- a/tfx/orchestration/portable/cache_utils.py
+++ b/tfx/orchestration/portable/cache_utils.py
@@ -166,11 +166,15 @@ def get_cached_outputs(
       cached_executions)
 
   # Defensively traverses candidate executions and returns once we find an
-  # execution with valid outputs.
+  # execution with valid outputs that can be confirmed to still exist.
   for execution in cached_executions:
     cached_output_artifacts = _get_outputs_of_execution(metadata_handler,
                                                         execution.id)
     if cached_output_artifacts is not None:
-      return cached_output_artifacts
+      try:
+        artifact_utils.verify_artifacts(cached_output_artifacts)
+        return cached_output_artifacts
+      except RuntimeError:
+        pass
 
   return None

--- a/tfx/orchestration/portable/cache_utils_test.py
+++ b/tfx/orchestration/portable/cache_utils_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for tfx.orchestration.portable.cache_utils."""
 import os
+import tensorflow as tf
 from unittest import mock
 
 from tfx.dsl.io import fileio
@@ -27,7 +28,6 @@ from tfx.utils import test_case_utils
 
 from google.protobuf import text_format
 from ml_metadata.proto import metadata_store_pb2
-import tensorflow as tf
 
 class CacheUtilsTest(test_case_utils.TfxTest):
 

--- a/tfx/orchestration/portable/cache_utils_test.py
+++ b/tfx/orchestration/portable/cache_utils_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for tfx.orchestration.portable.cache_utils."""
 import os
-import tensorflow as tf
+from unittest import mock
 
 from tfx.dsl.io import fileio
 from tfx.orchestration import metadata
@@ -24,9 +24,10 @@ from tfx.proto.orchestration import executable_spec_pb2
 from tfx.proto.orchestration import pipeline_pb2
 from tfx.types import standard_artifacts
 from tfx.utils import test_case_utils
+
 from google.protobuf import text_format
 from ml_metadata.proto import metadata_store_pb2
-
+import tensorflow as tf
 
 class CacheUtilsTest(test_case_utils.TfxTest):
 
@@ -166,7 +167,9 @@ class CacheUtilsTest(test_case_utils.TfxTest):
       # Different executor spec will result in new cache context.
       self.assertLen(m.store.get_contexts(), 2)
 
-  def testGetCachedOutputArtifacts(self):
+  @mock.patch(
+    "tfx.orchestration.portable.cache_utils.artifact_utils.verify_artifacts")
+  def testGetCachedOutputArtifacts(self, mock_verify_artifacts):
     # Output artifacts that will be used by the first execution with the same
     # cache key.
     output_model_one = standard_artifacts.Model()
@@ -188,10 +191,12 @@ class CacheUtilsTest(test_case_utils.TfxTest):
     with metadata.Metadata(connection_config=self._connection_config) as m:
       cache_context = context_lib.register_context_if_not_exists(
           m, context_lib.CONTEXT_TYPE_EXECUTION_CACHE, 'cache_key')
-      cached_output = cache_utils.get_cached_outputs(m, cache_context)
+
       # No succeed execution is associate with this context yet, so the cached
       # output is None
+      cached_output = cache_utils.get_cached_outputs(m, cache_context)
       self.assertIsNone(cached_output)
+
       execution_one = execution_publish_utils.register_execution(
           m, metadata_store_pb2.ExecutionType(name='my_type'), [cache_context])
       execution_publish_utils.publish_succeeded_execution(
@@ -210,6 +215,7 @@ class CacheUtilsTest(test_case_utils.TfxTest):
               output_models_key: [output_model_three, output_model_four],
               output_examples_key: [output_example_two]
           })
+
       # The cached output got should be the artifacts produced by the most
       # recent execution under the given cache context.
       cached_output = cache_utils.get_cached_outputs(m, cache_context)
@@ -234,6 +240,12 @@ class CacheUtilsTest(test_case_utils.TfxTest):
           ignored_fields=[
               'create_time_since_epoch', 'last_update_time_since_epoch'
           ])
+
+      # There should again be no cached outputs if the artifacts cannot be
+      # verified as still existing
+      mock_verify_artifacts.side_effect = RuntimeError()
+      cached_output = cache_utils.get_cached_outputs(m, cache_context)
+      self.assertIsNone(cached_output)
 
   def testGetCachedOutputArtifactsForNodesWithNoOuput(self):
     with metadata.Metadata(connection_config=self._connection_config) as m:

--- a/tfx/types/artifact_utils.py
+++ b/tfx/types/artifact_utils.py
@@ -17,10 +17,11 @@ import itertools
 import json
 import os
 import re
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Optional, Type, Union
 from absl import logging
 from packaging import version
 
+from tfx.dsl.io import fileio
 from tfx.types.artifact import _ArtifactType
 from tfx.types.artifact import Artifact
 from tfx.types.value_artifact import _ValueArtifactType
@@ -73,8 +74,8 @@ def get_single_instance(artifact_list: List[Artifact]) -> Artifact:
     ValueError: If length of artifact_list is not one.
   """
   if len(artifact_list) != 1:
-    raise ValueError('expected list length of one but got {}'.format(
-        len(artifact_list)))
+    raise ValueError(
+      f'expected list length of one but got {len(artifact_list)}')
   return artifact_list[0]
 
 
@@ -119,14 +120,12 @@ def is_artifact_version_older_than(artifact: Artifact,
     # Artifact without version.
     return True
 
-  if (version.parse(
+  # Artifact with old version
+  return bool(
+    version.parse(
       artifact.get_string_custom_property(
-          ARTIFACT_TFX_VERSION_CUSTOM_PROPERTY_KEY)) <
-      version.parse(artifact_version)):
-    # Artifact with old version.
-    return True
-  else:
-    return False
+        ARTIFACT_TFX_VERSION_CUSTOM_PROPERTY_KEY)) <
+    version.parse(artifact_version))
 
 
 def get_split_uris(artifact_list: List[Artifact], split: str) -> List[str]:
@@ -154,8 +153,8 @@ def get_split_uris(artifact_list: List[Artifact], split: str) -> List[str]:
       else:
         result.append(os.path.join(artifact.uri, f'Split-{split}'))
   if len(result) != len(artifact_list):
-    raise ValueError('Split does not exist over all example artifacts: %s' %
-                     split)
+    raise ValueError(
+      f'Split does not exist over all example artifacts: {split}')
   return result
 
 
@@ -175,8 +174,8 @@ def get_split_uri(artifact_list: List[Artifact], split: str) -> str:
   artifact_split_uris = get_split_uris(artifact_list, split)
   if len(artifact_split_uris) != 1:
     raise ValueError(
-        ('Expected exactly one artifact with split %r, but found matching '
-         'artifacts %s.') % (split, artifact_split_uris))
+        f'Expected exactly one artifact with split {repr(split)}, but found '
+        f'matching artifacts {artifact_split_uris}.')
   return artifact_split_uris[0]
 
 
@@ -198,9 +197,9 @@ def encode_split_names(splits: List[str]) -> str:
       # TODO(ccy): Disallow empty split names once the importer removes split as
       # a property for all artifacts.
       raise ValueError(
-          ('Split names are expected to be alphanumeric (allowing dashes and '
-           'underscores, provided they are not the first character); got %r '
-           'instead.') % (split,))
+        'Split names are expected to be alphanumeric (allowing dashes and '
+        f'underscores, provided they are not the first character); got {repr(split)} '
+        'instead.')
     rewritten_splits.append(split)
   return json.dumps(rewritten_splits)
 
@@ -303,12 +302,12 @@ def deserialize_artifact(
   # Validate inputs.
   if not isinstance(artifact_type, metadata_store_pb2.ArtifactType):
     raise ValueError(
-        ('Expected metadata_store_pb2.ArtifactType for artifact_type, got %s '
-         'instead') % (artifact_type,))
+      'Expected metadata_store_pb2.ArtifactType for artifact_type, got '
+      f'{artifact_type} instead')
   if artifact and not isinstance(artifact, metadata_store_pb2.Artifact):
     raise ValueError(
-        ('Expected metadata_store_pb2.Artifact for artifact, got %s '
-         'instead') % (artifact,))
+      f'Expected metadata_store_pb2.Artifact for artifact, got {artifact} '
+      'instead')
 
   # Get the artifact's class and construct the Artifact object.
   artifact_cls = get_artifact_type_class(artifact_type)
@@ -316,3 +315,33 @@ def deserialize_artifact(
   result.artifact_type.CopyFrom(artifact_type)
   result.set_mlmd_artifact(artifact or metadata_store_pb2.Artifact())
   return result
+
+
+def verify_artifacts(
+  artifacts: Union[Dict[str, List[Artifact]], List[Artifact], Artifact]
+) -> bool:
+  """Check that all artifacts have uri and exist at that uri.
+
+  Args:
+      artifacts: artifacts dict (key -> types.Artifact), single artifact
+        list, or artifact instance.
+
+  Returns:
+    whether all artifacts have uri and exist at that uri
+  """
+  if isinstance(artifacts, Artifact):
+    artifact_list = [artifacts]
+  elif isinstance(artifacts, list):
+    artifact_list = artifacts
+  elif isinstance(artifacts, dict):
+    artifact_list = [
+      a for artifact_list in artifacts.values() for a in artifact_list
+    ]
+  else:
+    raise TypeError
+
+  for artifact_instance in artifact_list:
+    if not artifact_instance.uri:
+      raise RuntimeError(f'Artifact {artifact_instance} does not have uri')
+    if not fileio.exists(artifact_instance.uri):
+      raise RuntimeError(f'Artifact uri {artifact_instance.uri} is missing')

--- a/tfx/types/artifact_utils_test.py
+++ b/tfx/types/artifact_utils_test.py
@@ -111,20 +111,20 @@ class ArtifactUtilsTest(tf.test.TestCase):
     # When reading artifacts with new version.
     artifacts[0].set_string_custom_property(
         artifact_utils.ARTIFACT_TFX_VERSION_CUSTOM_PROPERTY_KEY,
-        artifact_utils._ARTIFACT_VERSION_FOR_SPLIT_UPDATE)
+        artifact_utils._ARTIFACT_VERSION_FOR_SPLIT_UPDATE)  # pylint: disable=protected-access
     artifacts[1].set_string_custom_property(
         artifact_utils.ARTIFACT_TFX_VERSION_CUSTOM_PROPERTY_KEY,
-        artifact_utils._ARTIFACT_VERSION_FOR_SPLIT_UPDATE)
+        artifact_utils._ARTIFACT_VERSION_FOR_SPLIT_UPDATE)  # pylint: disable=protected-access
     self.assertEqual(['/tmp1/Split-train', '/tmp2/Split-train'],
                      artifact_utils.get_split_uris(artifacts, 'train'))
     self.assertEqual(['/tmp1/Split-eval', '/tmp2/Split-eval'],
                      artifact_utils.get_split_uris(artifacts, 'eval'))
 
   def testArtifactTypeRoundTrip(self):
-    mlmd_artifact_type = standard_artifacts.Examples._get_artifact_type()
+    mlmd_artifact_type = standard_artifacts.Examples._get_artifact_type()  # pylint: disable=protected-access
     self.assertIs(standard_artifacts.Examples,
                   artifact_utils.get_artifact_type_class(mlmd_artifact_type))
-    mlmd_artifact_type = _MyArtifact._get_artifact_type()
+    mlmd_artifact_type = _MyArtifact._get_artifact_type()  # pylint: disable=protected-access
     # Test that the ID is ignored for type comparison purposes during
     # deserialization.
     mlmd_artifact_type.id = 123
@@ -132,7 +132,7 @@ class ArtifactUtilsTest(tf.test.TestCase):
                   artifact_utils.get_artifact_type_class(mlmd_artifact_type))
 
   def testValueArtifactTypeRoundTrip(self):
-    mlmd_artifact_type = standard_artifacts.String.annotate_as(
+    mlmd_artifact_type = standard_artifacts.String.annotate_as(  # pylint: disable=protected-access
         system_artifacts.Dataset)._get_artifact_type()
     artifact_class = artifact_utils.get_artifact_type_class(mlmd_artifact_type)
     self.assertEqual(
@@ -146,7 +146,7 @@ class ArtifactUtilsTest(tf.test.TestCase):
   @mock.patch.object(logging, 'warning', autospec=True)
   def testArtifactTypeRoundTripUnknownArtifactClass(self, mock_warning):
     mlmd_artifact_type = copy.deepcopy(
-        standard_artifacts.Examples._get_artifact_type())
+        standard_artifacts.Examples._get_artifact_type())  # pylint: disable=protected-access
     self.assertIs(standard_artifacts.Examples,
                   artifact_utils.get_artifact_type_class(mlmd_artifact_type))
     mlmd_artifact_type.name = 'UnknownTypeName'
@@ -159,7 +159,7 @@ class ArtifactUtilsTest(tf.test.TestCase):
     self.assertTrue(issubclass(reconstructed_class, artifact.Artifact))
     self.assertEqual('UnknownTypeName', reconstructed_class.TYPE_NAME)
     self.assertEqual(mlmd_artifact_type,
-                     reconstructed_class._get_artifact_type())
+                     reconstructed_class._get_artifact_type())  # pylint: disable=protected-access
 
   def testIsArtifactVersionOlderThan(self):
     examples = standard_artifacts.Examples()
@@ -179,6 +179,21 @@ class ArtifactUtilsTest(tf.test.TestCase):
     self.assertFalse(
         artifact_utils.is_artifact_version_older_than(examples, '0.1'))
 
+  @mock.patch("tfx.types.artifact_utils.fileio", autospec=True)
+  def testVerifyArtifacts(self, mock_fileio):
+    """Test that artifacts (in various input formats) are verified to exist"""
+    artifact_instance= standard_artifacts.Examples()
+    uri = '/tmp/artifact'
+    artifact_instance.uri = uri
+    mock_fileio.exists.side_effect = lambda path: path == uri
+    inputs = [
+        (artifact_instance, "artifact instance"),
+        ([artifact_instance], "artifacts list"),
+        ({"key": [artifact_instance]}, "artifacts dict"),
+    ]
+    for artifacts, artifacts_format in inputs:
+      with self.subTest(artifacts_format):
+        artifact_utils.verify_artifacts(artifacts)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/tfx/types/artifact_utils_test.py
+++ b/tfx/types/artifact_utils_test.py
@@ -182,7 +182,7 @@ class ArtifactUtilsTest(tf.test.TestCase):
   @mock.patch("tfx.types.artifact_utils.fileio", autospec=True)
   def testVerifyArtifacts(self, mock_fileio):
     """Test that artifacts (in various input formats) are verified to exist"""
-    artifact_instance= standard_artifacts.Examples()
+    artifact_instance = standard_artifacts.Examples()
     uri = '/tmp/artifact'
     artifact_instance.uri = uri
     mock_fileio.exists.side_effect = lambda path: path == uri
@@ -194,6 +194,22 @@ class ArtifactUtilsTest(tf.test.TestCase):
     for artifacts, artifacts_format in inputs:
       with self.subTest(artifacts_format):
         artifact_utils.verify_artifacts(artifacts)
+
+  @mock.patch("tfx.types.artifact_utils.fileio", autospec=True)
+  def testVerifyArtifactsFailsNoUri(self, _):
+    """When an artifact has no uri, verify_artifacts fails"""
+    artifact_instance = standard_artifacts.Examples()
+    with self.assertRaises(RuntimeError):
+      artifact_utils.verify_artifacts(artifact_instance)
+
+  @mock.patch("tfx.types.artifact_utils.fileio", autospec=True)
+  def testVerifyArtifactsFailsMissingFile(self, mock_fileio):
+    """When an artifact's uri points to a non-existent file, verify_artifacts fails"""
+    artifact_instance = standard_artifacts.Examples()
+    artifact_instance.uri = '/tmp/artifact'
+    mock_fileio.exists.side_effect = lambda path: False
+    with self.assertRaises(RuntimeError):
+      artifact_utils.verify_artifacts(artifact_instance)
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
If cache is enabled, and if matching artifacts are found in the cache for a component's outputs, verify the output artifacts before making an execution decision. This avoids a situation in which the artifacts are missing (no object exists at the URI associated with the artifact due to a deletion process outside of the pipeline) and the downstream component that uses this component's outputs fails.

* since the downstream consumer of the cached artifacts will use `BaseDriver.verify_input_artifacts` to verify the artifacts, use the same method when checking the cache to "fail fast" (avoid using the cache)
* note that MLMD ArtifactState is not used at all in the BaseDriver logic. perhaps in a follow-up PR, we can add (1) checks when getting artifacts from cache that the objects are marked LIVE/PUBLISHED and (2) for artifacts from cache that are deemed to be missing given the logic in the current PR, update their state in MLMD to MISSING

cc @1025KB to follow up on our discussion on Wednesday