### PR TITLE
Migrate CSAT survey to Github action from probot.

### DIFF
--- a/.github/workflows/CSAT.yml
+++ b/.github/workflows/CSAT.yml
@@ -1,0 +1,21 @@
+name: 'CSAT survey'
+on:
+  issues:
+    types:
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./\.github/workflows/scripts/CSAT.js')
+            script({github, context})

--- a/.github/workflows/scripts/CSAT.js
+++ b/.github/workflows/scripts/CSAT.js
@@ -1,0 +1,46 @@
+const CONSTENT_VALUES = require('./constant');
+/*
+Invoked from staleCSAT.js and CSAT.yaml file to 
+post survey link in closed issue.
+*/
+module.exports = async ({ github, context }) => {
+    const issue = context.payload.issue.html_url;
+    let base_url = '';
+     //Loop over all ths label present in issue and check if specific label is present for survey link.
+    for (const label of context.payload.issue.labels) {
+            if (label.name.includes(CONSTENT_VALUES.GLOBALS.LABELS.BUG) ||
+                label.name.includes(CONSTENT_VALUES.GLOBALS.LABELS.BUG_INSTALL) ||
+                label.name.includes(CONSTENT_VALUES.GLOBALS.LABELS.TYPE_PERFORMANCE) ||
+                label.name.includes(CONSTENT_VALUES.GLOBALS.LABELS.TYPE_OTHER) ||
+                label.name.includes(CONSTENT_VALUES.GLOBALS.LABELS.TYPE_SUPPORT) ||
+                label.name.includes(CONSTENT_VALUES.GLOBALS.LABELS.TYPE_DOCS_BUG)) {
+                console.log(`label-${label.name}, posting CSAT survey for issue =${issue}`);       
+                if (context.repo.repo.includes('mediapipe'))
+                    base_url = CONSTENT_VALUES.MODULE.CSAT.MEDIA_PIPE_BASE_URL;
+                else
+                    base_url = CONSTENT_VALUES.MODULE.CSAT.BASE_URL;
+                const yesCsat =
+                    (CONSTENT_VALUES.MODULE.CSAT.YES)
+                        .link(
+                            base_url + CONSTENT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+                            CONSTENT_VALUES.MODULE.CSAT.YES + CONSTENT_VALUES.MODULE.CSAT.ISSUEID_PRAM + issue)
+                const noCsat =
+                    (CONSTENT_VALUES.MODULE.CSAT.NO)
+                        .link(
+                            base_url + CONSTENT_VALUES.MODULE.CSAT.SATISFACTION_PARAM +
+                            CONSTENT_VALUES.MODULE.CSAT.NO + CONSTENT_VALUES.MODULE.CSAT.ISSUEID_PRAM + issue)
+                const comment = CONSTENT_VALUES.MODULE.CSAT.MSG + '\n' + yesCsat + '\n' + noCsat + '\n';
+                let isnumber = context.issue.number ??  context.payload.issue.number;
+
+                await github.rest.issues.createComment({
+                    issue_number: isnumber,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: comment
+                });
+                return 
+            }
+        }
+    }
+
+

--- a/.github/workflows/scripts/constant.js
+++ b/.github/workflows/scripts/constant.js
@@ -1,0 +1,33 @@
+let CONSTENT_VALUES = {
+    GLOBALS: {
+        LABELS: {
+            STALE: "stale",
+            AWAITINGRES: "stat:awaiting response",
+            BUG: 'type:bug',
+            BUG_INSTALL: 'type:build/install',
+            TYPE_SUPPORT: 'type:support',
+            TYPE_OTHER: 'type:others',
+            TYPE_DOCS_BUG: 'type:docs-bug',
+            TYPE_PERFORMANCE: 'type:performance'
+        },
+        STATE: {
+            CLOSED: "closed"
+        },
+        TENSORFLOW_CORE_REPO: 'https://github.com/tensorflow/tensorflow/pull',
+        PR_TRIGGER_REPO: 'testRep,keras'
+    },
+    MODULE: {
+        CSAT: {
+            YES:'Yes',
+            NO:'No',
+            BASE_URL: 'https://docs.google.com/forms/d/e/1FAIpQLSfaP12TRhd9xSxjXZjcZFNXPG' +
+        'k4kc1-qMdv3gc6bEP90vY1ew/viewform?',
+            MEDIA_PIPE_BASE_URL: 'https://docs.google.com/forms/d/e/1FAIpQLScOLT8zeBHummIZFnfr9wqvxYzWD1DAypyvNia5WVIWtFANYg/viewform?',
+            SATISFACTION_PARAM: 'entry.85265664=',
+            ISSUEID_PRAM: '&entry.2137816233=',
+            MSG: 'Are you satisfied with the resolution of your issue?',
+        }
+    }
+
+}
+module.exports = CONSTENT_VALUES

--- a/.github/workflows/scripts/staleCSAT.js
+++ b/.github/workflows/scripts/staleCSAT.js
@@ -1,0 +1,49 @@
+
+const csat = require('./CSAT.js');
+const constant = require("./constant.js");
+/*
+When stale bot closes the issue this function will 
+invoke and post CSAT link on the issue.
+This function will fetch all the issues closed within 20 minutes and
+post the survey link if survey link is not posted already.
+*/
+
+module.exports = async ({ github, context }) => {
+
+  let date = new Date();
+  let totalMilliSeconds = date.getTime();
+  let minutes = 20;
+  let millisecondsToSubtract = minutes * 60 * 1000;
+  let closeTime = totalMilliSeconds-millisecondsToSubtract;
+  let newDate = new Date(closeTime);
+  let ISOCloseTime = newDate.toISOString();
+  let closeTimeIssues  = await github.rest.issues.listForRepo({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    state:"closed", 
+    labels:"stale",
+    since:ISOCloseTime
+  });
+ let ISSUESLIST = closeTimeIssues.data;
+ for(let i=0;i<ISSUESLIST.length;i++){ 
+  if(ISSUESLIST[i].node_id && ISSUESLIST[i].node_id.indexOf("PR") !=-1)
+     continue;
+
+  let comments = await github.rest.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: ISSUESLIST[i].number
+  });
+  let noOfComments = comments.data.length;
+  let lastComment = comments.data[noOfComments-1];
+  let strCom = JSON.stringify(lastComment);
+  if(strCom.indexOf(constant.MODULE.CSAT.MSG) == -1){
+       context.payload.issue = {};
+       context.payload.issue.number = ISSUESLIST[i].number;
+       context.payload.issue.labels = ISSUESLIST[i].labels;
+       context.payload.issue.html_url = ISSUESLIST[i].html_url;
+
+       csat({github, context});
+  }
+ }
+}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -63,3 +63,9 @@ jobs:
 
         #stale label for issues
         stale-issue-label: 'stale'
+    - uses: actions/checkout@v3
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          const script = require('./\.github/workflows/scripts/staleCSAT.js')
+          script({github, context})


### PR DESCRIPTION
Changes in this PR:

Add file constant.js for script level constant values.
Add file CSAT.yml to invoke the workflow and call the script when closed event occur.
Add file staleCSAT.js when stale workflow closes issue then invoke the script.
Update file stale.yml to invoke staleCSAT.js script for survey link.
Thanks.