### PR TITLE
Add feature to optionally provide stats to trainer so number of examples can be determined dynamically

### DIFF
--- a/tfx/components/trainer/component.py
+++ b/tfx/components/trainer/component.py
@@ -72,6 +72,7 @@ class Trainer(base_component.BaseComponent):
 
   def __init__(
       self,
+      statistics: Optional[types.BaseChannel] = None,
       examples: Optional[types.BaseChannel] = None,
       transformed_examples: Optional[types.BaseChannel] = None,
       transform_graph: Optional[types.BaseChannel] = None,
@@ -170,6 +171,7 @@ class Trainer(base_component.BaseComponent):
     model = types.Channel(type=standard_artifacts.Model)
     model_run = types.Channel(type=standard_artifacts.ModelRun)
     spec = standard_component_specs.TrainerSpec(
+        statistics=statistics,
         examples=examples,
         transform_graph=transform_graph,
         schema=schema,

--- a/tfx/types/standard_component_specs.py
+++ b/tfx/types/standard_component_specs.py
@@ -411,6 +411,8 @@ class TrainerSpec(ComponentSpec):
       HYPERPARAMETERS_KEY:
           ChannelParameter(
               type=standard_artifacts.HyperParameters, optional=True),
+      STATISTICS_KEY:
+          ChannelParameter(type=standard_artifacts.ExampleStatistics, optional=True),
   }
   OUTPUTS = {
       MODEL_KEY: ChannelParameter(type=standard_artifacts.Model),


### PR DESCRIPTION
Enables the user to use number of examples information computed by ```StatisticsGen``` in their training code.  Passing statistics to trainer enables the use of

```
splits = fn_args.num_examples.keys()                                                                                                                                                                  
training_examples = fn_args.num_examples['train']                                                                                                                                            
validation_examples = fn_args.num_examples['eval']
```
in
 
```run_fn(fn_args: tfx.components.FnArgs):```

The configuration of ```Trainer``` would look as follows:
```
trainer = Trainer(                                                                                                                                                                                          
    module_file=trainer_file,                                                                                                                                                                               
    examples=transform.outputs['transformed_examples'],                                                                                                                                                     
    transform_graph=transform.outputs['transform_graph'],                                                                                                                                                   
    schema=transform.outputs['post_transform_schema'],                                                                                                                                                      
    hyperparameters=tuner.outputs['best_hyperparameters'],                                                                                                                                                  
    statistics=statistics_gen.outputs['statistics'], #new
)
```
More details at:
https://github.com/tensorflow/tfx/issues/7700