### PR TITLE
Add a workaround for the removal of top-level TFMA attributes

### DIFF
--- a/tfx/components/model_validator/executor.py
+++ b/tfx/components/model_validator/executor.py
@@ -28,6 +28,12 @@ from tfx.types import artifact_utils
 from tfx.utils import io_utils
 from tfx.utils import path_utils
 
+try:
+  # Try to access EvalResult from tfma directly
+  _EvalResult = tfma.EvalResult
+except AttributeError:
+  # If tfma doesn't have EvalResult, use the one from view_types
+  from tensorflow_model_analysis.view.view_types import EvalResult as _EvalResult
 
 class Executor(base_beam_executor.BaseBeamExecutor):
   """DEPRECATED: Please use `Evaluator` instead.
@@ -51,13 +57,13 @@ class Executor(base_beam_executor.BaseBeamExecutor):
   """
 
   # TODO(jyzhao): customized threshold support.
-  def _pass_threshold(self, eval_result: tfma.EvalResult) -> bool:
+  def _pass_threshold(self, eval_result: _EvalResult) -> bool:
     """Check threshold."""
     return True
 
   # TODO(jyzhao): customized validation support.
-  def _compare_eval_result(self, current_model_eval_result: tfma.EvalResult,
-                           blessed_model_eval_result: tfma.EvalResult) -> bool:
+  def _compare_eval_result(self, current_model_eval_result: _EvalResult,
+                           blessed_model_eval_result: _EvalResult) -> bool:
     """Compare accuracy of all metrics and return true if current is better or equal."""
     for current_metric, blessed_metric in zip(
         current_model_eval_result.slicing_metrics,

--- a/tfx/components/testdata/module_file/evaluator_module.py
+++ b/tfx/components/testdata/module_file/evaluator_module.py
@@ -19,9 +19,23 @@ import tensorflow_model_analysis as tfma
 from tfx_bsl.tfxio import tensor_adapter
 
 
+try:
+  # Try to access EvalSharedModel from tfma directly
+  _EvalSharedModel = tfma.EvalSharedModel
+except AttributeError:
+  # If tfma doesn't have EvalSharedModel, use the one from api.types
+  from tensorflow_model_analysis.api.types import EvalSharedModel as _EvalSharedModel
+
+try:
+  # Try to access MaybeMultipleEvalSharedModels from tfma directly
+  _MaybeMultipleEvalSharedModels = tfma.MaybeMultipleEvalSharedModels
+except AttributeError:
+  # If tfma doesn't have MaybeMultipleEvalSharedModels, use the one from api.types
+  from tensorflow_model_analysis.api.types import MaybeMultipleEvalSharedModels as _MaybeMultipleEvalSharedModels
+    
 def custom_eval_shared_model(eval_saved_model_path: str, model_name: str,
                              eval_config: tfma.EvalConfig,
-                             **kwargs: Dict[str, Any]) -> tfma.EvalSharedModel:
+                             **kwargs: Dict[str, Any]) -> _EvalSharedModel:
   return tfma.default_eval_shared_model(
       eval_saved_model_path=eval_saved_model_path,
       model_name=model_name,
@@ -30,7 +44,7 @@ def custom_eval_shared_model(eval_saved_model_path: str, model_name: str,
 
 
 def custom_extractors(
-    eval_shared_model: tfma.MaybeMultipleEvalSharedModels,
+    eval_shared_model: _MaybeMultipleEvalSharedModels,
     eval_config: tfma.EvalConfig,
     tensor_adapter_config: tensor_adapter.TensorAdapterConfig,
 ) -> List[tfma.extractors.Extractor]:

--- a/tfx/components/testdata/module_file/evaluator_module.py
+++ b/tfx/components/testdata/module_file/evaluator_module.py
@@ -32,7 +32,8 @@ try:
 except AttributeError:
   # If tfma doesn't have MaybeMultipleEvalSharedModels, use the one from api.types
   from tensorflow_model_analysis.api.types import MaybeMultipleEvalSharedModels as _MaybeMultipleEvalSharedModels
-    
+
+
 def custom_eval_shared_model(eval_saved_model_path: str, model_name: str,
                              eval_config: tfma.EvalConfig,
                              **kwargs: Dict[str, Any]) -> _EvalSharedModel:

--- a/tfx/experimental/pipeline_testing/executor_verifier_utils.py
+++ b/tfx/experimental/pipeline_testing/executor_verifier_utils.py
@@ -33,6 +33,14 @@ from ml_metadata.proto import metadata_store_pb2
 from tensorflow_metadata.proto.v0 import anomalies_pb2
 
 
+try:
+  # Try to access EvalResult from tfma directly
+  _EvalResult = tfma.EvalResult
+except AttributeError:
+  # If tfma doesn't have EvalResult, use the one from view_types
+  from tensorflow_model_analysis.view.view_types import EvalResult as _EvalResult
+
+
 def compare_dirs(dir1: str, dir2: str):
   """Recursively compares contents of the two directories.
 
@@ -159,7 +167,7 @@ def verify_file_dir(output_uri: str,
 
 
 def _group_metric_by_slice(
-    eval_result: tfma.EvalResult) -> Dict[str, Dict[str, float]]:
+    eval_result: _EvalResult) -> Dict[str, Dict[str, float]]:
   """Returns a dictionary holding metric values for every slice.
 
   Args:


### PR DESCRIPTION
Add a workaround for the removal of top-level TFMA attributes from TFMA 0.47.0