### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,8 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
         which-tests: ["not e2e", "e2e"]
         dependency-selector: ["NIGHTLY", "DEFAULT"]
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: ['cp39', 'cp310']
+        python-version: ['cp39', 'cp310', 'cp311']
 
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:

--- a/nightly_test_constraints.txt
+++ b/nightly_test_constraints.txt
@@ -22,7 +22,8 @@ alembic==1.13.3
 annotated-types==0.7.0
 anyio==4.6.0
 apache-airflow==2.10.3
-apache-beam==2.50.0
+apache-beam==2.50.0; python_version < "3.11"
+apache-beam==2.53.0; python_version >= "3.11"
 apispec==6.6.1
 argcomplete==3.5.1
 argon2-cffi==23.1.0
@@ -125,7 +126,7 @@ greenlet==3.1.1
 grpc-google-iam-v1==0.13.1
 grpc-interceptor==0.15.4
 grpcio==1.66.2
-grpcio-status==1.48.2
+grpcio-status==1.62.3
 gunicorn==23.0.0
 h11==0.14.0
 h5py==3.12.1
@@ -246,9 +247,11 @@ promise==2.3
 prompt_toolkit==3.0.48
 propcache==0.2.0
 proto-plus==1.24.0
-protobuf==4.21.12
+protobuf==4.21.12; python_version < "3.11"
+protobuf==4.25.5; python_version >= "3.11"
 psutil==6.0.0
 ptyprocess==0.7.0
+pyarrow==10.0.1; python_version >= "3.11"
 pyarrow-hotfix==0.6
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
@@ -315,7 +318,8 @@ tensorflow-decision-forests==1.10.1
 tensorflow-estimator==2.15.0
 tensorflow-hub==0.15.0
 tensorflow-io==0.24.0
-tensorflow-io-gcs-filesystem==0.24.0
+tensorflow-io-gcs-filesystem==0.24.0; python_version < "3.11"
+tensorflow-io-gcs-filesystem==0.37.1; python_version >= "3.11"
 tensorflow-metadata>=1.17.1
 # tensorflow-ranking==0.5.5
 tensorflow-serving-api==2.17.1

--- a/package_build/ml-pipelines-sdk/pyproject.toml
+++ b/package_build/ml-pipelines-sdk/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -31,7 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 keywords = ["tensorflow", "tfx"]
-requires-python = ">=3.9,<3.11"
+requires-python = ">=3.9,<3.12"
 [project.urls]
 Homepage = "https://www.tensorflow.org/tfx"
 Repository = "https://github.com/tensorflow/tfx"

--- a/package_build/tfx/pyproject.toml
+++ b/package_build/tfx/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -31,7 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 keywords = ["tensorflow", "tfx"]
-requires-python = ">=3.9,<3.11"
+requires-python = ">=3.9,<3.12"
 [project.urls]
 Homepage = "https://www.tensorflow.org/tfx"
 Repository = "https://github.com/tensorflow/tfx"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -31,7 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 keywords = ["tensorflow", "tfx"]
-requires-python = ">=3.9,<3.11"
+requires-python = ">=3.9,<3.12"
 [project.urls]
 Homepage = "https://www.tensorflow.org/tfx"
 Repository = "https://github.com/tensorflow/tfx"

--- a/test_constraints.txt
+++ b/test_constraints.txt
@@ -22,7 +22,8 @@ alembic==1.13.3
 annotated-types==0.7.0
 anyio==4.6.0
 apache-airflow==2.10.3
-apache-beam==2.50.0
+apache-beam==2.50.0; python_version < "3.11"
+apache-beam==2.53.0; python_version >= "3.11"
 apispec==6.6.1
 argcomplete==3.5.1
 argon2-cffi==23.1.0
@@ -125,7 +126,7 @@ greenlet==3.1.1
 grpc-google-iam-v1==0.13.1
 grpc-interceptor==0.15.4
 grpcio==1.66.2
