### PR TITLE
`Rest_Simple` tutorial is not working in Colab

### DIFF
--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -355,7 +355,7 @@
       },
       "outputs": [],
       "source": [
-        "#!{SUDO_IF_NEEDED} apt-get install tensorflow-model-server #Instlling Tensorflow Model server 2.8 instead of latest version\n"
+        "#!{SUDO_IF_NEEDED} apt-get install tensorflow-model-server #installing Tensorflow Model server 2.8 instead of latest version\n"
         "Tensorflow Serving >2.9.0 required `GLIBC_2.29` and `GLIBCXX_3.4.26`. Currently colab environment doesn't support latest version of`GLIBC`,\n"
         "so workaround is to use specific version of Tensorflow Serving `2.8.0` to mitigate issue.\n"
         "!wget 'http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server-2.8.0/t/tensorflow-model-server/tensorflow-model-server_2.8.0_all.deb'\n",

--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -355,6 +355,9 @@
       },
       "outputs": [],
       "source": [
+        "#!{SUDO_IF_NEEDED} apt-get install tensorflow-model-server #Instlling Tensorflow Model server 2.8 instead of latest version\n"
+        "Tensorflow Serving >2.9.0 required `GLIBC_2.29` and `GLIBCXX_3.4.26`. Currently colab environment doesn't support latest version of`GLIBC`,\n"
+        "so workaround is to use specific version of Tensorflow Serving `2.8.0` to mitigate issue.\n"
         "!wget 'http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server-2.8.0/t/tensorflow-model-server/tensorflow-model-server_2.8.0_all.deb'\n",
         "!dpkg -i tensorflow-model-server_2.8.0_all.deb\n",
         "!pip3 install tensorflow-serving-api==2.8.0"

--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -355,7 +355,9 @@
       },
       "outputs": [],
       "source": [
-        "!{SUDO_IF_NEEDED} apt-get install tensorflow-model-server"
+        "!wget 'http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server-2.8.0/t/tensorflow-model-server/tensorflow-model-server_2.8.0_all.deb'\n",
+        "!dpkg -i tensorflow-model-server_2.8.0_all.deb\n",
+        "!pip3 install tensorflow-serving-api==2.8.0"
       ]
     },
     {

--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -355,9 +355,10 @@
       },
       "outputs": [],
       "source": [
-        "#!{SUDO_IF_NEEDED} apt-get install tensorflow-model-server #installing Tensorflow Model server 2.8 instead of latest version\n",
-        "Tensorflow Serving >2.9.0 required `GLIBC_2.29` and `GLIBCXX_3.4.26`. Currently colab environment doesn't support latest version of`GLIBC`,\n",
-        "so workaround is to use specific version of Tensorflow Serving `2.8.0` to mitigate issue.\n",
+        "# TODO: Use the latest model server version when colab supports it.\n",
+        "#!{SUDO_IF_NEEDED} apt-get install tensorflow-model-server\n",
+        "# We need to install Tensorflow Model server 2.8 instead of latest version\n",
+        "# Tensorflow Serving >2.9.0 required `GLIBC_2.29` and `GLIBCXX_3.4.26`. Currently colab environment doesn't support latest version of`GLIBC`,so workaround is to use specific version of Tensorflow Serving `2.8.0` to mitigate issue.\n",
         "!wget 'http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server-2.8.0/t/tensorflow-model-server/tensorflow-model-server_2.8.0_all.deb'\n",
         "!dpkg -i tensorflow-model-server_2.8.0_all.deb\n",
         "!pip3 install tensorflow-serving-api==2.8.0"

--- a/docs/tutorials/serving/rest_simple.ipynb
+++ b/docs/tutorials/serving/rest_simple.ipynb
@@ -355,9 +355,9 @@
       },
       "outputs": [],
       "source": [
-        "#!{SUDO_IF_NEEDED} apt-get install tensorflow-model-server #installing Tensorflow Model server 2.8 instead of latest version\n"
-        "Tensorflow Serving >2.9.0 required `GLIBC_2.29` and `GLIBCXX_3.4.26`. Currently colab environment doesn't support latest version of`GLIBC`,\n"
-        "so workaround is to use specific version of Tensorflow Serving `2.8.0` to mitigate issue.\n"
+        "#!{SUDO_IF_NEEDED} apt-get install tensorflow-model-server #installing Tensorflow Model server 2.8 instead of latest version\n",
+        "Tensorflow Serving >2.9.0 required `GLIBC_2.29` and `GLIBCXX_3.4.26`. Currently colab environment doesn't support latest version of`GLIBC`,\n",
+        "so workaround is to use specific version of Tensorflow Serving `2.8.0` to mitigate issue.\n",
         "!wget 'http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server-2.8.0/t/tensorflow-model-server/tensorflow-model-server_2.8.0_all.deb'\n",
         "!dpkg -i tensorflow-model-server_2.8.0_all.deb\n",
         "!pip3 install tensorflow-serving-api==2.8.0"


### PR DESCRIPTION
Rest_Simple tutorial is not working in colab using the tensorflow-model-server  Workaround: Downgrading `tensorflow-model-server` from `2.11.0` to `2.8.0` has resolved the issue.

Code to install tensorflow-model-server 2.8.0:
```
!wget 'http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server-2.8.0/t/tensorflow-model-server/tensorflow-model-server_2.8.0_all.deb'
!dpkg -i tensorflow-model-server_2.8.0_all.deb
!pip3 install tensorflow-serving-api==2.8.0
```

Please refer to the working gist here:  https://colab.sandbox.google.com/gist/chunduriv/dcb7494b272957ccc36d085bbd5e0b98/rest_simple.ipynb