### PR TITLE
modernize pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,4 +1,4 @@
-[MASTER]
+[MAIN]
 
 # Specify a configuration file.
 #rcfile=
@@ -6,9 +6,6 @@
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=
-
-# Profiled execution.
-profile=no
 
 # Add files or directories to the denylist. They should be base names, not
 # paths.
@@ -20,6 +17,7 @@ persistent=no
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 load-plugins=
+    pylint.extensions.bad_builtin,
 
 # Use multiple processes to speed up Pylint.
 jobs=4
@@ -44,8 +42,6 @@ enable=indexing-exception,old-raise-syntax
 disable=design,similarities,no-self-use,attribute-defined-outside-init,locally-disabled,star-args,pointless-except,bad-option-value,global-statement,fixme,suppressed-message,useless-suppression,locally-enabled,no-member,no-name-in-module,import-error,unsubscriptable-object,unbalanced-tuple-unpacking,undefined-variable,not-context-manager,useless-object-inheritance,unnecessary-pass,no-else-return,no-else-raise,no-else-continue,wrong-import-order,no-value-for-parameter,misplaced-comparison-constant,no-init,abstract-method,unpacking-non-sequence
 
 
-# Set the cache size for astng objects.
-cache-size=500
 
 
 [REPORTS]
@@ -54,11 +50,6 @@ cache-size=500
 # (visual studio) and html. You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=text
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=no
@@ -69,10 +60,6 @@ reports=no
 # number of statements analyzed. This is used by the global evaluation report
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
@@ -88,10 +75,6 @@ ignore-mixin-members=yes
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
-
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
@@ -119,16 +102,9 @@ additional-builtins=
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
-
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=apply,input,reduce
 
-
-# Disable the report(s) with the given id(s).
-# All non-Google reports are disabled by default.
-disable-report=R0001,R0002,R0003,R0004,R0101,R0102,R0201,R0202,R0220,R0401,R0402,R0701,R0801,R0901,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915,R0921,R0922,R0923
 
 # Regular expression which should only match correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -200,9 +176,6 @@ ignore-long-lines=(?x)
 # else.
 single-line-if-stmt=y
 
-# List of optional constructs for which whitespace checking is disabled
-no-space-check=
-
 # Maximum number of lines in a module
 max-module-lines=99999
 
@@ -251,10 +224,6 @@ int-import-graph=
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp
@@ -305,25 +274,6 @@ max-public-methods=20
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
 overgeneral-exceptions=Exception,StandardError,BaseException
-
-
-[AST]
-
-# Maximum line length for lambdas
-short-func-length=1
-
-# List of module members that should be marked as deprecated.
-# All of the string functions are listed in 4.1.4 Deprecated string functions
-# in the Python 2.4 docs.
-deprecated-members=string.atof,string.atoi,string.atol,string.capitalize,string.expandtabs,string.find,string.rfind,string.index,string.rindex,string.count,string.lower,string.split,string.rsplit,string.splitfields,string.join,string.joinfields,string.lstrip,string.rstrip,string.strip,string.swapcase,string.translate,string.upper,string.ljust,string.rjust,string.center,string.zfill,string.replace,sys.exitfunc
-
-
-[DOCSTRING]
-
-# List of exceptions that do not need to be mentioned in the Raises section of
-# a docstring.
-ignore-exceptions=AssertionError,NotImplementedError,StopIteration,TypeError
-
 
 
 [TOKENS]


### PR DESCRIPTION
This should remove most of the issues reported by the message:
```
pylintrc:1:0: E0015: Unrecognized option found: ....
```
The `google` section at the end is left untouched.
Some of the options have been long deprecated (going back to 2010) and some were not even found in the pylint codebase, so I assume those are also safe to remove.

Removed option list:
 - `cache-size`: https://github.com/PyCQA/pylint/commit/be5996b93d2e2674566fa186af78bf5029b0b9d8
 - `profile`: https://github.com/PyCQA/pylint/commit/de84bd3d01dd5581e877c9e9d58f32308e67a847
 - `files-output`: https://github.com/PyCQA/pylint/commit/36ed45346ab4d26814a3cffd9a2736f1fff2a40d
 - `comment`: https://github.com/PyCQA/pylint/commit/de84bd3d01dd5581e877c9e9d58f32308e67a847
 - `zope`: https://github.com/PyCQA/pylint/commit/59d73c408d8cd43bf565a0fc20bc67fdc26cf441
 - `module-attribute`, `required-attributes`: https://github.com/PyCQA/pylint/commit/1b1359a9606d52c4c2d76a6977d3e68f6a5f4a9c
 - `no-space-check`: https://pylint.pycqa.org/en/latest/whatsnew/2/2.6/full.html?highlight=no-space-check#what-s-new-in-pylint-2-6-0
 - `ignore-iface-methods`: https://pylint.pycqa.org/en/latest/whatsnew/1/1.7/summary.html?highlight=ignore-iface-methods#removed-changes
  - `short-func-length`: never existed?
  - `deprecated-members`: never existed?

Some functionalities were moved to plugins, in particular `pylint.extensions.bad_builtin` is enabled to allow using `bad-functions`.

Note that a clean modern default `pylintrc` file could be generated via `pylint --generate-rcfile`.