-grpcio-status==1.48.2
+grpcio-status==1.62.3
 gunicorn==23.0.0
 h11==0.14.0
 h5py==3.12.1
@@ -246,9 +247,11 @@ promise==2.3
 prompt_toolkit==3.0.48
 propcache==0.2.0
 proto-plus==1.24.0
-protobuf==4.21.12
+protobuf==4.21.12; python_version < "3.11"
+protobuf==4.25.5; python_version >= "3.11"
 psutil==6.0.0
 ptyprocess==0.7.0
+pyarrow==10.0.1; python_version >= "3.11"
 pyarrow-hotfix==0.6
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
@@ -315,7 +318,8 @@ tensorflow-decision-forests==1.10.1
 tensorflow-estimator==2.15.0
 tensorflow-hub==0.15.0
 tensorflow-io==0.24.0
-tensorflow-io-gcs-filesystem==0.24.0
+tensorflow-io-gcs-filesystem==0.24.0; python_version < "3.11"
+tensorflow-io-gcs-filesystem==0.37.1; python_version >= "3.11"
 tensorflow-metadata>=1.16.1
 # tensorflow-ranking==0.5.5
 tensorflow-serving-api==2.17.1

--- a/tfx/components/infra_validator/request_builder_test.py
+++ b/tfx/components/infra_validator/request_builder_test.py
@@ -440,7 +440,7 @@ class TestBuildRequests(tf.test.TestCase):
   def _PrepareTFServingRequestBuilder(self):
     patcher = mock.patch.object(
         request_builder, '_TFServingRpcRequestBuilder',
-        wraps=request_builder._TFServingRpcRequestBuilder)
+        autospec=True)
     builder_cls = patcher.start()
     self.addCleanup(patcher.stop)
     return builder_cls
@@ -466,7 +466,7 @@ class TestBuildRequests(tf.test.TestCase):
         model_name='foo',
         signatures={'serving_default': mock.ANY})
     builder.ReadExamplesArtifact.assert_called_with(
-        self._examples,
+        examples=self._examples,
         split_name='eval',
         num_examples=1)
     builder.BuildRequests.assert_called()
@@ -512,6 +512,6 @@ class TestBuildRequests(tf.test.TestCase):
     )
 
     builder.ReadExamplesArtifact.assert_called_with(
-        self._examples,
+        examples=self._examples,
         split_name=None,  # Without split_name (will choose any split).
         num_examples=1)   # Default num_examples = 1.

--- a/tfx/components/trainer/rewriting/tflite_rewriter_test.py
+++ b/tfx/components/trainer/rewriting/tflite_rewriter_test.py
@@ -181,7 +181,7 @@ class TFLiteRewriterTest(tf.test.TestCase):
 
   @mock.patch('tfx.components.trainer.rewriting.'
               'tflite_rewriter._create_tflite_compatible_saved_model')
-  @mock.patch('tensorflow.lite.TFLiteConverter.from_saved_model')
+  @mock.patch.object(tf.lite.TFLiteConverter, 'from_saved_model')
   def testInvokeTFLiteRewriterQuantizationFullIntegerFailsNoData(
       self, converter, model):
 
@@ -231,7 +231,7 @@ class TFLiteRewriterTest(tf.test.TestCase):
     with fileio.open(expected_model, 'rb') as f:
       self.assertEqual(f.read(), b'model')
 
-  @mock.patch('tensorflow.lite.TFLiteConverter.from_saved_model')
+  @mock.patch.object(tf.lite.TFLiteConverter, 'from_saved_model')
   def testInvokeTFLiteRewriterWithSignatureKey(self, converter):
     m = self.ConverterMock()
     converter.return_value = m


### PR DESCRIPTION
## Summary

Adds Python 3.11 to TFX's supported and tested matrix. Closes #7743.

All 12 CI jobs pass on the contributor's fork (3 Python versions × not-e2e/e2e × DEFAULT/NIGHTLY dependency selectors): https://github.com/nblomerus/tfx/actions/runs/26000991135

