### PR TITLE
Add SCaNN support to BulkInferrer

### DIFF
--- a/tfx/components/bulk_inferrer/executor.py
+++ b/tfx/components/bulk_inferrer/executor.py
@@ -42,6 +42,11 @@ try:
 except ImportError as e:
   logging.info('tensorflow_text is not available: %s', e)
 
+try:
+  import tensorflow_recommenders as _  # pylint: disable=g-import-not-at-top
+except ImportError as e:
+  logging.info('tensorflow_recommenders is not available: %s', e)
+
 
 _PREDICTION_LOGS_FILE_NAME = 'prediction_logs'
 _EXAMPLES_FILE_NAME = 'examples'


### PR DESCRIPTION
In order to load a saved model with a SCaNN layer, we need to import tensorflow_recommenders to avoid a runtime error.

The error would be: Op type not registered 'Scann>ScannSearchBatched'. Note that if you are loading a saved graph which used ops from tf.contrib, accessing (e.g.) `tf.contrib.resampler` should be done before importing the graph, as contrib ops are lazily registered when the module is first accessed.

Since SCaNN is a custom op, after running `pip install scann` the lazy loading mentioned in the error message still needs to be solved.

See https://github.com/google-research/google-research/tree/master/scann