### PR TITLE
Fixed bug where docker does not mount path because it is relative

### DIFF
--- a/tfx/components/infra_validator/model_server_runners/local_docker_runner.py
+++ b/tfx/components/infra_validator/model_server_runners/local_docker_runner.py
@@ -116,7 +116,7 @@ class LocalDockerRunner(base_runner.BaseModelServerRunner):
     if isinstance(self._serving_binary, serving_bins.TensorFlowServing):
       is_local = os.path.isdir(self._model_path)
       run_params = self._serving_binary.MakeDockerRunParams(
-          model_path=self._model_path,
+          model_path=os.path.abspath(self._model_path),
           needs_mount=is_local)
     else:
       raise NotImplementedError('Unsupported serving binary {}'.format(


### PR DESCRIPTION
Docker doesn't mount the model_path because it is relative.  Updated it so that it uses the absolute path.