### PR TITLE
migrate to mlmd filter query

### DIFF
--- a/tfx/orchestration/experimental/core/async_pipeline_task_gen.py
+++ b/tfx/orchestration/experimental/core/async_pipeline_task_gen.py
@@ -194,7 +194,8 @@ class _Generator:
     # generates a task from it.
     # TODO(b/275231956) Too many executions may have performance issue, it is
     # better to limit the number of executions.
-    executions = task_gen_utils.get_executions(metadata_handler, node)
+    executions = task_gen_utils.get_executions(
+        metadata_handler, node.contexts.contexts)
     oldest_active_execution = task_gen_utils.get_oldest_active_execution(
         executions)
     if oldest_active_execution:

--- a/tfx/orchestration/experimental/core/pipeline_ops.py
+++ b/tfx/orchestration/experimental/core/pipeline_ops.py
@@ -511,7 +511,8 @@ def resume_manual_node(
           ),
       )
 
-  executions = task_gen_utils.get_executions(mlmd_handle, node)
+  executions = task_gen_utils.get_executions(
+      mlmd_handle, node.contexts.contexts)
   active_executions = [
       e for e in executions if execution_lib.is_execution_active(e)
   ]
@@ -1043,7 +1044,7 @@ def _cancel_node(
             'Canceling active executions for pure service node: %s', node_uid
         )
         active_executions = task_gen_utils.get_executions(
-            mlmd_handle, node, only_active=True
+            mlmd_handle, node.contexts.contexts, only_active=True
         )
         _cancel_executions(active_executions, mlmd_handle, node_uid)
       return True
