### PR TITLE
[WIP] Disable editable mode install for testing on CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pip wheel
         # TODO(b/232490018): Cython need to be installed separately to build pycocotools.
         python -m pip install Cython -c ./test_constraints.txt
-        pip install -c ./test_constraints.txt --extra-index-url https://pypi-nightly.tensorflow.org/simple --pre --editable .[all]
+        pip install -c ./test_constraints.txt --extra-index-url https://pypi-nightly.tensorflow.org/simple --pre .[all]
       env:
         TFX_DEPENDENCY_SELECTOR: ${{ matrix.dependency-selector }}
 


### PR DESCRIPTION
We no longer need `editable` mode to install `tfx` since #6907 was merged. Let's remove it.