### PR TITLE
Loosen constraints for google-api-core and google-cloud-aiplatform in TFX 1.13

### DIFF
--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -80,13 +80,8 @@ def make_required_install_packages():
       'apache-beam[gcp]>=2.40,<3',
       'attrs>=19.3.0,<22',
       'click>=7,<9',
-      # TODO(b/245393802): Remove pinned version when pip can find depenencies
-      # without this. `google-api-core` is needed for many google cloud
-      # packages. `google-api-core==1.33.0` and
-      # `google-cloud-aiplatform==1.18.0` requires
-      # `protobuf>=3.20.1` while `tensorflow` requires `protobuf<3.20`.
-      'google-api-core<1.33',
-      'google-cloud-aiplatform>=1.6.2,<1.18',
+      'google-api-core<3',
+      'google-cloud-aiplatform>=1.6.2,<2',
       'google-cloud-bigquery>=2.26.0,<3',
       'grpcio>=1.28.1,<2',
       'keras-tuner>=1.0.4,<2',


### PR DESCRIPTION
[TFX 1.13 has constraints to google-api-core and google-cloud-aiplatform because of the protobuf versions](https://github.com/tensorflow/tfx/blob/r1.13.0/tfx/dependencies.py#L83-L90), but [TF 2.12 can accept protobuf>=3.20.3](https://github.com/tensorflow/tensorflow/blob/r2.12/tensorflow/tools/pip_package/setup.py#L100-L107), so we can loosen those constraints in TFX 1.13 to allow for newer versions of these packages, which may use newer versions of protobuf.

So this change will allow TFX 1.13 to work with a wider range of versions of google-api-core and google-cloud-aiplatform. [I followed the version constraints in r1.14.0 branch](https://github.com/tensorflow/tfx/blob/44e493a2879e480f368a5e48641c49edbbe55f18/tfx/dependencies.py#L83-L85).

Fix #6375 