### PR TITLE
Add a workflow to build wheels and (only on release) publish to PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,100 @@
+name: Build Wheels & Publish to PyPI
+
+on:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: install python dependencies
+      run: pip install build
+
+    - name: build sdist
+      run: |
+        python -m build --sdist -o wheelhouse
+
+    - name: List and check sdist
+      run: |
+        ls -lh wheelhouse/
+        twine check wheelhouse/*
+
+    - name: Upload sdist
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels
+        path: ./wheelhouse/*.tar.gz
+
+  build_wheels:
+    name: >
+      build ${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
+      ${{ (matrix.arch) || '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        python-version: ['cp39', 'cp310']
+
+    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Build ${{ matrix.platform || matrix.os }} binaries
+      uses: pypa/cibuildwheel@v2.20.0
+      env:
+        CIBW_BUILD: '${{ matrix.python-version }}-*'
+        # Linux wheels are built in manylinux containers
+        CIBW_BUILD_VERBOSITY: 1
+
+    - name: List and check wheels
+      run: |
+        pip install twine pkginfo>=1.10.0
+        ${{ matrix.ls || 'ls -lh' }} wheelhouse/
+        twine check wheelhouse/*
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels
+        path: ./wheelhouse/*.whl
+
+  upload_to_pypi:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
+    needs: [build_wheels, build_sdist]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tfx
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve wheels and sdist
+        uses: actions/download-artifact@v4
+
+      - name: List the build artifacts
+        run: |
+          ls -lAs wheels/
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.9
+        with:
+          packages_dir: wheels/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,12 +57,26 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Build ${{ matrix.platform || matrix.os }} binaries
-      uses: pypa/cibuildwheel@v2.20.0
-      env:
-        CIBW_BUILD: '${{ matrix.python-version }}-*'
-        # Linux wheels are built in manylinux containers
-        CIBW_BUILD_VERBOSITY: 1
+    - name: Install python build dependencies
+      run: |
+          pip install wheel
+
+    - uses: bazel-contrib/setup-bazel@0.8.5
+      name: Set up Bazel
+      with:
+        # Avoid downloading Bazel every time.
+        bazelisk-cache: true
+        # Store build cache per workflow.
+        disk-cache: ${{ github.workflow }}
+        # Share repository cache between workflows.
+        repository-cache: true
+
+    - name: Build wheels
+      run: |
+        package_build/initialize.sh &&
+        python package_build/tfx/setup.py bdist_wheel &&
+        python package_build/ml-pipelines-sdk/setup.py bdist_wheel
+        mv dist/*.whl wheelhouse/
 
     - name: List and check wheels
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: '3.10'
 
     - name: install python dependencies
-      run: pip install build
+      run: pip install build twine
 
     - name: build sdist
       run: |
@@ -48,8 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: ['cp310']
-        # python-version: ['cp39', 'cp310']
+        python-version: ['cp39', 'cp310']
 
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
@@ -86,6 +85,7 @@ jobs:
         package_build/initialize.sh
         python package_build/tfx/setup.py bdist_wheel
         python package_build/ml-pipelines-sdk/setup.py bdist_wheel
+        mkdir wheelhouse
         mv dist/*.whl wheelhouse/
 
     - name: List and check wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [published]
 
+env:
+  USE_BAZEL_VERSION: "7.2.1"
+
 jobs:
   build_sdist:
     name: Build sdist
@@ -45,7 +48,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: ['cp39', 'cp310']
+        python-version: ['cp310']
+        # python-version: ['cp39', 'cp310']
 
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
@@ -67,14 +71,20 @@ jobs:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
         # Store build cache per workflow.
-        disk-cache: ${{ github.workflow }}
+        disk-cache: ${{ github.workflow }}-${{ hashFiles('.github/workflows/wheels.yml') }}
         # Share repository cache between workflows.
         repository-cache: true
 
+    - name: Verify bazel installation
+      run: |
+        which bazel
+        bazel info
+        bazel version
+
     - name: Build wheels
       run: |
-        package_build/initialize.sh &&
-        python package_build/tfx/setup.py bdist_wheel &&
+        package_build/initialize.sh
+        python package_build/tfx/setup.py bdist_wheel
         python package_build/ml-pipelines-sdk/setup.py bdist_wheel
         mv dist/*.whl wheelhouse/
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: sdist
         path: ./wheelhouse/*.tar.gz
 
   build_wheels:
@@ -97,7 +97,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
         path: ./wheelhouse/*.whl
 
   upload_to_pypi:
@@ -113,6 +113,8 @@ jobs:
     steps:
       - name: Retrieve wheels and sdist
         uses: actions/download-artifact@v4
+        merge-multiple: true
+        path: wheels/
 
       - name: List the build artifacts
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ bazel-*
 **/*_pb2.py
 **/*_pb2_grpc.py
 # LINT.ThenChange(.dockerignore)
+
+MODULE.bazel
+MODULE.bazel.lock


### PR DESCRIPTION
This PR adds a workflow which automatically builds an sdist and a wheel when a pull request is made. If a release is made, the wheels are built and then automatically published to PyPI. Unfortunately I cannot use `cibuildwheel` to target many different architectures at this time because the build system is quite unusual, and will need some additional work to make it compatible with current best practices.

@pradeepkuppla We'll need to enable trusted publishing on the [`tfx` project page](https://pypi.org/project/tfx/) to get this to work. [Instructions are here](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing), or I can guide you through this - it's straightforward to do, and should take only a few minutes.

In testing the build locally, I've also added a few build artifacts to `.gitignore`. [I tested this workflow to the extent that I could](https://github.com/peytondmurray/tfx/actions/runs/10275586921/job/28434484804?pr=1), but I will need to get trusted publishing set up on PyPI for this project to be sure about it.