### PR TITLE
Export KUBEFLOW_TFX_CMD pubilcly instead of private access

### DIFF
--- a/tfx/orchestration/kubeflow/v2/kubeflow_v2_dag_runner.py
+++ b/tfx/orchestration/kubeflow/v2/kubeflow_v2_dag_runner.py
@@ -33,7 +33,7 @@ from tfx.utils import version_utils
 
 from google.protobuf import json_format
 
-_KUBEFLOW_TFX_CMD = (
+KUBEFLOW_TFX_CMD = (
     'python', '-m',
     'tfx.orchestration.kubeflow.v2.container.kubeflow_v2_run_executor')
 
@@ -80,7 +80,7 @@ class KubeflowV2DagRunnerConfig(pipeline_config.PipelineConfig):
     self.display_name = display_name
     self.default_image = default_image or _KUBEFLOW_TFX_IMAGE
     if default_commands is None:
-      self.default_commands = _KUBEFLOW_TFX_CMD
+      self.default_commands = KUBEFLOW_TFX_CMD
     else:
       self.default_commands = default_commands
 


### PR DESCRIPTION
- When customize the command of `KubeflowV2DagRunner` via [`default_command` argument](https://github.com/tensorflow/tfx/blob/2450843564f4bc9297f01d1c8fd69c01c7dba4d8/tfx/orchestration/kubeflow/v2/kubeflow_v2_dag_runner.py#L59) of [`KubeflowV2DagRunnerConfig`](https://github.com/tensorflow/tfx/blob/2450843564f4bc9297f01d1c8fd69c01c7dba4d8/tfx/orchestration/kubeflow/v2/kubeflow_v2_dag_runner.py#L53), access default `KUBEFLOW_TFX_CMD` variable publicly instead of private manner
- Relevant to this issue https://github.com/tensorflow/tfx/issues/5527

cc: @jeongukjae 