### PR TITLE
Add pre-commit lint action

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,33 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+     branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.7
+      with:
+        # Ensure the full history is fetched
+        # This is required to run pre-commit on a specific set of commits
+        # TODO: Remove this when all the pre-commit issues are fixed
+        fetch-depth: 0
+    - uses: actions/setup-python@v5.1.1
+      with:
+        python-version: 3.9
+    - name: Determine commit range
+      id: commit_range
+      run: |
+       echo "TO_REF=${{ github.sha }}" >> $GITHUB_ENV
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "FROM_REF=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+        else
+          echo "FROM_REF=${{ github.event.before }}" >> $GITHUB_ENV
+        fi
+    - uses: pre-commit/action@v3.0.1
+      with:
+        # TODO: Remove this when all the pre-commit issues are fixed
+        extra_args: --from-ref ${{ env.FROM_REF }} --to-ref ${{ env.TO_REF }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,38 @@
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+# Common tasks
+#
+# - Register git hooks: pre-commit install --install-hooks
+# - Run on all files:   pre-commit run --all-files
+#
+# These pre-commit hooks are run as CI.
+#
+# NOTE: if it can be avoided, add configs/args in pyproject.toml or below instead of creating a new `.config.file`.
+# https://pre-commit.ci/#configuration
+ci:
+  autoupdate_schedule: monthly
+  autofix_commit_msg: |
+    [pre-commit.ci] Apply automatic pre-commit fixes
+
+repos:
+  # general
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+        exclude: '\.svg$'
+      - id: trailing-whitespace
+        exclude: '\.svg$'
+      - id: check-json
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-toml
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.6
+    hooks:
+      - id: ruff
+        args: ["--fix"]


### PR DESCRIPTION
This PR adds a pre-commit lint action. Since there are lots of linting issues when running `ruff`, this actions only runs linting on the changed files in the PR, until we fix all the linting issues.

In future we can also directly use: https://pre-commit.ci/ which would also auto-commit linting issues. I didn't went with it right away as I couldn't find a way to do a selective run on the changed files with that.

The proposal is to get this in and start linting pull requests and slowly fix linting errors and then start running pre-commit on full code based instead of PR diff.