### PR TITLE
Remove 'awaiting' labels when user issue/PR updated.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -43,9 +43,10 @@ jobs:
         exempt-pr-labels: "override-stale" 
         #Limit the No. of API calls in one run default value is 30. 
         operations-per-run: 1000 
-        #Prevent to remove stale label when PRs or issues are updated. 
-        remove-stale-when-updated: false
-       
+        # Prevent to remove stale label when PRs or issues are updated.
+        remove-stale-when-updated: true
+        # List of labels to remove when issues/PRs unstale. 
+        labels-to-remove-when-unstale: 'stat:awaiting response'
         stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
         days-before-stale: 30
         days-before-close: 5


### PR DESCRIPTION
Remove the label "stat:awaiting response", when issue/PR unstale.