### PR TITLE
Add int64 support to bulk-inferrer output types

### DIFF
--- a/tfx/components/bulk_inferrer/prediction_to_example_utils.py
+++ b/tfx/components/bulk_inferrer/prediction_to_example_utils.py
@@ -170,13 +170,15 @@ def _add_columns(example: tf.train.Example,
   for col, value in features:
     assert col not in feature_map, ('column name %s already exists in example: '
                                     '%s') % (col, example)
-    # Note: we only consider two types, bytes and float for now.
+    # Note: we only consider three types, bytes, int64 and float for now.
     if isinstance(value[0], (str, bytes)):
       if isinstance(value[0], str):
         bytes_value = [v.encode('utf-8') for v in value]
       else:
         bytes_value = value
       feature_map[col].bytes_list.value[:] = bytes_value
+    elif isinstance(value[0], int):
+      feature_map[col].int64_list.value[:] = value
     else:
       feature_map[col].float_list.value[:] = value
   return example

--- a/tfx/components/bulk_inferrer/prediction_to_example_utils_test.py
+++ b/tfx/components/bulk_inferrer/prediction_to_example_utils_test.py
@@ -268,6 +268,15 @@ class PredictionToExampleUtilsTest(tf.test.TestCase, parameterized.TestCase):
              string_val: "prediction"
            }
          }
+         outputs {
+           key: "output_ints"
+           value {
+             dtype: DT_INT64
+             tensor_shape { dim { size: 1 } dim { size: 2 }}
+             int64_val: 2
+             int64_val: 3
+           }
+         }
        }
      }
     """ % input_key, prediction_log_pb2.PredictionLog())
@@ -289,6 +298,10 @@ class PredictionToExampleUtilsTest(tf.test.TestCase, parameterized.TestCase):
               output_key: 'output_bytes'
               output_column: 'predict_bytes'
             }
+            output_columns {
+              output_key: 'output_ints'
+              output_column: 'predict_ints'
+            }
           }
         }
     """, bulk_inferrer_pb2.OutputExampleSpec())
@@ -306,6 +319,10 @@ class PredictionToExampleUtilsTest(tf.test.TestCase, parameterized.TestCase):
             feature: {
               key: "predict_bytes"
               value: { bytes_list: { value: "prediction" } }
+            }
+            feature: {
+              key: "predict_ints"
+              value: { int64_list: { value: 2 value: 3 } }
             }
           }
     """, tf.train.Example())


### PR DESCRIPTION
This is needed to use the bulk-inferrer with a `tensorflow_recommenders.layers.factorized_top_k.TopK`. The TopK layer's `call()` returns a tuple of `(top candidate scores, top candidate identifiers)`. Since the candidate identifiers are integer, the bulk-inferrer must support integer output. Without this support the integer ids are cast to floats, which can cause errors due to loss of precision for large ids.

See https://www.tensorflow.org/recommenders/api_docs/python/tfrs/layers/factorized_top_k/TopK

Related PR: https://github.com/tensorflow/tfx/pull/5694