### PR TITLE
Default to Sequence Examples

### DIFF
--- a/tfx/components/example_gen/component.py
+++ b/tfx/components/example_gen/component.py
@@ -159,7 +159,7 @@ class FileBasedExampleGen(base_beam_component.BaseBeamComponent):
                                     data_types.RuntimeParameter]] = None,
       range_config: Optional[Union[range_config_pb2.RangeConfig,
                                    data_types.RuntimeParameter]] = None,
-      output_data_format: Optional[int] = example_gen_pb2.FORMAT_TF_EXAMPLE,
+      output_data_format: Optional[int] = example_gen_pb2.FORMAT_TF_SEQUENCE_EXAMPLE,
       output_file_format: Optional[int] = example_gen_pb2.FORMAT_TFRECORDS_GZIP,
       custom_executor_spec: Optional[executor_spec.ExecutorSpec] = None):
     """Construct a FileBasedExampleGen component.

--- a/tfx/components/example_gen/custom_executors/avro_executor.py
+++ b/tfx/components/example_gen/custom_executors/avro_executor.py
@@ -27,7 +27,7 @@ from tfx.types import standard_component_specs
 
 @beam.ptransform_fn
 @beam.typehints.with_input_types(beam.Pipeline)
-@beam.typehints.with_output_types(tf.train.Example)
+@beam.typehints.with_output_types(tf.train.SequenceExample)
 def _AvroToExample(  # pylint: disable=invalid-name
     pipeline: beam.Pipeline, exec_properties: Dict[str, Any],
     split_pattern: str) -> beam.pvalue.PCollection:

--- a/tfx/components/example_gen/custom_executors/parquet_executor.py
+++ b/tfx/components/example_gen/custom_executors/parquet_executor.py
@@ -26,7 +26,7 @@ from tfx.types import standard_component_specs
 
 @beam.ptransform_fn
 @beam.typehints.with_input_types(beam.Pipeline)
-@beam.typehints.with_output_types(tf.train.Example)
+@beam.typehints.with_output_types(tf.train.SequenceExample)
 def _ParquetToExample(  # pylint: disable=invalid-name
     pipeline: beam.Pipeline, exec_properties: Dict[str, Any],
     split_pattern: str) -> beam.pvalue.PCollection:

--- a/tfx/components/example_gen/import_example_gen/component.py
+++ b/tfx/components/example_gen/import_example_gen/component.py
@@ -48,7 +48,7 @@ class ImportExampleGen(component.FileBasedExampleGen):  # pylint: disable=protec
                                     data_types.RuntimeParameter]] = None,
       range_config: Optional[Union[range_config_pb2.RangeConfig,
                                    data_types.RuntimeParameter]] = None,
-      payload_format: Optional[int] = example_gen_pb2.FORMAT_TF_EXAMPLE):
+      payload_format: Optional[int] = example_gen_pb2.FORMAT_TF_SEQUENCE_EXAMPLE):
     """Construct an ImportExampleGen component.
 
     Args:

--- a/tfx/components/schema_gen/executor.py
+++ b/tfx/components/schema_gen/executor.py
@@ -26,6 +26,11 @@ from tfx.types import standard_component_specs
 from tfx.utils import io_utils
 from tfx.utils import json_utils
 
+from tfx_bsl.tfxio.tensor_representaiton_util import (
+  InferTensorRepresentationsFromSchema, 
+  SetTensorRepresentationsInSchema
+)
+
 
 # Default file name for generated schema file.
 DEFAULT_FILE_NAME = 'schema.pbtxt'
@@ -89,5 +94,10 @@ class Executor(base_executor.BaseExecutor):
         artifact_utils.get_single_uri(
             output_dict[standard_component_specs.SCHEMA_KEY]),
         DEFAULT_FILE_NAME)
+    
+    # Add tensor representations to handle SequenceExamples downstream.
+    tensor_representations = InferTensorRepresentationsFromSchema(schema)
+    SetTensorRepresentationsInSchema(schema, tensor_representations)
+
     io_utils.write_pbtxt_file(output_uri, schema)
     logging.info('Schema written to %s.', output_uri)


### PR DESCRIPTION
This is a draft / suggestion based on [5689](https://github.com/tensorflow/tfx/pull/5689)

Everything now goes to Sequence Examples. There is an isinstance filter to navigate the types. 

This supports long-term development by natively implementing sequence type features, which TFX would need to lean on in order to support LLM training and so on. 

@lego0901 