### PR TITLE
User Guide Fix: Update Broken Link

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -345,7 +345,7 @@ needed.
 TFX provides a powerful platform for every phase of a machine learning project,
 from research, experimentation, and development on your local machine, through
 deployment. In order to avoid code duplication and eliminate the potential for
-[training/serving skew](#training-serving-skew-detection) it is strongly
+[training/serving skew](https://www.tensorflow.org/tfx/guide/tfdv#training-serving_skew_detection) it is strongly
 recommended to implement your TFX pipeline for both model training and
 deployment of trained models, and use [Transform](transform.md) components which
 leverage the [TensorFlow Transform](tft.md) library for both training and


### PR DESCRIPTION
updated broken `training/serving skew` link from '#training-serving-skew-detection' to 'https://www.tensorflow.org/tfx/guide/tfdv#training-serving_skew_detection'