### PR TITLE
Update 404 broken link

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -399,7 +399,7 @@ You will first query [**ML Metadata (MLMD)**](mlmd.md) to locate the results of
 these executions of these components, and then use the visualization support API
 in TFDV to create the visualizations in your notebook. This includes
 [tfdv.load_statistics()](https://www.tensorflow.org/tfx/data_validation/api_docs/python/tfdv/load_statistics)
-and [tfdv.visualize_statistics()](`tfdv.visualize_statistics`) Using this
+and [tfdv.visualize_statistics()](https://www.tensorflow.org/tfx/data_validation/api_docs/python/tfdv/visualize_statistics) Using this
 visualization you can better understand the characteristics of your dataset, and
 if necessary modify as required.
 


### PR DESCRIPTION
updated tfdv.visualize_statistics() broken 404 link from 'tfdv.visualize_statistics' to 'https://www.tensorflow.org/tfx/data_validation/api_docs/python/tfdv/visualize_statistics'