### PR TITLE
Fix "Data preprocessing for ML with Google Cloud" Link

### DIFF
--- a/docs/tutorials/_toc.yaml
+++ b/docs/tutorials/_toc.yaml
@@ -50,7 +50,7 @@ toc:
 - title: "Preprocess data (advanced)"
   path: /tfx/tutorials/transform/census
 - title: "Data preprocessing for ML with Google Cloud"
-  path: /tfx/tutorials/transform/data-preprocessing-for-ml-with-tf-transform-pt2
+  path: /tfx/tutorials/transform/data_preprocessing_with_cloud
 
 - heading: "Model Analysis"
 - title: "Get started with TFMA"


### PR DESCRIPTION
Fixing "Data preprocessing for ML with Google Cloud" broken Link by pointing file path location from "/tfx/tutorials/transform/data-preprocessing-for-ml-with-tf-transform-pt2" to "/tfx/tutorials/transform/data_preprocessing_with_cloud"