### PR TITLE
add base_model to transform component

### DIFF
--- a/tfx/components/transform/component.py
+++ b/tfx/components/transform/component.py
@@ -89,6 +89,7 @@ class Transform(base_beam_component.BaseBeamComponent):
       self,
       examples: types.BaseChannel,
       schema: types.BaseChannel,
+      base_model: Optional[types.BaseChannel] = None,
       module_file: Optional[Union[str, data_types.RuntimeParameter]] = None,
       preprocessing_fn: Optional[Union[str,
                                        data_types.RuntimeParameter]] = None,
@@ -109,6 +110,9 @@ class Transform(base_beam_component.BaseBeamComponent):
         'eval'.
       schema: A BaseChannel of type `standard_artifacts.Schema`. This should
         contain a single schema artifact.
+      base_model: A BaseChannel of type `standard_artifacts.Model`. This
+        tensorflow model / function must be executable in graph mode. The path
+        of this model will be accessible from custom_configs.
       module_file: The file path to a python module file, from which the
         'preprocessing_fn' function will be loaded.
         Exactly one of 'module_file' or 'preprocessing_fn' must be supplied.
@@ -215,6 +219,7 @@ class Transform(base_beam_component.BaseBeamComponent):
     spec = standard_component_specs.TransformSpec(
         examples=examples,
         schema=schema,
+        base_model=base_model,
         module_file=module_file,
         preprocessing_fn=preprocessing_fn,
         stats_options_updater_fn=stats_options_updater_fn,

--- a/tfx/components/transform/component_test.py
+++ b/tfx/components/transform/component_test.py
@@ -36,6 +36,8 @@ class ComponentTest(tf.test.TestCase):
     self.examples = channel_utils.as_channel([examples_artifact])
     self.schema = channel_utils.as_channel(
         [standard_artifacts.Schema()])
+    self.base_model = channel_utils.as_channel(
+        [standard_artifacts.Model()])
 
   def _verify_outputs(self,
                       transform,
@@ -169,6 +171,28 @@ class ComponentTest(tf.test.TestCase):
     self.assertEqual(
         json.dumps(custom_config), transform.spec.exec_properties[
             standard_component_specs.CUSTOM_CONFIG_KEY])
+
+  def test_construct_with_base_model(self):
+    preprocessing_fn = 'path.to.my_preprocessing_fn'
+    custom_config = {'param': 1}
+    transform = component.Transform(
+        examples=self.examples,
+        schema=self.schema,
+        base_model=self.base_model,
+        preprocessing_fn=preprocessing_fn,
+        custom_config=custom_config,
+    )
+    self._verify_outputs(transform)
+    self.assertEqual(
+        preprocessing_fn, transform.spec.exec_properties[
+            standard_component_specs.PREPROCESSING_FN_KEY])
+    self.assertEqual(
+        json.dumps(custom_config), transform.spec.exec_properties[
+            standard_component_specs.CUSTOM_CONFIG_KEY])
+    self.assertIsNotNone(
+        json.loads(transform.spec.exec_properties[
+            standard_component_specs.CUSTOM_CONFIG_KEY]
+        ).get("base_model"))
 
   def test_construct_missing_user_module(self):
     with self.assertRaises(ValueError):

--- a/tfx/components/transform/component_test.py
+++ b/tfx/components/transform/component_test.py
@@ -189,10 +189,9 @@ class ComponentTest(tf.test.TestCase):
     self.assertEqual(
         json.dumps(custom_config), transform.spec.exec_properties[
             standard_component_specs.CUSTOM_CONFIG_KEY])
-    self.assertIsNotNone(
-        json.loads(transform.spec.exec_properties[
-            standard_component_specs.CUSTOM_CONFIG_KEY]
-        ).get("base_model"))
+    self.assertIsNotNone(transform.spec.inputs.get("base_model"))
+    self.assertEqual(
+        transform.spec.inputs["base_model"].type_name, "Model")
 
   def test_construct_missing_user_module(self):
     with self.assertRaises(ValueError):

--- a/tfx/components/transform/executor_test.py
+++ b/tfx/components/transform/executor_test.py
@@ -66,6 +66,8 @@ class ExecutorTest(tft_unit.TransformTestCase):
   _SCHEMA_ARTIFACT_DIR = 'schema_gen'
   _MODULE_FILE = 'module_file/transform_module.py'
 
+  _PREVIOUS_MODEL_DIR = "trainer/pervious"
+
   _TEST_COUNTERS = {
       'num_instances': 24909,
       'total_columns_count': 18,
@@ -146,6 +148,11 @@ class ExecutorTest(tft_unit.TransformTestCase):
         standard_component_specs.EXAMPLES_KEY: self._example_artifacts[:1],
         standard_component_specs.SCHEMA_KEY: [schema_artifact],
     }
+
+    # base model (optional)
+    self.previous_model = standard_artifacts.Model()
+    self.previous_model.uri = os.path.join(source_data_dir, 
+                                           self._PREVIOUS_MODEL_DIR)
 
     # Create output dict.
     self._transformed_output = standard_artifacts.TransformGraph()
@@ -388,6 +395,20 @@ class ExecutorTest(tft_unit.TransformTestCase):
             self._exec_properties))
 
     self._transform_executor.Do(self._input_dict, self._output_dict,
+                                self._exec_properties)
+    self._verify_transform_outputs()
+
+  def test_do_with_base_model(self):
+    self._exec_properties[
+        standard_component_specs.PREPROCESSING_FN_KEY] = self._preprocessing_fn
+    input_dict = self._input_dict.copy()
+    input_dict[standard_component_specs.BASE_MODEL_KEY] = [self.previous_model]
+       
+    self.assertIsNone(
+        self._transform_executor._GetStatsOptionsUpdaterFn(
+            self._exec_properties))
+
+    self._transform_executor.Do(input_dict, self._output_dict,
                                 self._exec_properties)
     self._verify_transform_outputs()
 

