### PR TITLE
docs: Update supported Python versions in CONTRIBUTING.md to 3.10-3.13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ This project follows
 
 # Contributing Guidelines
 
-At this point, TFX only supports Python 3 (3.7, 3.8, and 3.9) on Linux and
+At this point, TFX only supports Python 3 (3.10, 3.11, 3.12, and 3.13) on Linux and
 MacOS. Please use one of these operating systems for development and testing.
 
 ## Setting up local development environment


### PR DESCRIPTION
# Description
This PR resolves [Issue #7774](https://github.com/tensorflow/tfx/issues/7774) by updating the outdated Python version support statement in `CONTRIBUTING.md`.

### The Problem
The `CONTRIBUTING.md` file currently states:
> *“At this point, TFX only supports Python 3 (3.7, 3.8, and 3.9) on Linux and MacOS.”*

This documentation is significantly outdated. In our current configuration (defined in `pyproject.toml`), TFX has transitioned to requiring **`Python >= 3.10`**, with official support extending up to **`Python 3.13`**. Python 3.7, 3.8, and 3.9 are no longer supported.

### The Solution
We updated `CONTRIBUTING.md` to accurately reflect the active Python version support matrix:
> *“At this point, TFX only supports Python 3 (3.10, 3.11, 3.12, and 3.13) on Linux and MacOS.”*

This aligns the documentation perfectly with the project's build and package configuration.
