### PR TITLE
Move docs dependencies to common location and check for broken docs on pull request

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -26,6 +26,7 @@ jobs:
           cache-dependency-path: |
             setup.py
             tfx/dependencies.py
+            requirements-docs.txt
 
       - name: Save time for cache for mkdocs
         run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -2,8 +2,7 @@ name: deploy-docs
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
+  pull_request:
 permissions:
   contents: write
 jobs:
@@ -17,6 +16,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+        if: (github.event_name != 'pull_request')
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v5
@@ -43,3 +43,8 @@ jobs:
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force
+        if: (github.event_name != 'pull_request')
+
+      - name: Build docs to check for errors
+        run: mkdocs build --verbose
+        if: (github.event_name == 'pull_request')

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -47,5 +47,5 @@ jobs:
         if: (github.event_name != 'pull_request')
 
       - name: Build docs to check for errors
-        run: mkdocs build --verbose
+        run: mkdocs build
         if: (github.event_name == 'pull_request')

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -40,7 +40,7 @@ jobs:
             mkdocs-material-
 
       - name: Install Dependencies
-        run: pip install $(<requirements-docs.txt)
+        run: pip install -r requirements-docs.txt
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -39,7 +39,7 @@ jobs:
             mkdocs-material-
 
       - name: Install Dependencies
-        run: pip install mkdocs mkdocs-material mkdocstrings[python] griffe-inherited-docstrings mkdocs-autorefs mkdocs-jupyter mkdocs-caption markdown-grid-tables
+        run: pip install $(<requirements-docs.txt)
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -2,6 +2,8 @@ name: deploy-docs
 on:
   workflow_dispatch:
   push:
+    branches:
+      - 'master'
   pull_request:
 permissions:
   contents: write

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,8 @@
+mkdocs
+mkdocstrings[python]
+mkdocs-material
+griffe-inherited-docstrings
+mkdocs-autorefs
+mkdocs-jupyter
+mkdocs-caption
+markdown-grid-tables

--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -37,7 +37,7 @@ dependency string once wheel is built.
 from __future__ import annotations
 
 import os
-
+from pathlib import Path
 
 def select_constraint(default, nightly=None, git_master=None):
     """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
@@ -262,17 +262,12 @@ def make_extra_packages_docs() -> list[str]:
     list[str]
         List of packages required for building docs
     """
-    return [
-        "mkdocs",
-        "mkdocstrings[python]",
-        "mkdocs-material",
-        "griffe-inherited-docstrings",
-        "mkdocs-autorefs",
-        "mkdocs-jupyter",
-        "mkdocs-caption",
-        "pymdown-extensions",
-        "markdown-grid-tables",
-    ]
+    with open(Path(__file__).resolve().parent.parent / "requirements-docs.txt", "r") as fp:
+        reqs = fp.readlines()
+
+    reqs = [req.replace("\n", "") for req in reqs]
+
+    return reqs
 
 
 def make_extra_packages_all():


### PR DESCRIPTION
This PR accomplishes two main things

- Move the docs dependencies to `docs-requirements.txt`. Before, the requirements were repeated in `tfx/dependencies.py` and in the github docs workflow.
- Build but do not deploy the docs on pull request. This is to check if any PR will break the docs.