### PR TITLE
ci: declare contents:read on pre-commit workflow

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -5,6 +5,9 @@ on:
   push:
      branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `pre-commit` workflow runs `pre-commit/action@v3.0.1` against the diff range. It only checks out the repo and invokes pre-commit hooks locally; no GitHub API write, no comment-on-PR step.

This patch sets `permissions: contents: read` at workflow scope, matching the per-job permission block already declared in `wheels.yml` (`id-token: write` for trusted publishing).

With explicit scope:

- the workflow token can't be widened by a future change to the repository default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- a hypothetical compromise of `actions/checkout`, `actions/setup-python`, or `pre-commit/action` (cf. tj-actions/changed-files CVE-2025-30066) stays boxed in read-only

`ci-test.yml` is deliberately out of scope: it uses `cache: 'pip'` in `setup-python` plus a `bazelisk-cache: true` directive, both of which write back to the GitHub Actions cache. Pinning explicit permissions there has to account for the cache-save path, which deserves a separate look.

No behavioural change.