### PR TITLE
improvement: make `Duplicated node_id` error more actionable

### DIFF
--- a/tfx/orchestration/pipeline.py
+++ b/tfx/orchestration/pipeline.py
@@ -376,7 +376,7 @@ class Pipeline(base_node.BaseNode):
       if component.id in node_by_id:
         raise RuntimeError(
             f'Duplicated node_id {component.id} for component type'
-            f'{component.type}.')
+            f'{component.type}. Try setting a different node_id using `.with_id()`.')
       node_by_id[component.id] = component
 
     # Connects nodes based on producer map.

--- a/tfx/orchestration/pipeline.py
+++ b/tfx/orchestration/pipeline.py
@@ -376,7 +376,8 @@ class Pipeline(base_node.BaseNode):
       if component.id in node_by_id:
         raise RuntimeError(
             f'Duplicated node_id {component.id} for component type'
-            f'{component.type}. Try setting a different node_id using `.with_id()`.')
+            f'{component.type}. Try setting a different node_id using '
+            '`.with_id()`.')
       node_by_id[component.id] = component
 
     # Connects nodes based on producer map.


### PR DESCRIPTION
by suggesting using `.with_id()`.