### PR TITLE
Add `push` trigger to tests

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,6 +2,7 @@
 
 name: tfx-unit-tests
 on:
+  push:
   pull_request:
     branches: [ master ]
     paths-ignore:


### PR DESCRIPTION
This very small PR adds the `push` trigger to the testing workflow