### PR TITLE
Update pusher executor to use constants for custom property keys

### DIFF
--- a/tfx/components/pusher/executor.py
+++ b/tfx/components/pusher/executor.py
@@ -223,11 +223,11 @@ class Executor(base_executor.BaseExecutor):
                   model_push: types.Artifact,
                   pushed_destination: str,
                   pushed_version: Optional[str] = None) -> None:
-    model_push.set_int_custom_property('pushed', 1)
+    model_push.set_int_custom_property(_PUSHED_KEY, 1)
     model_push.set_string_custom_property(
         _PUSHED_DESTINATION_KEY, pushed_destination)
     if pushed_version is not None:
       model_push.set_string_custom_property(_PUSHED_VERSION_KEY, pushed_version)
 
   def _MarkNotPushed(self, model_push: types.Artifact):
-    model_push.set_int_custom_property('pushed', 0)
+    model_push.set_int_custom_property(_PUSHED_KEY, 0)


### PR DESCRIPTION
Found that `_PUSHED_KEY` is defined, it looks like it is for this, but not used anywhere.
So updating the executor to use that constant for property keys.