### PR TITLE
Upgrade `ml-metadata` to `1.17.1`

### DIFF
--- a/tfx/dependencies.py
+++ b/tfx/dependencies.py
@@ -58,7 +58,7 @@ def make_pipeline_sdk_required_install_packages():
         "ml-metadata"
         + select_constraint(
             # LINT.IfChange
-            default=">=1.16.0,<1.17.0",
+            default=">=1.17.1,<1.18.0",
             # LINT.ThenChange(tfx/workspace.bzl)
             nightly=">=1.17.0.dev",
             git_master="@git+https://github.com/google/ml-metadata@master",

--- a/tfx/workspace.bzl
+++ b/tfx/workspace.bzl
@@ -79,7 +79,7 @@ def tfx_workspace():
         name = "com_github_google_ml_metadata",
         repo = "google/ml-metadata",
         # LINT.IfChange
-        tag = "v1.16.0",
+        tag = "v1.17.1",
         # LINT.ThenChange(//tfx/dependencies.py)
     )
 


### PR DESCRIPTION
## Description

This PR upgrades the ml-metadata dependency from 1.16.0 to 1.17.1 across TFX's build configuration.

## Changes
- **tfx/dependencies.py**: Update default version constraint from `>=1.16.0,<1.17.0` to `>=1.17.1,<1.18.0`
- **tfx/workspace.bzl**: Update Bazel workspace tag from `v1.16.0` to `v1.17.1`

Both configurations are kept synchronized using LINT comments to ensure consistency between Python packaging and Bazel builds.

## Motivation

This upgrade aligns ml-metadata dependency versions with the current TFX release train, ensuring consistency with the coordinated dependency versions across the TensorFlow ML ecosystem.

## Related Issues

N/A