### PR TITLE
feat: make experimental.annotations.OutputDict compatible with typing.TypedDict

### DIFF
--- a/tfx/dsl/component/experimental/annotations.py
+++ b/tfx/dsl/component/experimental/annotations.py
@@ -198,4 +198,3 @@ class BeamComponentParameter(_PipelineTypeGeneric):
 
 class OutputDict(TypedDict):
   """Component return type annotation."""
-  pass

--- a/tfx/dsl/component/experimental/annotations.py
+++ b/tfx/dsl/component/experimental/annotations.py
@@ -196,9 +196,6 @@ class BeamComponentParameter(_PipelineTypeGeneric):
   pass
 
 
-# TODO(olgai): change this comment
-# TODO(ccy): potentially make this compatible `typing.TypedDict` in
-# Python 3.8, to allow for component return value type checking.
 class OutputDict(TypedDict):
   """Component return type annotation."""
   pass

--- a/tfx/dsl/component/experimental/annotations.py
+++ b/tfx/dsl/component/experimental/annotations.py
@@ -17,10 +17,18 @@ Experimental. No backwards compatibility guarantees.
 """
 
 import inspect
+import sys
+
 from typing import Any, Type, Union, Dict, List
 
 from tfx.dsl.component.experimental import json_compat
 from tfx.types import artifact
+
+if sys.version_info >= (3, 8):
+  from typing import TypedDict
+else:
+  from typing_extensions import TypedDict
+
 try:
   import apache_beam as beam  # pytype: disable=import-error  # pylint: disable=g-import-not-at-top
   _BeamPipeline = beam.Pipeline
@@ -188,10 +196,9 @@ class BeamComponentParameter(_PipelineTypeGeneric):
   pass
 
 
+# TODO(olgai): change this comment
 # TODO(ccy): potentially make this compatible `typing.TypedDict` in
 # Python 3.8, to allow for component return value type checking.
-class OutputDict:
-  """Decorator declaring component executor function outputs."""
-
-  def __init__(self, **kwargs):
-    self.kwargs = kwargs
+class OutputDict(TypedDict):
+  """Component return type annotation."""
+  pass

--- a/tfx/dsl/component/experimental/decorators_test.py
+++ b/tfx/dsl/component/experimental/decorators_test.py
@@ -108,8 +108,16 @@ class InjectorOutput(TypedDict):
 
 @component
 def _injector_1_with_custom_typed_dict(
-    foo: Parameter[int], bar: Parameter[str]) -> InjectorOutput(
-        a=int, b=int, c=str, d=bytes):
+        foo: Parameter[int], bar: Parameter[str]) -> InjectorOutput:
+  assert foo == 9
+  assert bar == 'secret'
+  return {'a': 10, 'b': 22, 'c': 'unicode', 'd': b'bytes'}
+
+
+@component
+def _injector_1_with_custom_typed_dict_alter_syntax(
+        foo: Parameter[int], bar: Parameter[str]) -> InjectorOutput(
+            a=int, b=int, c=str, d=bytes):
   assert foo == 9
   assert bar == 'secret'
   return {'a': 10, 'b': 22, 'c': 'unicode', 'd': b'bytes'}

--- a/tfx/dsl/component/experimental/decorators_test.py
+++ b/tfx/dsl/component/experimental/decorators_test.py
@@ -100,6 +100,14 @@ def _injector_1(
   assert bar == 'secret'
   return {'a': 10, 'b': 22, 'c': 'unicode', 'd': b'bytes'}
 
+@component
+def _injector_1_with_typed_dict(
+        foo: Parameter[int], bar: Parameter[str]) -> TypedDict(
+            "InjectorOutput", a=int, b=int, c=str, d=bytes):
+  assert foo == 9
+  assert bar == 'secret'
+  return {'a': 10, 'b': 22, 'c': 'unicode', 'd': b'bytes'}
+
 class InjectorOutput(TypedDict):
   a: int
   b: int
@@ -449,17 +457,18 @@ class ComponentDecoratorTest(tf.test.TestCase):
   def testBeamExecutionSuccess(self):
     """Test execution with return values; success case."""
     instance_1 = _injector_1(foo=9, bar='secret')
-    instance_2 = _injector_1_with_custom_typed_dict(foo=9, bar='secret')
-    instance_3 = _simple_component(
+    instance_2 = _injector_1_with_typed_dict(foo=9, bar='secret')
+    instance_3 = _injector_1_with_custom_typed_dict(foo=9, bar='secret')
+    instance_4 = _simple_component(
         a=instance_1.outputs['a'],
         b=instance_1.outputs['b'],
         c=instance_2.outputs['c'],
-        d=instance_2.outputs['d'])
-    instance_4 = _verify(
-        e=instance_3.outputs['e'],
-        f=instance_3.outputs['f'],
-        g=instance_3.outputs['g'],
-        h=instance_3.outputs['h'])  # pylint: disable=assignment-from-no-return
+        d=instance_3.outputs['d'])
+    instance_5 = _verify(
+        e=instance_4.outputs['e'],
+        f=instance_4.outputs['f'],
+        g=instance_4.outputs['g'],
+        h=instance_4.outputs['h'])  # pylint: disable=assignment-from-no-return
 
     metadata_config = metadata.sqlite_metadata_connection_config(
         self._metadata_path)
@@ -467,7 +476,7 @@ class ComponentDecoratorTest(tf.test.TestCase):
         pipeline_name='test_pipeline_1',
         pipeline_root=self._test_dir,
         metadata_connection_config=metadata_config,
-        components=[instance_1, instance_2, instance_3, instance_4])
+        components=[instance_1, instance_2, instance_3, instance_4, instance_5])
 
     beam_dag_runner.BeamDagRunner().run(test_pipeline)
 

--- a/tfx/dsl/component/experimental/function_parser.py
+++ b/tfx/dsl/component/experimental/function_parser.py
@@ -83,8 +83,8 @@ def _validate_signature(
                        subject_message)
 
   # Validate return type hints.
-  if isinstance(typehints.get('return', None), annotations.OutputDict):
-    for arg, arg_typehint in typehints['return'].kwargs.items():
+  if isinstance(typehints.get('return', None), Dict):
+    for arg, arg_typehint in typehints['return'].items():
       if (isinstance(arg_typehint, annotations.OutputArtifact) or
           (inspect.isclass(arg_typehint) and
            issubclass(arg_typehint, artifact.Artifact))):
@@ -98,8 +98,9 @@ def _validate_signature(
     pass
   else:
     raise ValueError(
-        ('%s must have either an OutputDict instance or `None` as its return '
-         'value typehint.') % subject_message)
+        ('%s must have either an OutputDict instance, '
+         'typing.TypedDict instance '
+         'or `None` as its return value typehint.') % subject_message)
 
 
 def _parse_signature(
@@ -224,7 +225,7 @@ def _parse_signature(
           (arg, func))
 
   if 'return' in typehints and typehints['return'] not in (None, type(None)):
-    for arg, arg_typehint in typehints['return'].kwargs.items():
+    for arg, arg_typehint in typehints['return'].items():
       if arg_typehint in _OPTIONAL_PRIMITIVE_MAP:
         unwrapped_typehint = _OPTIONAL_PRIMITIVE_MAP[arg_typehint]
         outputs[arg] = _PRIMITIVE_TO_ARTIFACT[unwrapped_typehint]

--- a/tfx/dsl/component/experimental/function_parser.py
+++ b/tfx/dsl/component/experimental/function_parser.py
@@ -29,11 +29,6 @@ from tfx.dsl.component.experimental import json_compat
 from tfx.types import artifact
 from tfx.types import standard_artifacts
 
-if sys.version_info >= (3, 8):
-  from typing import _TypedDictMeta
-else:
-  from typing_extensions import _TypedDictMeta
-
 try:
   import apache_beam as beam  # pytype: disable=import-error  # pylint: disable=g-import-not-at-top
   _BeamPipeline = beam.Pipeline
@@ -68,8 +63,7 @@ _OPTIONAL_PRIMITIVE_MAP = dict((Optional[t], t) for t in _PRIMITIVE_TO_ARTIFACT)
 def _get_return_type_annotations(typehints: Dict[str, Any]) -> Optional[Dict]:
   """Returns annotations of expected return types."""
   return_annotations = typehints.get('return')
-  if (isinstance(return_annotations, _TypedDictMeta) and
-          getattr(return_annotations, "__annotations__")):
+  if hasattr(return_annotations, "__annotations__"):
     return return_annotations.__annotations__
   elif isinstance(return_annotations, Dict):
     return return_annotations

--- a/tfx/dsl/component/experimental/function_parser.py
+++ b/tfx/dsl/component/experimental/function_parser.py
@@ -65,11 +65,16 @@ _PRIMITIVE_TO_ARTIFACT = {
 _OPTIONAL_PRIMITIVE_MAP = dict((Optional[t], t) for t in _PRIMITIVE_TO_ARTIFACT)
 
 
-def _get_return_type_annotations(typehints):
-  try:
-    return typehints['return'].items()
-  except TypeError:
-    return typehints['return'].__annotations__.items()
+def _get_return_type_annotations(typehints: Dict[str, Any]) -> Optional[Dict]:
+  """Returns annotations of expected return types."""
+  return_annotations = typehints.get('return')
+  if (isinstance(return_annotations, _TypedDictMeta) and
+          getattr(return_annotations, "__annotations__")):
+    return return_annotations.__annotations__
+  elif isinstance(return_annotations, Dict):
+    return return_annotations
+  else:
+    return None
 
 
 def _validate_signature(
@@ -95,9 +100,9 @@ def _validate_signature(
                        subject_message)
 
   # Validate return type hints.
-  if (isinstance(typehints.get('return'), Dict) or
-      isinstance(typehints.get('return'), _TypedDictMeta)):
-    for arg, arg_typehint in _get_return_type_annotations(typehints):
+  return_annotations = _get_return_type_annotations(typehints)
+  if isinstance(return_annotations, Dict):
+    for arg, arg_typehint in return_annotations.items():
       if (isinstance(arg_typehint, annotations.OutputArtifact) or
           (inspect.isclass(arg_typehint) and
            issubclass(arg_typehint, artifact.Artifact))):
@@ -238,8 +243,10 @@ def _parse_signature(
           'Unknown type hint annotation for argument %r on function %r' %
           (arg, func))
 
-  if 'return' in typehints and typehints['return'] not in (None, type(None)):
-    for arg, arg_typehint in _get_return_type_annotations(typehints):
+  return_annotations = _get_return_type_annotations(typehints)
+  if ('return' in typehints and typehints['return'] not in (None, type(None))
+          and isinstance(return_annotations, Dict)):
+    for arg, arg_typehint in return_annotations.items():
       if arg_typehint in _OPTIONAL_PRIMITIVE_MAP:
         unwrapped_typehint = _OPTIONAL_PRIMITIVE_MAP[arg_typehint]
         outputs[arg] = _PRIMITIVE_TO_ARTIFACT[unwrapped_typehint]

--- a/tfx/dsl/component/experimental/function_parser.py
+++ b/tfx/dsl/component/experimental/function_parser.py
@@ -65,6 +65,13 @@ _PRIMITIVE_TO_ARTIFACT = {
 _OPTIONAL_PRIMITIVE_MAP = dict((Optional[t], t) for t in _PRIMITIVE_TO_ARTIFACT)
 
 
+def _get_return_type_annotations(typehints):
+  try:
+    return typehints['return'].items()
+  except TypeError:
+    return typehints['return'].__annotations__.items()
+
+
 def _validate_signature(
     func: types.FunctionType,
     argspec: inspect.FullArgSpec,  # pytype: disable=module-attr
@@ -88,8 +95,9 @@ def _validate_signature(
                        subject_message)
 
   # Validate return type hints.
-  if isinstance(typehints.get('return', None), Dict):
-    for arg, arg_typehint in typehints['return'].items():
+  if (isinstance(typehints.get('return'), Dict) or
+      isinstance(typehints.get('return'), _TypedDictMeta)):
+    for arg, arg_typehint in _get_return_type_annotations(typehints):
       if (isinstance(arg_typehint, annotations.OutputArtifact) or
           (inspect.isclass(arg_typehint) and
            issubclass(arg_typehint, artifact.Artifact))):
@@ -98,19 +106,8 @@ def _validate_signature(
              'be declared as function parameters annotated with type hint '
              '`tfx.types.annotations.OutputArtifact[T]` where T is a '
              'subclass of `tfx.types.Artifact`. They should not be declared '
-             'as part of the return value `OutputDict` type hint.') % func)
-
-  elif isinstance(typehints.get('return', None), _TypedDictMeta):
-    for arg, arg_typehint in typehints['return'].__annotations__.items():
-      if (isinstance(arg_typehint, annotations.OutputArtifact) or
-          (inspect.isclass(arg_typehint) and
-           issubclass(arg_typehint, artifact.Artifact))):
-        raise ValueError(
-            ('Output artifacts for the component executor function %r should '
-             'be declared as function parameters annotated with type hint '
-             '`tfx.types.annotations.OutputArtifact[T]` where T is a '
-             'subclass of `tfx.types.Artifact`. They should not be declared '
-             'as part of the return value `OutputDict` type hint.') % func)
+             'as part of the return value `OutputDict` or '
+             '`TypedDict` type hint.') % func)
   elif 'return' not in typehints or typehints['return'] in (None, type(None)):
     pass
   else:
@@ -242,13 +239,7 @@ def _parse_signature(
           (arg, func))
 
   if 'return' in typehints and typehints['return'] not in (None, type(None)):
-    return_type_annotations = typehints['return']
-    try:
-      typehints['return'].items()
-    except TypeError:
-      return_type_annotations = typehints['return'].__annotations__
-
-    for arg, arg_typehint in return_type_annotations.items():
+    for arg, arg_typehint in _get_return_type_annotations(typehints):
       if arg_typehint in _OPTIONAL_PRIMITIVE_MAP:
         unwrapped_typehint = _OPTIONAL_PRIMITIVE_MAP[arg_typehint]
         outputs[arg] = _PRIMITIVE_TO_ARTIFACT[unwrapped_typehint]

--- a/tfx/dsl/component/experimental/function_parser.py
+++ b/tfx/dsl/component/experimental/function_parser.py
@@ -21,7 +21,6 @@ Internal use only. No backwards compatibility guarantees.
 
 import enum
 import inspect
-import sys
 import types
 from typing import Any, Dict, Optional, Tuple, Type, Union
 from tfx.dsl.component.experimental import annotations

--- a/tfx/dsl/component/experimental/function_parser_test.py
+++ b/tfx/dsl/component/experimental/function_parser_test.py
@@ -345,7 +345,8 @@ class FunctionParserTest(tf.test.TestCase):
     # Function with *args and **kwargs.
     with self.assertRaisesRegex(
         ValueError,
-        'must have either an OutputDict instance or `None` as its return'):
+        'must have either an OutputDict instance, '
+        'typing.TypedDict instance or `None` as its return'):
 
       def func_a(a: int, b: int) -> object:
         del a, b


### PR DESCRIPTION
With this change, `OutputDict` is now a `typing.TypedDict`; the old syntax is still supported.

Now, we can annotate our `@component` return type as follows:
```python
from typing import TypedDict

@component
def MyValidationComponent(...) -> TypedDict("MyTypedDictOutput", accuracy=float):
   ...
  return {
    'accuracy': accuracy
  }
 ```
Alternative `TypedDict` syntax is supported as well.
The main advantage is that it's a TFX-agnostic type that type-checkers can validate.
 
 -----
 ### TODO:
 - [ ] Update any docs/tutorials