### PR TITLE
replace deprecated ExecutorClassSpec with BeamExecutorSpec

### DIFF
--- a/tfx/components/example_gen/custom_executors/avro_executor.py
+++ b/tfx/components/example_gen/custom_executors/avro_executor.py
@@ -72,7 +72,8 @@ class Executor(BaseExampleGenExecutor):
 
   Example usage:
 
-    from tfx.components.base import executor_spec
+    from tfx.dsl.components.base.executor_spec import
+    BeamExecutorSpec
     from tfx.components.example_gen.component import
     FileBasedExampleGen
     from tfx.components.example_gen.custom_executors import
@@ -80,7 +81,7 @@ class Executor(BaseExampleGenExecutor):
 
     example_gen = FileBasedExampleGen(
         input_base=avro_dir_path,
-        custom_executor_spec=executor_spec.ExecutorClassSpec(
+        custom_executor_spec=BeamExecutorSpec(
             avro_executor.Executor))
   """
 


### PR DESCRIPTION
ExecutorClassSpec is deprecated and should be replaced with BeamExecutorSpec.