### PR TITLE
Replace ExecutorClassSpec with BeamExecutorSpec

### DIFF
--- a/tfx/components/example_gen/custom_executors/parquet_executor.py
+++ b/tfx/components/example_gen/custom_executors/parquet_executor.py
@@ -74,7 +74,7 @@ class Executor(BaseExampleGenExecutor):
 
   Example usage:
 
-    from tfx.components.base import executor_spec
+    frin tfx.dsl.components.base.executor_spec import BeamExecutorSpec
     from tfx.components.example_gen.component import
     FileBasedExampleGen
     from tfx.components.example_gen.custom_executors import
@@ -82,7 +82,7 @@ class Executor(BaseExampleGenExecutor):
 
     example_gen = FileBasedExampleGen(
         input_base=parquet_dir_path,
-        custom_executor_spec=executor_spec.ExecutorClassSpec(
+        custom_executor_spec=BeamExecutorSpec(
             parquet_executor.Executor))
   """
 


### PR DESCRIPTION
ExecutorClassSpec is no longer supported.