@@ -1383,7 +1384,8 @@ def _orchestrate_active_pipeline(
         )
         node = _filter_by_node_id(node_infos, node_id).node
         active_executions = task_gen_utils.get_executions(
-            mlmd_connection_manager.primary_mlmd_handle, node, only_active=True
+            mlmd_connection_manager.primary_mlmd_handle,
+            node.contexts.contexts, only_active=True
         )
         _cancel_executions(
             active_executions,
@@ -1480,7 +1482,8 @@ def _maybe_enqueue_cancellation_task(
     `True` if a cancellation task was enqueued. `False` if node is already
     stopped or no cancellation was required.
   """
-  executions = task_gen_utils.get_executions(mlmd_handle, node)
+  executions = task_gen_utils.get_executions(
+      mlmd_handle, node.contexts.contexts)
   pipeline = pipeline_state.pipeline
   node_uid = task_lib.NodeUid.from_node(pipeline, node)
 

--- a/tfx/orchestration/experimental/core/pipeline_state.py
+++ b/tfx/orchestration/experimental/core/pipeline_state.py
@@ -1131,7 +1131,8 @@ def get_all_node_executions(
 ) -> Dict[str, List[metadata_store_pb2.Execution]]:
   """Returns all executions of all pipeline nodes if present."""
   return {
-      node.node_info.id: task_gen_utils.get_executions(mlmd_handle, node)
+      node.node_info.id: task_gen_utils.get_executions(
+          mlmd_handle, node.contexts.contexts)
       for node in get_all_nodes(pipeline)
   }
 

--- a/tfx/orchestration/experimental/core/sync_pipeline_task_gen.py
+++ b/tfx/orchestration/experimental/core/sync_pipeline_task_gen.py
@@ -265,7 +265,8 @@ class _Generator:
         task_lib.exec_node_task_id_from_node(self._pipeline, node)):
       return result
 
-    node_executions = task_gen_utils.get_executions(self._mlmd_handle, node)
+    node_executions = task_gen_utils.get_executions(
+        self._mlmd_handle, node.contexts.contexts)
     latest_executions_set = task_gen_utils.get_latest_executions_set(
         node_executions)
 

--- a/tfx/orchestration/experimental/core/task_gen_utils.py
+++ b/tfx/orchestration/experimental/core/task_gen_utils.py
@@ -244,29 +244,27 @@ def generate_resolved_info(
 
 def get_executions(
     metadata_handler: metadata.Metadata,
-    node: node_proto_view.NodeProtoView,
+    contexts: Iterable[metadata_store_pb2.Context],
     only_active: bool = False,
 ) -> List[metadata_store_pb2.Execution]:
-  """Returns all executions for the given pipeline node.
+  """Returns all executions for the given contexts.
 
-  This finds all executions having the same set of contexts as the pipeline
-  node.
+  This finds all executions for the given list of contexts.
 
   Args:
     metadata_handler: A handler to access MLMD db.
-    node: The pipeline node for which to obtain executions.
+    contexts: Contexts for which to obtain executions.
     only_active: If set to true, only active executions are returned. Otherwise,
       all executions are returned. Active executions mean executions with NEW or
       RUNNING last_known_state.
 
   Returns:
-    List of executions for the given node in MLMD db.
+    List of executions for the given contexts in MLMD db.
   """
-  if not node.contexts.contexts:
+  if not contexts:
     return []
-  # Get all the contexts associated with the node.
   filter_query = q.And([])
-  for i, context_spec in enumerate(node.contexts.contexts):
+  for i, context_spec in enumerate(contexts):
     context_type = context_spec.type.name
     context_name = data_types_utils.get_value(context_spec.name)
     filter_query.append(

--- a/tfx/orchestration/experimental/core/task_gen_utils_test.py
+++ b/tfx/orchestration/experimental/core/task_gen_utils_test.py
@@ -82,7 +82,8 @@ class TaskGenUtilsTest(parameterized.TestCase, tu.TfxTest):
   def test_get_executions(self):
     with self._mlmd_connection as m:
       for node in [n.pipeline_node for n in self._pipeline.nodes]:
-        self.assertEmpty(task_gen_utils.get_executions(m, node))
+        self.assertEmpty(
+            task_gen_utils.get_executions(m, node.contexts.contexts))
 
     # Create executions for the same nodes under different pipeline contexts.
     self._set_pipeline_context(self._pipeline, 'pipeline', 'my_pipeline1')
@@ -107,22 +108,29 @@ class TaskGenUtilsTest(parameterized.TestCase, tu.TfxTest):
     self._set_pipeline_context(self._pipeline, 'pipeline', 'my_pipeline1')
     with self._mlmd_connection as m:
       self.assertCountEqual(all_eg_execs[0:2],
-                            task_gen_utils.get_executions(m, self._example_gen))
+                            task_gen_utils.get_executions(
+                                m, self._example_gen.contexts.contexts))
       self.assertCountEqual(all_transform_execs[0:1],
-                            task_gen_utils.get_executions(m, self._transform))
-      self.assertEmpty(task_gen_utils.get_executions(m, self._trainer))
+                            task_gen_utils.get_executions(
+                                m, self._transform.contexts.contexts))
+      self.assertEmpty(task_gen_utils.get_executions(
+          m, self._trainer.contexts.contexts))
     self._set_pipeline_context(self._pipeline, 'pipeline', 'my_pipeline2')
     with self._mlmd_connection as m:
       self.assertCountEqual(all_eg_execs[2:],
-                            task_gen_utils.get_executions(m, self._example_gen))
+                            task_gen_utils.get_executions(
+                                m, self._example_gen.contexts.contexts))
       self.assertCountEqual(all_transform_execs[1:],
-                            task_gen_utils.get_executions(m, self._transform))
-      self.assertEmpty(task_gen_utils.get_executions(m, self._trainer))
+                            task_gen_utils.get_executions(
+                                m, self._transform.contexts.contexts))
+      self.assertEmpty(task_gen_utils.get_executions(
+          m, self._trainer.contexts.contexts))
 
   def test_get_executions_only_active(self):
     with self._mlmd_connection as m:
       for node in [n.pipeline_node for n in self._pipeline.nodes]:
-        self.assertEmpty(task_gen_utils.get_executions(m, node))
+        self.assertEmpty(task_gen_utils.get_executions(
+            m, node.contexts.contexts))
 
     # Create executions for the same nodes under different pipeline contexts.
     self._set_pipeline_context(self._pipeline, 'pipeline', 'my_pipeline1')
