### PR TITLE
Fix ranking pipeline and add grpcio constraint

### DIFF
--- a/test_constraints.txt
+++ b/test_constraints.txt
@@ -8,6 +8,9 @@
 # constraint if it is installed either directly or transitively by the
 # dependencies.
 
+# TODO(b/220800338): Workaround for markupsafe.
+markupsafe<2.1.0
+
 # TODO(b/232490018) Remove pinned Cython after pycocotools issue resolved.
 Cython<1
 

--- a/test_constraints.txt
+++ b/test_constraints.txt
@@ -8,5 +8,8 @@
 # constraint if it is installed either directly or transitively by the
 # dependencies.
 
-# TODO(b/220800338): Workaround for markupsafe.
-markupsafe<2.1.0
+# TODO(b/232490018) Remove pinned Cython after pycocotools issue resolved.
+Cython<1
+
+# TODO(b/240657867): Remove this after consulting with grpcio.
+grpcio<1.48

--- a/tfx/examples/ranking/ranking_pipeline_e2e_test.py
+++ b/tfx/examples/ranking/ranking_pipeline_e2e_test.py
@@ -13,13 +13,22 @@
 # limitations under the License.
 """Tests for tfx.examples.ranking.ranking_pipeline."""
 import os
+import unittest
 
 import tensorflow as tf
 from tfx.examples.ranking import ranking_pipeline
 from tfx.orchestration import metadata
 from tfx.orchestration.beam.beam_dag_runner import BeamDagRunner
 
+try:
+  import struct2tensor  # pylint: disable=g-import-not-at-top
+except ImportError:
+  struct2tensor = None
 
+
+@unittest.skipIf(struct2tensor is None,
+                 'Cannot import required modules. This can happen when'
+                 ' struct2tensor is not available.')
 class RankingPipelineTest(tf.test.TestCase):
 
   def setUp(self):

--- a/tfx/examples/ranking/struct2tensor_parsing_utils_test.py
+++ b/tfx/examples/ranking/struct2tensor_parsing_utils_test.py
@@ -17,10 +17,14 @@ import itertools
 import unittest
 
 import tensorflow as tf
-from tfx.examples.ranking import struct2tensor_parsing_utils
 
 from google.protobuf import text_format
 from tensorflow_serving.apis import input_pb2
+
+try:
+  from tfx.examples.ranking import struct2tensor_parsing_utils  # pylint: disable=g-import-not-at-top
+except ImportError:
+  struct2tensor_parsing_utils = None
 
 
 _ELWCS = [
@@ -166,6 +170,9 @@ examples {
 
 
 @unittest.skipIf(tf.__version__ < '2', reason='TF 1.x not supported.')
+@unittest.skipIf(struct2tensor_parsing_utils is None,
+                 'Cannot import required modules. This can happen when'
+                 ' struct2tensor is not available.')
 class ELWCDecoderTest(tf.test.TestCase):
 
   def testAllDTypes(self):


### PR DESCRIPTION
* Skips ranking pipeline tests when struct2tensor is not available.
* Temporarily avoid grpcio==1.48.0 which causes a hang in the penguin_pipeline_local_infraval_e2e_test.py.
*  Add markupsafe constraint