## Changes

### Packaging
- `requires-python` upper bound bumped from `<3.11` to `<3.12` in the three pyproject.toml files (top-level + `package_build/tfx` + `package_build/ml-pipelines-sdk`).
- `Programming Language :: Python :: 3.11` classifier added in each.

### CI matrix
- `'3.11'` added to `ci-test.yml`; `'cp311'` added to `wheels.yml`.
- `strategy.fail-fast: false` added so individual job failures don't cancel the rest of the matrix, and was essential for debugging this PR. Happy to split this into a separate PR if preferred.

### Dependency pins (test_constraints.txt + nightly_test_constraints.txt)

The TFX 1.17 cp311 wheels require newer versions of several deps than the cp39/cp310 wheels, so this uses PEP 508 environment markers to pin per-Python-version. Each `==` pin is conditional on Python version where the existing pin would conflict with the cp311 wheels' own `Requires-Dist`:

| Package | `<3.11` | `>=3.11` | Why |
|---|---|---|---|
| `apache-beam` | `2.50.0` | `2.53.0` | tfx-bsl/tfdv cp311 wheels require beam `>=2.53` |
| `protobuf` | `4.21.12` | `4.25.5` | tfx-bsl/tfdv/ml-metadata cp311 wheels require `>=4.25.2`; beam 2.53 requires `!=4.21.*` |
| `pyarrow` | (unconstrained) | `10.0.1` | 10.0.0 has no cp311 wheel and fails sdist build under setuptools 70 |
| `tensorflow-io-gcs-filesystem` | `0.24.0` | `0.37.1` | 0.24.0 has no cp311 wheel |

Plus one unconditional bump: `grpcio-status` `1.48.2` → `1.62.3`. `google-api-core` requires `grpcio-status>=1.49.1` on Python 3.11+; `grpcio-status` 1.63+ would require protobuf 5, conflicting with TFX's `protobuf<5`. 1.62.3 is the last release using protobuf 4.

### Test fixes
Two test files had patterns that broke on Python 3.11:

- `tfx/components/infra_validator/request_builder_test.py` — `mock.patch.object(..., wraps=Cls)` returns a `_SentinelObject` for `.return_value` until the wrapped class is called (Python 3.11 mock behaviour change). Switched to `autospec=True`. `autospec` is strict about kwargs so the `examples=` arg is passed by keyword.
- `tfx/components/trainer/rewriting/tflite_rewriter_test.py` — `mock.patch('tensorflow.lite.TFLiteConverter.from_saved_model')` fails on 3.11 because mock's string-path resolution doesn't trigger TF's lazy `tf.lite` module wrapper. Switched to `mock.patch.object(tf.lite.TFLiteConverter, ...)`, which references the object directly. This keeps TFLite functional — a deliberately different approach than #7764, which gutted TFLite to side-step the issue.

## Scope choices

- **3.11 only, not 3.12.** The TFX-ecosystem cp312 wheels (tfdv, tfx-bsl, ml-metadata) aren't published on PyPI or the nightly index yet, so 3.12 support is blocked on Google releasing those. #7821 covers the broader 3.12 work (via local wheel builds).
- **Conditional pins, not range widening.** I considered loosening `==` pins to ranges (`>=`) and letting pip's resolver pick. But the current constraints file is a frozen snapshot for reproducibility, and the maintainers can tell me if they'd prefer the range approach.

## Test plan

- [x] All 12 CI jobs green on contributor fork.
- [x] Each modified test (`request_builder_test.py::testBuildRequests_TFServing`, `::testBuildRequests_DefaultArgument`, `tflite_rewriter_test.py::testInvokeTFLiteRewriterQuantizationFullIntegerFailsNoData`, `::testInvokeTFLiteRewriterWithSignatureKey`) passes on 3.9, 3.10, 3.11.
- [x] No tests skipped or xfailed as a result of this change.