@@ -158,25 +166,32 @@ class TaskGenUtilsTest(parameterized.TestCase, tu.TfxTest):
     with self._mlmd_connection as m:
       self.assertCountEqual(
           active_eg_execs[0:2],
-          task_gen_utils.get_executions(m, self._example_gen, only_active=True))
+          task_gen_utils.get_executions(
+              m, self._example_gen.contexts.contexts, only_active=True))
       self.assertEmpty(
-          task_gen_utils.get_executions(m, self._transform, only_active=True))
+          task_gen_utils.get_executions(
+              m, self._transform.contexts.contexts, only_active=True))
       self.assertEmpty(
-          task_gen_utils.get_executions(m, self._trainer, only_active=True))
+          task_gen_utils.get_executions(
+              m, self._trainer.contexts.contexts, only_active=True))
     self._set_pipeline_context(self._pipeline, 'pipeline', 'my_pipeline2')
     with self._mlmd_connection as m:
       self.assertCountEqual(
           active_eg_execs[2:],
-          task_gen_utils.get_executions(m, self._example_gen, only_active=True))
+          task_gen_utils.get_executions(
+              m, self._example_gen.contexts.contexts, only_active=True))
       self.assertEmpty(
-          task_gen_utils.get_executions(m, self._transform, only_active=True))
+          task_gen_utils.get_executions(
+              m, self._transform.contexts.contexts, only_active=True))
       self.assertEmpty(
-          task_gen_utils.get_executions(m, self._trainer, only_active=True))
+          task_gen_utils.get_executions(
+              m, self._trainer.contexts.contexts, only_active=True))
 
   def test_generate_task_from_active_execution(self):
     with self._mlmd_connection as m:
       # No tasks generated without running execution.
-      executions = task_gen_utils.get_executions(m, self._trainer)
+      executions = task_gen_utils.get_executions(
+          m, self._trainer.contexts.contexts)
       self.assertIsNone(
           task_gen_utils.generate_cancel_task_from_running_execution(
               m, self._pipeline, self._trainer, executions,
@@ -192,7 +207,8 @@ class TaskGenUtilsTest(parameterized.TestCase, tu.TfxTest):
       m.store.put_executions([execution])
 
       # Check that task can be generated.
-      executions = task_gen_utils.get_executions(m, self._trainer)
+      executions = task_gen_utils.get_executions(
+          m, self._trainer.contexts.contexts)
       task = task_gen_utils.generate_cancel_task_from_running_execution(
           m, self._pipeline, self._trainer, executions,
           task_lib.NodeCancelType.CANCEL_EXEC)
@@ -203,7 +219,8 @@ class TaskGenUtilsTest(parameterized.TestCase, tu.TfxTest):
       execution = m.store.get_executions()[0]
       execution.last_known_state = metadata_store_pb2.Execution.COMPLETE
       m.store.put_executions([execution])
-      executions = task_gen_utils.get_executions(m, self._trainer)
+      executions = task_gen_utils.get_executions(
+          m, self._trainer.contexts.contexts)
       self.assertIsNone(
           task_gen_utils.generate_cancel_task_from_running_execution(
               m, self._pipeline, self._trainer, executions,

--- a/tfx/orchestration/portable/mlmd/execution_lib.py
+++ b/tfx/orchestration/portable/mlmd/execution_lib.py
@@ -23,6 +23,7 @@ from absl import logging
 from tfx import types
 from tfx.orchestration import data_types_utils
 from tfx.orchestration import metadata
+from tfx.orchestration.experimental.core import task_gen_utils
 from tfx.orchestration.portable import outputs_utils
 from tfx.orchestration.portable.mlmd import artifact_lib
 from tfx.orchestration.portable.mlmd import common_utils
@@ -511,13 +512,8 @@ def get_executions_associated_with_all_contexts(
   Returns:
     A list of executions associated with all given contexts.
   """
-  executions_dict = None
-  for context in contexts:
-    executions = metadata_handler.store.get_executions_by_context(context.id)
-    if executions_dict is None:
-      executions_dict = {e.id: e for e in executions}
-    else:
-      executions_dict = {e.id: e for e in executions if e.id in executions_dict}
+  executions = task_gen_utils.get_executions(metadata_handler, contexts)
+  executions_dict = {e.id: e for e in executions}
   return list(executions_dict.values()) if executions_dict else []
 
 


### PR DESCRIPTION
Migrate to MLMD filter query at two places in the source code.

1. https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/portable/input_resolution/channel_resolver.py#L118
2. https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/portable/mlmd/execution_lib.py#L501

Iteratively querying for each context is causing performance issues for old pipelines. Contexts like "pipeline" and "node" have too many records for old, long-running pipelines in the table.

I found [this](https://github.com/tensorflow/tfx/blob/master/tfx/orchestration/experimental/core/task_gen_utils.py#L245) utility to get executions using filter queries, but this method takes "node" as an argument. Rewrote the method and its invocations to use "contexts" instead.
