### PR TITLE
Upgrade bazel version to 5.3.0 for github CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -35,10 +35,10 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Set up Bazel 3.4.1
+    - name: Set up Bazel 5.3.0
       run: |
         # Instruction from https://docs.bazel.build/versions/master/install-ubuntu.html
-        curl -sSL https://github.com/bazelbuild/bazel/releases/download/3.4.1/bazel-3.4.1-installer-linux-x86_64.sh -o bazel_installer.sh
+        curl -sSL https://github.com/bazelbuild/bazel/releases/download/5.3.0/bazel-5.3.0-installer-linux-x86_64.sh -o bazel_installer.sh
         chmod +x bazel_installer.sh
         sudo ./bazel_installer.sh
 
@@ -47,7 +47,7 @@ jobs:
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding setup.py + TFX version 
+        # Look to see if there is a cache hit for the corresponding setup.py + TFX version
         key: ${{ runner.os }}-pip-${{ hashFiles('tfx/dependencies.py') }}-
         restore-keys: |
           ${{ runner.os }}-pip-


### PR DESCRIPTION
Currentlt, github CI is breaking because of the bazel version misalignment between the Github CI script (3.4.1) and TFX workspace (5.3.0). This PR aims to align CI with the TFX workspace.