### PR TITLE
Fix missing `with` in download-artifact action

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -113,8 +113,9 @@ jobs:
     steps:
       - name: Retrieve wheels and sdist
         uses: actions/download-artifact@v4
-        merge-multiple: true
-        path: wheels/
+        with:
+          merge-multiple: true
+          path: wheels/
 
       - name: List the build artifacts
         run: |


### PR DESCRIPTION
This PR fixes a missing `with` indented block in the wheels workflow.