### PR TITLE
Uses the latest available version when building a container image bas…

### DIFF
--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -76,12 +76,12 @@ def make_required_install_packages():
       'apache-beam[gcp]>=2.40,<3',
       'attrs>=19.3.0,<22',
       'click>=7,<8',
-      # TODO(b/238946565): Remove pinned version when pip can find depenencies
+      # TODO(b/245393802): Remove pinned version when pip can find depenencies
       # without this. `google-api-core` is needed for many google cloud
-      # packages. `google-cloud-recommendations-ai==0.2.0` is a dependency of
-      # apache-beam[gcp] and it requires 'google-api-core<2' which cause a lot
-      # of backtracking.
-      'google-api-core<2',
+      # packages. `google-api-core==1.33.0` requires
+      # `protobuf<4.0.0dev,>=3.20.1` while `tensorboard` requires
+      # `protobuf<3.20`.
+      'google-api-core<1.33',
       'google-cloud-aiplatform>=1.6.2,<2',
       'google-cloud-bigquery>=2.26.0,<3',
       'grpcio>=1.28.1,<2',

--- a/tfx/tools/docker/Dockerfile
+++ b/tfx/tools/docker/Dockerfile
@@ -85,13 +85,6 @@ RUN python -m pip install --upgrade pip
 COPY --from=wheel-builder /tfx/src/dist/*.whl /tfx/src/dist/
 WORKDIR /tfx/src
 
-# TODO(b/237994511): Deletes this workaround when we have regular 2.9.
-RUN if [ "${ADDITIONAL_PACKAGES}" = "tensorflow==2.9.0-rc2" \
-          -a -f "/opt/conda/lib/python3.7/site-packages/tensorflow_serving_api-2.9.0.dist-info/METADATA" ]; then \
-      sed -i "s/Requires-Dist: tensorflow (<3,>=2.9.0)/Requires-Dist: tensorflow (<3,>=2.9.0rc2)/" \
-         "/opt/conda/lib/python3.7/site-packages/tensorflow_serving_api-2.9.0.dist-info/METADATA"  ; \
-    fi
-
 RUN MLSDK_WHEEL=$(find dist -name "ml_pipelines_sdk-*.whl"); \
     TFX_WHEEL=$(find dist -name "tfx-*.whl"); \
     if [ "${TFX_DEPENDENCY_SELECTOR}" = "NIGHTLY" ]; then \


### PR DESCRIPTION
…ed on DLVM images.

Also caps google-api-core version to avoid 1.33.0 which is not compatible with tensorboard.

And deleted a workaround for ill-formed TF 2.9 image because we have a new image without the problem.

PiperOrigin-RevId: 475214110