--- a/tfx/types/standard_component_specs.py
+++ b/tfx/types/standard_component_specs.py
@@ -462,6 +462,9 @@ class TransformSpec(ComponentSpec):
       ANALYZER_CACHE_KEY:
           ChannelParameter(
               type=standard_artifacts.TransformCache, optional=True),
+      BASE_MODEL_KEY:
+          ChannelParameter(
+              type=standard_artifacts.Model, optional=True),
   }
   OUTPUTS = {
       TRANSFORM_GRAPH_KEY:


### PR DESCRIPTION
# Summary
Add `base_model` channel to the `Transform` component, so that `preprocessing_fn` can access the additional model artifacts during transformation through `custom_configs["base_model"]`. This design is similar to the `base_model` argument of the [Trainer component](https://www.tensorflow.org/tfx/api_docs/python/tfx/v1/components/Trainer).

# Example use cases
## Apply pre-computed feature segmentations

```python
def preprocessing_fn(inputs, custom_config):
    outputs = {}
    # load the feature segmentation base model
    with tf.init_scope():
        base_model = tf.saved_models.load(custom_config["base_model"])
    
    outputs["user_segments"] = base_model({
        "age": inputs["age"], 
        "gender": inputs["gender"],
        "location": inputs["location"],
    })
    ...
```

## Apply embeddings of categorical variables trained from another model in the pipeline
```python
import os
import pprint
import tempfile
import math
from typing import Dict

import tensorflow as tf
import tensorflow_transform as tft
import tensorflow_hub as hub

import tensorflow_transform.beam as tft_beam
from tensorflow_transform.tf_metadata import dataset_metadata
from tensorflow_transform.tf_metadata import schema_utils

from apache_beam.transforms import util

from tensorflow.python.keras.models import Model, load_model

raw_data = [
      {'title': ['sterling silver necklace'], 'query': ['silver necklace']},
      {'title': ['gold bracelet'], 'query': ['silver necklace']},
      {'title': ['opal'], 'query': ['silver necklace']}
  ]

raw_feature_spec = {
    'title': tf.io.VarLenFeature(tf.string),
    'query': tf.io.VarLenFeature(tf.string),
}

raw_data_metadata = dataset_metadata.DatasetMetadata(
  schema_utils.schema_from_feature_spec(raw_feature_spec)
)


def get_embedding_similarity(input_1, input_2, embed):
    @tf.function
    def embed_fn(a, b):
        text_1_embedding = embed(a)
        text_2_embedding = embed(b)

        text_1_normalized = tf.nn.l2_normalize(text_1_embedding, axis=-1)
        text_2_normalized = tf.nn.l2_normalize(text_2_embedding, axis=-1)
        cosine_distance = tf.reduce_sum(
            tf.multiply(text_1_normalized, text_2_normalized), axis=-1
        )
        clip_cosine_similarities = tf.clip_by_value(cosine_distance, -1.0, 1.0)
        cosine_scores = 1.0 - tf.acos(clip_cosine_similarities) / math.pi

        l2_norm = tf.norm(text_1_normalized - text_2_normalized, axis=-1, ord='euclidean')

        return cosine_scores, l2_norm
    return embed_fn(input_1, input_2)

def impute(feature_tensor, default):
    sparse = tf.sparse.SparseTensor(
        feature_tensor.indices,
        feature_tensor.values,
        [feature_tensor.dense_shape[0], 1],
    )
    dense = tf.sparse.to_dense(sp_input=sparse, default_value=default)

    return tf.squeeze(dense, axis=1)

def text_feature_transform(feature_dict: Dict[str, tf.Tensor]) -> Dict[str, tf.Tensor]:
    outputs = dict()
    for key in feature_dict.keys():
        feature = impute(feature_dict[key], "")
        outputs[key] = feature
    return outputs

def preprocessing_fn(inputs, custom_config):
    inputs_text_transform = {key: inputs[key] for key in ['query','title']}
    outputs_text = text_feature_transform(inputs_text_transform)

    outputs = {
        **outputs_text,
    }

    with tf.init_scope():
        embed = tf.saved_model.load(custom_config["base_model"])

    cos_dist, euc_dist = get_embedding_similarity(impute(inputs['query'],""), impute(inputs['title'],""), embed)
    outputs[f"query_title_nnlm_cos_dist"] = cos_dist
    outputs[f"query_title_nnlm_euc_dist"] = euc_dist

    return outputs

def run_tft_pipeline():
    custom_config = {"base_model": "gs://mybucekt/custom_embedding_model/"}
    preprocessing_fn = lambda inputs: preprocessing_fn(inputs, custom_config)
    temp_dir = tempfile.mkdtemp()
    os.environ['TFHUB_CACHE_DIR']=os.path.join(temp_dir, "tfhub_modules")
    with tft_beam.Context(temp_dir=temp_dir, force_tf_compat_v1=False):
        transformed_dataset, transform_fn = ((raw_data, raw_data_metadata) | tft_beam.AnalyzeAndTransformDataset(preprocessing_fn))

    transformed_data, transformed_metadata = transformed_dataset

    print('\nRaw data:\n{}\n'.format(pprint.pformat(raw_data)))
    print('Transformed data:\n{}'.format(pprint.pformat(transformed_data)))


if __name__== "__main__":
    run_tft_pipeline()
```

Example adapted from: https://github.com/tensorflow/transform/issues/219

The model artifacts can be generic and stores any tensorflow models and functions.