### PR TITLE
Vertex AI Tuner component example

### DIFF
--- a/docs/guide/tuner.md
+++ b/docs/guide/tuner.md
@@ -237,7 +237,7 @@ vertex_job_spec = {
                 },
             'replica_count': 1,
             'container_spec': {
-                'image_uri': 'us-east1-docker.pkg.dev/itp-ml-sndbx/intuitive-ml-docker-repo/beam260tf215tft151deep:v2.60',
+                'image_uri': default_kfp_image,
                 },
             }],
         "enable_web_access": True,

--- a/docs/guide/tuner.md
+++ b/docs/guide/tuner.md
@@ -173,8 +173,6 @@ parallel, by using the
 [Google Cloud AI Platform extension Tuner component](https://github.com/tensorflow/tfx/blob/master/tfx/extensions/google_cloud_ai_platform/tuner/component.py),
 it provides the ability to run parallel tuning, using an AI Platform Training
 Job as a distributed worker flock manager. 
-
-
 [TuneArgs](https://github.com/tensorflow/tfx/blob/master/tfx/proto/tuner.proto)
 is the configuration given to this component. This is a drop-in replacement of
 the stock Tuner component.

--- a/docs/guide/tuner.md
+++ b/docs/guide/tuner.md
@@ -172,7 +172,7 @@ component does not have ability to execute more than one search worker in
 parallel, by using the
 [Google Cloud AI Platform extension Tuner component](https://github.com/tensorflow/tfx/blob/master/tfx/extensions/google_cloud_ai_platform/tuner/component.py),
 it provides the ability to run parallel tuning, using an AI Platform Training
-Job as a distributed worker flock manager. 
+Job as a distributed worker flock manager.
 [TuneArgs](https://github.com/tensorflow/tfx/blob/master/tfx/proto/tuner.proto)
 is the configuration given to this component. This is a drop-in replacement of
 the stock Tuner component.


### PR DESCRIPTION
Vertex AI tuner component example added, there were examples for local and CAIP, but not for Vertex.  This one is working for me in Vertex, open to make any adjustments as needed.