### PR TITLE
Display tfma output

### DIFF
--- a/tfx/orchestration/experimental/interactive/standard_visualizations.py
+++ b/tfx/orchestration/experimental/interactive/standard_visualizations.py
@@ -81,7 +81,7 @@ class ModelEvaluationVisualization(visualizations.ArtifactVisualization):
     tfma_result = tfma.load_eval_result(artifact.uri)
     # TODO(ccy): add comment instructing user to use the TFMA library directly
     # in order to render non-default slicing metric views.
-    tfma.view.render_slicing_metrics(tfma_result)
+    display(tfma.view.render_slicing_metrics(tfma_result))
 
 
 class SchemaVisualization(visualizations.ArtifactVisualization):


### PR DESCRIPTION
The render_slicing_metrics only returns a view, without either returning or displaying it it won't ever show up.

Also needed https://github.com/tensorflow/model-analysis/pull/165 to test this in jupyter lab.

Edit: I noticed that there is a difference in behavior in colab vs jupyter lab rendering, colab doesn't return anything while jupyter does, so I guess this could break in colab?