### PR TITLE
Fixed the broken links in tfma.md

### DIFF
--- a/docs/guide/tfma.md
+++ b/docs/guide/tfma.md
@@ -15,25 +15,25 @@ evaluation in TFX. TensorFlow Model Analysis allows you to perform model
 evaluations in the TFX pipeline, and view resultant metrics and plots in a
 Jupyter notebook. Specifically, it can provide:
 
-*   [Metrics](../model_analysis/metrics) computed on entire training and holdout
+*   [Metrics](https://www.tensorflow.org/tfx/model_analysis/metrics) computed on entire training and holdout
     dataset, as well as next-day evaluations
 *   Tracking metrics over time
 *   Model quality performance on different feature slices
-*   [Model validation](../model_analysis/model_validations) for ensuring that
+*   [Model validation](https://www.tensorflow.org/tfx/model_analysis/model_validations) for ensuring that
     model's maintain consistent performance
 
 ## Next Steps
 
-Try our [TFMA tutorial](../tutorials/model_analysis/tfma_basic).
+Try our [TFMA tutorial](https://www.tensorflow.org/tfx/tutorials/model_analysis/tfma_basic).
 
 Check out our [github](https://github.com/tensorflow/model-analysis) page for
 details on the supported
-[metrics and plots](../model_analysis/metrics) and associated notebook
-[visualizations](../model_analysis/visualizations).
+[metrics and plots](https://www.tensorflow.org/tfx/model_analysis/metrics) and associated notebook
+[visualizations](https://www.tensorflow.org/tfx/model_analysis/visualizations).
 
-See the [installation](../model_analysis/install) and
-[getting started](../model_analysis/get_started) guides for information and
-examples on how to get [set up](../model_analysis/setup) in a standalone
+See the [installation](https://www.tensorflow.org/tfx/model_analysis/install) and
+[getting started](https://www.tensorflow.org/tfx/model_analysis/get_started) guides for information and
+examples on how to get [set up](https://www.tensorflow.org/tfx/model_analysis/setup) in a standalone
 pipeline. Recall that TFMA is also used within the [Evaluator](evaluator.md)
 component in TFX, so these resources will be useful for getting started in TFX
 as well.


### PR DESCRIPTION
Fixed the broken links for the following:
1.Metrics in line 18
2.Model validation in line 22
3.TFMA tutorial in line 27
4.metrics and plot in line 31
5.visualization in line 32
6.installation in line 34
7.getting started in line 35
8.setup in line 36