### PR TITLE
Update TFX_DAG_NAME constant

### DIFF
--- a/tfx/orchestration/kubeflow/utils.py
+++ b/tfx/orchestration/kubeflow/utils.py
@@ -18,7 +18,7 @@ from tfx.dsl.components.base import base_node
 from tfx.orchestration.kubeflow.decorators import FinalStatusStr
 
 # Key of dag for all TFX components when compiling pipeline with exit handler.
-TFX_DAG_NAME = '_tfx_dag'
+TFX_DAG_NAME = 'tfx-dag'
 
 
 def replace_exec_properties(component: base_node.BaseNode) -> None:


### PR DESCRIPTION
updating TFX_DAG_NAME contant to agro compliant name to fix below error. Ref issue: #5528 
"error_details":"Internal error: spec.templates[0].name: '_tfx_dag' is invalid: name must consist of alpha-numeric characters or '-', and must start with an alpha-numeric character (e.g. My-name1-2, 123-NAME)