### PR TITLE
Refactor Utils to support added type casting capabilities

### DIFF
--- a/tfx/components/example_gen/utils.py
+++ b/tfx/components/example_gen/utils.py
@@ -128,7 +128,8 @@ def dict_to_example(instance: Dict[str, Any]) -> example_pb2.Example:
       feature[key] = pyval_to_feature(pyval, key)
 
     else:
-      raise RuntimeError(f'Key {key} with Column type {type(value)} is not supported.')
+      raise RuntimeError("""Key {} with Column type {} 
+                         is not supported.""".format(key, type(value)))
     
   return example_pb2.Example(features=feature_pb2.Features(feature=feature))
 

--- a/tfx/components/example_gen/utils.py
+++ b/tfx/components/example_gen/utils.py
@@ -84,26 +84,7 @@ _DEFAULT_ENCODING = 'utf-8'
 _SINGLE_VALUE_TYPES = (int, str, float)
 
 
-def value_to_feature(pyval, key) -> feature_pb2.Feature:
-  if pyval is None:
-    return feature_pb2.Feature()
-  elif isinstance(pyval, int):
-    return feature_pb2.Feature(
-        int64_list=feature_pb2.Int64List(value=[pyval]))
-  elif isinstance(pyval, float):
-    return feature_pb2.Feature(
-        float_list=feature_pb2.FloatList(value=[pyval]))
-  elif isinstance(pyval, str):
-    return feature_pb2.Feature(
-        bytes_list=feature_pb2.BytesList(
-            value=[pyval.encode(_DEFAULT_ENCODING)]))
-  else:
-    raise RuntimeError(f"""Column type `value of {type(pyval)}` 
-                        is not supported.
-                        \nProblematic key is {key}""")
-  
-
-def list_to_feature(pyval, key) -> feature_pb2.Feature:
+def pyval_to_feature(pyval:list, key:str) -> feature_pb2.Feature:
   if not pyval: 
     return feature_pb2.Feature()
   elif isinstance(pyval[0], int):
@@ -117,9 +98,9 @@ def list_to_feature(pyval, key) -> feature_pb2.Feature:
         bytes_list=feature_pb2.BytesList(
             value=[v.encode(_DEFAULT_ENCODING) for v in pyval]))
   else:
-    raise RuntimeError(f"""Column type `list of {type(pyval[0])}` 
-                        is not supported.
-                        \nProblematic key is {key}""")
+    raise RuntimeError("""Column type `{}` is not supported.
+                        \nProblematic key is {}
+                        """.format(type(pyval[0]), key))
 
 
 def dict_to_example(instance: Dict[str, Any]) -> example_pb2.Example:
@@ -141,10 +122,10 @@ def dict_to_example(instance: Dict[str, Any]) -> example_pb2.Example:
       pyval = pyval.decode(_DEFAULT_ENCODING)
 
     if isinstance(pyval, _SINGLE_VALUE_TYPES):
-      feature[key] = value_to_feature(pyval)
+      feature[key] = pyval_to_feature([pyval], key)
     
     elif isinstance(pyval, list):
-      feature[key] = list_to_feature(pyval)
+      feature[key] = pyval_to_feature(pyval, key)
 
     else:
       raise RuntimeError(f'Key {key} with Column type {type(value)} is not supported.')

--- a/tfx/components/example_gen/utils.py
+++ b/tfx/components/example_gen/utils.py
@@ -144,7 +144,7 @@ def dict_to_example(instance: Dict[str, Any]) -> example_pb2.Example:
       feature[key] = value_to_feature(pyval)
     
     elif isinstance(pyval, list):
-      feature[key] = list_to_feature
+      feature[key] = list_to_feature(pyval)
 
     else:
       raise RuntimeError(f'Key {key} with Column type {type(value)} is not supported.')

--- a/tfx/components/example_gen/utils.py
+++ b/tfx/components/example_gen/utils.py
@@ -98,7 +98,7 @@ def pyval_to_feature(pyval:list, key:str) -> feature_pb2.Feature:
         bytes_list=feature_pb2.BytesList(
             value=[v.encode(_DEFAULT_ENCODING) for v in pyval]))
   else:
-    raise RuntimeError("""Column type `{}` is not supported.
+    raise RuntimeError("""Value type `{}` is not supported.
                         \nProblematic key is {}
                         """.format(type(pyval[0]), key))
 


### PR DESCRIPTION
To facilitate @1025KB / `jyzhao`'s `TODO`, separate functionality to support extended capabilities.

Also enables more helpful error message to be clear on which key(s) are causing problems. 
F-strings work in both supported Python versions on PyPi (3.8, 3.9)

Recommended expanded types handling: 
Decimal - to int and float lists (BigQuery sometimes encodes numbers as Decimal)
Dictionaries - get to lists or list-of-lists
Datetimes - to UNIX / epoch time probably

Further discussion but possible and plausible types:
List-of-Lists - for Sequence Examples*

*This utils function could/would/should produce `SequenceExamples`. In my estimation per [PR 5689](https://github.com/tensorflow/tfx/pull/5689), I posit all TFX `ExampleGens` should produce `SequenceExamples` as this is forward-looking (in terms of supporting NLP applications etc) and because a `SequenceExample` with empty `sequence_features` seems not only permissible but also is not world breaking with `SchemaGen`, unlike the situation currently. 

Passing a `SequenceExample` to `SchemaGen` without PR 5689 means there has to be some other piece of code used to make `TF Transform` work -- what average user should be burdened with figuring that out?
