### PR TITLE
Use 'local_pip_package_path' to install pip when the path refers to a remote file system

### DIFF
--- a/tfx/components/evaluator/executor.py
+++ b/tfx/components/evaluator/executor.py
@@ -241,7 +241,7 @@ class Executor(base_beam_executor.BaseBeamExecutor):
     # may be created by the Beam multi-process DirectRunner) can find the
     # needed dependencies.
     # TODO(b/187122662): Move this to the ExecutorOperator or Launcher.
-    with udf_utils.TempPipInstallContext(extra_pip_packages):
+    with udf_utils.TempPipInstallContext(local_pip_package_path):
       with self._make_beam_pipeline() as pipeline:
         examples_list = []
         tensor_adapter_config = None


### PR DESCRIPTION
Updated [tfx/tfx/components/evaluator/executor.py](https://github.com/tensorflow/tfx/blob/c08360b3525a1d1af8d267933cc06f24af686dff/tfx/components/evaluator/executor.py#L123) to use local_pip_package_path to install pip when the path refers to a remote file system
#6920