### PR TITLE
fix(types): Resolve 'tfx.' prefixed KFP v2/Vertex AI artifact types to native Python classes

### DIFF
--- a/tfx/types/artifact_utils.py
+++ b/tfx/types/artifact_utils.py
@@ -169,7 +169,11 @@ def get_artifact_type_class(
     # We need to compare `.name` and `.properties` (and not the entire proto
     # directly), because the proto `.id` field will be populated when the type
     # is read from MLMD.
-    if (artifact_type.name == candidate_type.name and
+    artifact_type_name = artifact_type.name
+    if artifact_type_name.startswith('tfx.'):
+      artifact_type_name = artifact_type_name[4:]
+
+    if (artifact_type_name == candidate_type.name and
         artifact_type.properties == candidate_type.properties):
       return cls
 

--- a/tfx/types/artifact_utils_test.py
+++ b/tfx/types/artifact_utils_test.py
@@ -133,6 +133,16 @@ class ArtifactUtilsTest(tf.test.TestCase):
     self.assertIs(_MyArtifact,
                   artifact_utils.get_artifact_type_class(mlmd_artifact_type))
 
+    # Test that artifact types prefixed with 'tfx.' (as produced by KFP v2)
+    # are correctly resolved to their native Python classes.
+    mlmd_artifact_type_prefixed = metadata_store_pb2.ArtifactType()
+    mlmd_artifact_type_prefixed.name = 'tfx.Examples'
+    mlmd_artifact_type_prefixed.properties['span'] = metadata_store_pb2.INT
+    mlmd_artifact_type_prefixed.properties['version'] = metadata_store_pb2.INT
+    mlmd_artifact_type_prefixed.properties['split_names'] = metadata_store_pb2.STRING
+    self.assertIs(standard_artifacts.Examples,
+                  artifact_utils.get_artifact_type_class(mlmd_artifact_type_prefixed))
+
   def testValueArtifactTypeRoundTrip(self):
     mlmd_artifact_type = standard_artifacts.String.annotate_as(  # pylint: disable=protected-access
         system_artifacts.Dataset)._get_artifact_type()


### PR DESCRIPTION
# Description
This PR resolves a major type resolution bug ([Issue #7849](https://github.com/tensorflow/tfx/issues/7849)) where standard TFX artifacts produced under Kubeflow Pipelines (KFP) v2 or Google Cloud Vertex AI Pipelines fail to resolve to their native Python classes.

### The Problem
Under KFP v2 / Vertex AI (which uses IR-based pipeline execution), TFX artifacts are registered in MLMD using their YAML schema title which is prefixed with `tfx.` (e.g. `tfx.Examples`, `tfx.Model`). 

When a downstream Python step queries MLMD, TFX's `get_artifact_type_class()` utility attempts to match the MLMD type name against native Python classes. Because native classes have `TYPE_NAME` attributes without the prefix (e.g. `TYPE_NAME = "Examples"`), the exact match check fails:
```python
    if (artifact_type.name == candidate_type.name and ...):
```
Consequently, TFX prints a warning (*"Could not find matching artifact class for type..."*) and generates an ephemeral generic `Artifact` subclass. This is highly brittle and breaks any downstream code performing class checks (e.g. `isinstance(artifact, standard_artifacts.Examples)`) or using subclass-specific properties/methods.

### The Solution
We normalize `artifact_type.name` by stripping the `tfx.` prefix before checking for a match with native TFX classes:
```python
    artifact_type_name = artifact_type.name
    if artifact_type_name.startswith('tfx.'):
      artifact_type_name = artifact_type_name[4:]
```

### Testing
- Added a new unit test in `artifact_utils_test.py` (`testArtifactTypeRoundTrip`) that constructs a mock KFP-prefixed `tfx.Examples` artifact type and asserts that it is correctly resolved to `standard_artifacts.Examples`.
- All `artifact_utils_test` tests pass successfully in the `tfx-py310` environment.
