### PR TITLE
Replacing missing features in chicago_taxi_clients.py with their statistical attributes

### DIFF
--- a/tfx/examples/chicago_taxi_pipeline/serving/chicago_taxi_client.py
+++ b/tfx/examples/chicago_taxi_pipeline/serving/chicago_taxi_client.py
@@ -31,6 +31,7 @@ from tensorflow_transform.tf_metadata import schema_utils
 from google.protobuf import text_format
 from tensorflow.python.lib.io import file_io  # pylint: disable=g-direct-tensorflow-import
 from tensorflow_metadata.proto.v0 import schema_pb2
+import tensorflow_data_validation as tfdv
 
 _LOCAL_INFERENCE_TIMEOUT_SECONDS = 5.0
 
@@ -126,6 +127,7 @@ def _do_inference(model_handle, examples_file, num_examples, schema):
 
   csv_reader = csv.DictReader(open(examples_file, 'r'))
 
+  dataset_stats = tfdv.generate_statistics_from_csv(examples_file)
   serialized_examples = []
   for _ in range(num_examples):
     one_line = next(csv_reader)
@@ -135,6 +137,8 @@ def _do_inference(model_handle, examples_file, num_examples, schema):
     one_example = {}
     for feature in schema.feature:
       name = feature.name
+      feature_stats = tfdv.get_feature_stats(dataset_stats.datasets[0],
+                                             tfdv.FeaturePath([name]))
       if one_line[name]:
         if feature.type == schema_pb2.FLOAT:
           one_example[name] = [float(one_line[name])]
@@ -143,7 +147,18 @@ def _do_inference(model_handle, examples_file, num_examples, schema):
         elif feature.type == schema_pb2.BYTES:
           one_example[name] = [one_line[name].encode('utf8')]
       else:
-        one_example[name] = []
+        # TF serve does not like missing features, so we'll populate
+        # missing features with mean / mode values of that feature
+        if feature.type == schema_pb2.FLOAT:
+          one_example[name] = [feature_stats.num_stats.mean]
+        elif feature.type == schema_pb2.INT:
+          one_example[name] = [int(feature_stats.num_stats.mean)]
+        elif feature.type == schema_pb2.BYTES:
+          top_values = list(feature_stats.string_stats.top_values)
+          if len(top_values) > 0:
+            one_example[name] = [top_values[0].value.encode('utf8')]
+          else:
+            one_example[name] = ["".encode('utf8')]
 
     serialized_example = proto_coder.encode(one_example)
     serialized_examples.append(serialized_example)
@@ -182,7 +197,7 @@ def _parse_flags(argv: List[str]) -> argparse.Namespace:
 
   parser.add_argument(
       '--schema_file', help='File holding the schema for the input data')
-  return parser.parse_args(argv)
+  return parser.parse_args(argv[1:])
 
 
 def main(args: argparse.Namespace):

--- a/tfx/examples/chicago_taxi_pipeline/serving/chicago_taxi_client.py
+++ b/tfx/examples/chicago_taxi_pipeline/serving/chicago_taxi_client.py
@@ -148,7 +148,7 @@ def _do_inference(model_handle, examples_file, num_examples, schema):
           one_example[name] = [one_line[name].encode('utf8')]
       else:
         # TF serve does not like missing features, so we'll populate
-        # missing features with mean / mode values of that feature
+        # the missing features with their mean/mode instead
         if feature.type == schema_pb2.FLOAT:
           one_example[name] = [feature_stats.num_stats.mean]
         elif feature.type == schema_pb2.INT:
@@ -158,7 +158,7 @@ def _do_inference(model_handle, examples_file, num_examples, schema):
           if len(top_values) > 0:
             one_example[name] = [top_values[0].value.encode('utf8')]
           else:
-            one_example[name] = ["".encode('utf8')]
+            one_example[name] = [''.encode('utf8')]
 
     serialized_example = proto_coder.encode(one_example)
     serialized_examples.append(serialized_example)


### PR DESCRIPTION
Using the Tensorflow data validation package, the dataset's statistics are calculated. And then when composing a request payload, in case the record is missing a feature, the value is replaced with one of the following:

If the feature is of type BYTES (categorical), the most common value will be used instead. If the feature is numeric, the average value of the column will be used. The average will also be cast to INT if the feature type is an integer.

This PR is to address a fix for this issue:

https://github.com/tensorflow/tfx/issues/5518